### PR TITLE
Fix an oversight with command permission levels

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/common/commands/ArcanaCommandBase.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/commands/ArcanaCommandBase.java
@@ -54,6 +54,11 @@ public abstract class ArcanaCommandBase<T> extends CommandBase {
     }
 
     @Override
+    public boolean canCommandSenderUseCommand(ICommandSender sender) {
+        return getRequiredPermissionLevel() == 0 || super.canCommandSenderUseCommand(sender);
+    }
+
+    @Override
     public void processCommand(ICommandSender sender, String[] args) {
         if (args.length < minimumRequiredArgs()) {
             printUsage(sender);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
Salis Arcana commands, even those set to permission level 0, cannot be used without op or cheats enabled.

**What is the new behavior (if this is a feature change)?**
Explicitly allow commands with permission level 0 to be used by anyone.

**Does this PR introduce a breaking change?**
No

**Other information**:
