### PR TITLE
Prevent a runtime error message about invalid item name prefixes

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/common/item/PlaceholderItem.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/item/PlaceholderItem.java
@@ -1,7 +1,5 @@
 package dev.rndmorris.salisarcana.common.item;
 
-import static dev.rndmorris.salisarcana.SalisArcana.MODID;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -30,10 +28,10 @@ public abstract class PlaceholderItem extends Item {
 
     public static void registerPlaceholders() {
         if (ConfigModuleRoot.enhancements.replaceWandCapsSettings.isEnabled()) {
-            GameRegistry.registerItem(capPlaceholder = new WandCapPlaceholderItem(), MODID + ":capPlaceholder");
+            GameRegistry.registerItem(capPlaceholder = new WandCapPlaceholderItem(), "capPlaceholder");
         }
         if (ConfigModuleRoot.enhancements.replaceWandCoreSettings.isEnabled()) {
-            GameRegistry.registerItem(rodPlaceholder = new WandRodPlaceholderItem(), MODID + ":rodPlaceholder");
+            GameRegistry.registerItem(rodPlaceholder = new WandRodPlaceholderItem(), "rodPlaceholder");
         }
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
An error message at mod startup complaining about item names already being prefixed.

**What is the new behavior (if this is a feature change)?**
No error message

**Does this PR introduce a breaking change?**
No

**Other information**:
