### PR TITLE
Fix Arcane Workbench Ghost Items when Shift-Click Crafting

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -73,3 +73,9 @@ Reduce the burn time of Thaumcraft's greatwood and silverwood slabs to match tha
 **Config option:** `staffFocusEffectFix`
 
 Fixes a graphical error where focus effects would appear below the tip of a staff.
+
+## Arcane Workbench Ghost Item Fix
+
+**Config option:** `arcaneWorkbenchGhostItemFix`
+
+Fixes ghost items being crafted in the arcane workbench after the wand runs out of vis during a shift-click craft.

--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -37,6 +37,7 @@ public class ClientProxy extends CommonProxy {
 
     @Override
     public boolean isSingleplayerClient() {
-        return Minecraft.getMinecraft().isSingleplayer();
+        return Minecraft.getMinecraft()
+            .isSingleplayer();
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -1,5 +1,6 @@
 package dev.rndmorris.salisarcana;
 
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.common.MinecraftForge;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -34,4 +35,8 @@ public class ClientProxy extends CommonProxy {
         }
     }
 
+    @Override
+    public boolean isSingleplayerClient() {
+        return Minecraft.getMinecraft().isSingleplayer();
+    }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -84,4 +84,7 @@ public class CommonProxy {
         }
     }
 
+    public boolean isSingleplayerClient() {
+        return false;
+    }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
@@ -21,6 +21,7 @@ public class BugfixesModule extends BaseConfigModule {
     public final ToggleSetting strictInfusionMatrixInputChecks;
     public final ToggleSetting unOredictGoldCoin;
     public final ToggleSetting staffFocusEffectFix;
+    public final ToggleSetting arcaneWorkbenchGhostItemFix;
 
     public BugfixesModule() {
         addSettings(
@@ -84,7 +85,12 @@ public class BugfixesModule extends BaseConfigModule {
                 this,
                 ConfigPhase.LATE,
                 "staffFocusEffectFix",
-                "Fixes a graphical error where focus effects would appear below the tip of a staff."));
+                "Fixes a graphical error where focus effects would appear below the tip of a staff."),
+            arcaneWorkbenchGhostItemFix = new ToggleSetting(
+                this,
+                ConfigPhase.LATE,
+                "arcaneWorkbenchGhostItemFix",
+                "Fixes ghost items being crafted in the arcane workbench after the wand runs out of vis during a shift-click craft."));
     }
 
     @Nonnull

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -182,6 +182,12 @@ public enum Mixins {
         .addMixinClasses("client.fx.beams.MixinFXBeamWand")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
+    ARCANE_WORKBENCH_GHOST_ITEM_FIX(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.bugfixes.arcaneWorkbenchGhostItemFix::isEnabled)
+        .addMixinClasses("items.MixinItemWandCasting_DisableSpendingCheck")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
+
     // Enhancements
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -183,9 +183,9 @@ public enum Mixins {
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     ARCANE_WORKBENCH_GHOST_ITEM_FIX(new Builder().setPhase(Phase.LATE)
-        .setSide(Side.BOTH)
+        .setSide(Side.CLIENT)
         .setApplyIf(ConfigModuleRoot.bugfixes.arcaneWorkbenchGhostItemFix::isEnabled)
-        .addMixinClasses("items.MixinItemWandCasting_DisableSpendingCheck")
+        .addMixinClasses("items.MixinItemWandCasting_DisableSpendingCheck", "tiles.MixinTileMagicWorkbench_GhostItemFix")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Enhancements

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -185,7 +185,9 @@ public enum Mixins {
     ARCANE_WORKBENCH_GHOST_ITEM_FIX(new Builder().setPhase(Phase.LATE)
         .setSide(Side.CLIENT)
         .setApplyIf(ConfigModuleRoot.bugfixes.arcaneWorkbenchGhostItemFix::isEnabled)
-        .addMixinClasses("items.MixinItemWandCasting_DisableSpendingCheck", "tiles.MixinTileMagicWorkbench_GhostItemFix")
+        .addMixinClasses(
+            "items.MixinItemWandCasting_DisableSpendingCheck",
+            "tiles.MixinTileMagicWorkbench_GhostItemFix")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Enhancements

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandCasting_DisableSpendingCheck.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandCasting_DisableSpendingCheck.java
@@ -9,7 +9,6 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 public class MixinItemWandCasting_DisableSpendingCheck {
     @ModifyExpressionValue(method = "consumeAllVis", at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;isRemote:Z"))
     private boolean isRemoteOverride(boolean isRemote) {
-        System.out.println("Spending vis on " + (isRemote ? "client" : "server"));
         return false;
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandCasting_DisableSpendingCheck.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandCasting_DisableSpendingCheck.java
@@ -1,13 +1,18 @@
 package dev.rndmorris.salisarcana.mixins.late.items;
 
-import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(value = ItemWandCasting.class, remap = false)
 public class MixinItemWandCasting_DisableSpendingCheck {
-    @ModifyExpressionValue(method = "consumeAllVis", at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;isRemote:Z"))
+
+    @ModifyExpressionValue(
+        method = "consumeAllVis",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;isRemote:Z"))
     private boolean isRemoteOverride(boolean isRemote) {
         return false;
     }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandCasting_DisableSpendingCheck.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandCasting_DisableSpendingCheck.java
@@ -1,0 +1,15 @@
+package dev.rndmorris.salisarcana.mixins.late.items;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import thaumcraft.common.items.wands.ItemWandCasting;
+
+@Mixin(value = ItemWandCasting.class, remap = false)
+public class MixinItemWandCasting_DisableSpendingCheck {
+    @ModifyExpressionValue(method = "consumeAllVis", at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;isRemote:Z"))
+    private boolean isRemoteOverride(boolean isRemote) {
+        System.out.println("Spending vis on " + (isRemote ? "client" : "server"));
+        return false;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_GhostItemFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_GhostItemFix.java
@@ -1,0 +1,33 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import dev.rndmorris.salisarcana.SalisArcana;
+import net.minecraft.nbt.NBTBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.nbt.NBTTagList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import thaumcraft.common.tiles.TileMagicWorkbench;
+
+@Mixin(value = TileMagicWorkbench.class, remap = false)
+public class MixinTileMagicWorkbench_GhostItemFix {
+    @Inject(method = "readCustomNBT", at = @At("HEAD"))
+    public void copyWandNBTTagOnClient(NBTTagCompound par1NBTTagCompound, CallbackInfo ci) {
+        if(!SalisArcana.proxy.isSingleplayerClient()) return;
+        NBTTagList inventory = par1NBTTagCompound.getTagList("Inventory", 10);
+
+        // Normally, the wand is the last tag in the list, but that is not strictly required by the format of Inventory NBTs
+        for(int i = inventory.tagCount() - 1; i >= 0; i--) {
+            NBTTagCompound item = inventory.getCompoundTagAt(i);
+            if(item.getByte("Slot") == 10) {
+                NBTBase tag = item.getTag("tag");
+                if(tag != null) {
+                    // Replace the NBT with a copy, so vis spending on the client doesn't affect the server's NBT tag
+                    item.setTag("tag", tag.copy());
+                }
+                return;
+            }
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_GhostItemFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_GhostItemFix.java
@@ -1,28 +1,32 @@
 package dev.rndmorris.salisarcana.mixins.late.tiles;
 
-import dev.rndmorris.salisarcana.SalisArcana;
 import net.minecraft.nbt.NBTBase;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dev.rndmorris.salisarcana.SalisArcana;
 import thaumcraft.common.tiles.TileMagicWorkbench;
 
 @Mixin(value = TileMagicWorkbench.class, remap = false)
 public class MixinTileMagicWorkbench_GhostItemFix {
+
     @Inject(method = "readCustomNBT", at = @At("HEAD"))
     public void copyWandNBTTagOnClient(NBTTagCompound par1NBTTagCompound, CallbackInfo ci) {
-        if(!SalisArcana.proxy.isSingleplayerClient()) return;
+        if (!SalisArcana.proxy.isSingleplayerClient()) return;
         NBTTagList inventory = par1NBTTagCompound.getTagList("Inventory", 10);
 
-        // Normally, the wand is the last tag in the list, but that is not strictly required by the format of Inventory NBTs
-        for(int i = inventory.tagCount() - 1; i >= 0; i--) {
+        // Normally, the wand is the last tag in the list, but that is not strictly required by the format of Inventory
+        // NBTs
+        for (int i = inventory.tagCount() - 1; i >= 0; i--) {
             NBTTagCompound item = inventory.getCompoundTagAt(i);
-            if(item.getByte("Slot") == 10) {
+            if (item.getByte("Slot") == 10) {
                 NBTBase tag = item.getTag("tag");
-                if(tag != null) {
+                if (tag != null) {
                     // Replace the NBT with a copy, so vis spending on the client doesn't affect the server's NBT tag
                     item.setTag("tag", tag.copy());
                 }


### PR DESCRIPTION
Fixes #90.

The problem lies in the fact that on Singleplayer, the NBT `tag`s of `ItemStack`s are shared between logical client and server. This is caused by Minecraft, not Thaumcraft, which is why this issue was hard to track down.

This patch disables the double-spending check and causes the client (or maybe the client and the server) to make their own copies of the wand's NBT tag when the game is in Singleplayer.

This might cause problems with add-ons if any addons expect calling `consumeAllVis` on the client in Singleplayer to not affect the server. If this becomes a problem, we can instead make a coremod into `ItemStack` to automatically copy the NBT `tag` of any wands loaded from NBT.

I have checked scrolling, shift-clicking, and normal crafting, and all correctly work without problems.