### PR TITLE
Allow Players to Craft After Arcane Workbench Recharges

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -74,8 +74,16 @@ Reduce the burn time of Thaumcraft's greatwood and silverwood slabs to match tha
 
 Fixes a graphical error where focus effects would appear below the tip of a staff.
 
-## Arcane Workbench Ghost Item Fix
+## Arcane Workbench Fixes
+
+### Fix Ghost Items After Shift-Click Crafting
 
 **Config option:** `arcaneWorkbenchGhostItemFix`
 
 Fixes ghost items being crafted in the arcane workbench after the wand runs out of vis during a shift-click craft.
+
+### Allow Crafting After Wand Runs Out Of Vis & Is Recharged
+
+**Config option:** `arcaneWorkbenchAllowRechargeCrafting`
+
+Allows players to craft after the wand in the GUI runs out of vis and is recharged by a Vis Charge Relay.

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
@@ -22,6 +22,7 @@ public class BugfixesModule extends BaseConfigModule {
     public final ToggleSetting unOredictGoldCoin;
     public final ToggleSetting staffFocusEffectFix;
     public final ToggleSetting arcaneWorkbenchGhostItemFix;
+    public final ToggleSetting arcaneWorkbenchAllowRechargeCrafting;
 
     public BugfixesModule() {
         addSettings(
@@ -90,7 +91,12 @@ public class BugfixesModule extends BaseConfigModule {
                 this,
                 ConfigPhase.LATE,
                 "arcaneWorkbenchGhostItemFix",
-                "Fixes ghost items being crafted in the arcane workbench after the wand runs out of vis during a shift-click craft."));
+                "Fixes ghost items being crafted in the arcane workbench after the wand runs out of vis during a shift-click craft."),
+            arcaneWorkbenchAllowRechargeCrafting = new ToggleSetting(
+                this,
+                ConfigPhase.LATE,
+                "arcaneWorkbenchAllowRechargeCrafting",
+                "Allows players to craft after the wand in the GUI runs out of vis and is recharged by a Vis Charge Relay."));
     }
 
     @Nonnull

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -190,6 +190,12 @@ public enum Mixins {
             "tiles.MixinTileMagicWorkbench_GhostItemFix")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
+    ARCANE_WORKBENCH_ALLOW_RECHARGE_CRAFTING(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.SERVER)
+        .setApplyIf(ConfigModuleRoot.bugfixes.arcaneWorkbenchAllowRechargeCrafting::isEnabled)
+        .addMixinClasses("tiles.MixinTileMagicWorkbenchCharger")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
+
     // Enhancements
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -191,7 +191,7 @@ public enum Mixins {
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     ARCANE_WORKBENCH_ALLOW_RECHARGE_CRAFTING(new Builder().setPhase(Phase.LATE)
-        .setSide(Side.SERVER)
+        .setSide(Side.BOTH)
         .setApplyIf(ConfigModuleRoot.bugfixes.arcaneWorkbenchAllowRechargeCrafting::isEnabled)
         .addMixinClasses("tiles.MixinTileMagicWorkbenchCharger")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbenchCharger.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbenchCharger.java
@@ -1,19 +1,29 @@
 package dev.rndmorris.salisarcana.mixins.late.tiles;
 
-import com.llamalad7.mixinextras.sugar.Local;
-import com.llamalad7.mixinextras.sugar.Share;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
 import thaumcraft.common.tiles.TileMagicWorkbench;
 import thaumcraft.common.tiles.TileMagicWorkbenchCharger;
 
 @Mixin(TileMagicWorkbenchCharger.class)
 public class MixinTileMagicWorkbenchCharger {
-    @Inject(method = "updateEntity", at = @At(value = "INVOKE", target = "Lthaumcraft/common/items/wands/ItemWandCasting;addRealVis(Lnet/minecraft/item/ItemStack;Lthaumcraft/api/aspects/Aspect;IZ)I"))
-    public void captureWorkbench(CallbackInfo ci, @Local TileMagicWorkbench workbench, @Share("workbench") LocalRef<TileMagicWorkbench> workbenchRef) {
+
+    @Inject(
+        method = "updateEntity",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/items/wands/ItemWandCasting;addRealVis(Lnet/minecraft/item/ItemStack;Lthaumcraft/api/aspects/Aspect;IZ)I",
+            remap = false))
+    public void captureWorkbench(CallbackInfo ci, @Local TileMagicWorkbench workbench,
+        @Share("workbench") LocalRef<TileMagicWorkbench> workbenchRef) {
+        // Only gets called on the logical server whenever an aspect is charged into the wand.
         workbenchRef.set(workbench);
     }
 
@@ -21,7 +31,7 @@ public class MixinTileMagicWorkbenchCharger {
     public void updateGUI(CallbackInfo ci, @Share("workbench") LocalRef<TileMagicWorkbench> workbenchRef) {
         TileMagicWorkbench workbench = workbenchRef.get();
 
-        if(workbench != null && workbench.eventHandler != null && workbench.getStackInSlot(9) == null) {
+        if (workbench != null && workbench.eventHandler != null && workbench.getStackInSlot(9) == null) {
             workbench.eventHandler.onCraftMatrixChanged(workbench);
         }
     }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbenchCharger.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbenchCharger.java
@@ -1,0 +1,28 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import thaumcraft.common.tiles.TileMagicWorkbench;
+import thaumcraft.common.tiles.TileMagicWorkbenchCharger;
+
+@Mixin(TileMagicWorkbenchCharger.class)
+public class MixinTileMagicWorkbenchCharger {
+    @Inject(method = "updateEntity", at = @At(value = "INVOKE", target = "Lthaumcraft/common/items/wands/ItemWandCasting;addRealVis(Lnet/minecraft/item/ItemStack;Lthaumcraft/api/aspects/Aspect;IZ)I"))
+    public void captureWorkbench(CallbackInfo ci, @Local TileMagicWorkbench workbench, @Share("workbench") LocalRef<TileMagicWorkbench> workbenchRef) {
+        workbenchRef.set(workbench);
+    }
+
+    @Inject(method = "updateEntity", at = @At("TAIL"))
+    public void updateGUI(CallbackInfo ci, @Share("workbench") LocalRef<TileMagicWorkbench> workbenchRef) {
+        TileMagicWorkbench workbench = workbenchRef.get();
+
+        if(workbench != null && workbench.eventHandler != null && workbench.getStackInSlot(9) == null) {
+            workbench.eventHandler.onCraftMatrixChanged(workbench);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #91.

This was a pretty simple fix. The client updates the crafting recipe whenever the wand changes because of `detectAndSendChanges`. The server, however, never puts the result item back into the output slot because its `onCraftMatrixChanged` never gets called. Now it does.