### PR TITLE
Allow Wand Replacement Recipes to Complete Using the Wand Being Modified

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -257,4 +257,6 @@ If enabled, prevents swapping a wand core with a staff core or a staff core with
 
 Requires `enableReplaceWandCapsRecipe=true` or `enableReplaceWandCoreRecipe=true`.
 
+Requires `arcaneWorkbenchGhostItemFix=true` in the bugfixes module.
+
 If enabled, allows swapping a wand's components using vis from the wand being modified.

--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -252,3 +252,9 @@ Used to set the tab of the Thaumonomicon on which the "Wand Core Substitution" r
 Requires `enableReplaceWandCoreRecipe=true`.
 
 If enabled, prevents swapping a wand core with a staff core or a staff core with a wand core. Disable to allow converting a wand to a staff and vice versa.
+
+## Config option: `allowSingleWandReplacement`
+
+Requires `enableReplaceWandCapsRecipe=true` or `enableReplaceWandCoreRecipe=true`.
+
+If enabled, allows swapping a wand's components using vis from the wand being modified.

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -26,7 +26,11 @@ import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.config.ConfigResearch;
 
+import javax.annotation.Nullable;
+
 public class CustomRecipes {
+    public static @Nullable ReplaceWandCapsRecipe replaceWandCapsRecipe = null;
+    public static @Nullable ReplaceWandCoreRecipe replaceWandCoreRecipe = null;
 
     public static void registerRecipes() {
 
@@ -53,13 +57,13 @@ public class CustomRecipes {
         if (enhancements.replaceWandCapsSettings.isEnabled()) {
             // noinspection unchecked
             ThaumcraftApi.getCraftingRecipes()
-                .add(new ReplaceWandCapsRecipe());
+                .add(replaceWandCapsRecipe = new ReplaceWandCapsRecipe());
         }
 
         if (enhancements.replaceWandCoreSettings.isEnabled()) {
             // noinspection unchecked
             ThaumcraftApi.getCraftingRecipes()
-                .add(new ReplaceWandCoreRecipe());
+                .add(replaceWandCoreRecipe = new ReplaceWandCoreRecipe());
         }
 
         if (enhancements.rottenFleshRecipe.isEnabled()) {

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -26,9 +28,8 @@ import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.config.ConfigResearch;
 
-import javax.annotation.Nullable;
-
 public class CustomRecipes {
+
     public static @Nullable ReplaceWandCapsRecipe replaceWandCapsRecipe = null;
     public static @Nullable ReplaceWandCoreRecipe replaceWandCoreRecipe = null;
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -2,6 +2,7 @@ package dev.rndmorris.salisarcana.config.modules;
 
 import javax.annotation.Nonnull;
 
+import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
 import dev.rndmorris.salisarcana.config.ConfigPhase;
 import dev.rndmorris.salisarcana.config.settings.BlockItemListSetting;
 import dev.rndmorris.salisarcana.config.settings.CustomResearchSetting;
@@ -339,6 +340,7 @@ public class EnhancementsModule extends BaseConfigModule {
 
     public boolean singleWandReplacementEnabled() {
         return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())
+            && ConfigModuleRoot.bugfixes.arcaneWorkbenchGhostItemFix.isEnabled()
             && this.allowSingleWandReplacement.isEnabled();
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -337,6 +337,10 @@ public class EnhancementsModule extends BaseConfigModule {
                     .setCategory(wandCategory));
     }
 
+    public boolean singleWandReplacementEnabled() {
+        return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled()) && this.allowSingleWandReplacement.isEnabled();
+    }
+
     @Nonnull
     @Override
     public String getModuleId() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -24,6 +24,7 @@ public class EnhancementsModule extends BaseConfigModule {
     public final ReplaceWandComponentSettings replaceWandCoreSettings;
     public final ToggleSetting enforceWandCoreTypes;
     public final ToggleSetting preserveWandVis;
+    public final ToggleSetting allowSingleWandReplacement;
 
     public final ToggleSetting lookalikePlanks;
     public final IntArraySetting nodeModifierWeights;
@@ -327,6 +328,12 @@ public class EnhancementsModule extends BaseConfigModule {
                 ConfigPhase.LATE,
                 "preserveWandVis",
                 "If enabled, vis will be preserved when a wand, staff, or stave's components are replaced.")
+                    .setCategory(wandCategory),
+            allowSingleWandReplacement = new ToggleSetting(
+                this,
+                ConfigPhase.LATE,
+                "allowSingleWandReplacement",
+                "If enabled, allows swapping a wand's components using vis from the wand being modified.")
                     .setCategory(wandCategory));
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -338,7 +338,8 @@ public class EnhancementsModule extends BaseConfigModule {
     }
 
     public boolean singleWandReplacementEnabled() {
-        return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled()) && this.allowSingleWandReplacement.isEnabled();
+        return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())
+            && this.allowSingleWandReplacement.isEnabled();
     }
 
     @Nonnull

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -326,8 +326,13 @@ public enum Mixins {
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
     SINGLE_WAND_REPLACEMENT(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)
-        .setApplyIf(() -> (ConfigModuleRoot.enhancements.replaceWandCapsSettings.isEnabled() || ConfigModuleRoot.enhancements.replaceWandCoreSettings.isEnabled()) && ConfigModuleRoot.enhancements.allowSingleWandReplacement.isEnabled())
+        .setApplyIf(ConfigModuleRoot.enhancements::singleWandReplacementEnabled)
         .addMixinClasses("container.MixinContainerArcaneWorkbench_SingleWandReplacement")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    SINGLE_WAND_REPLACEMENT_CLIENT(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.CLIENT)
+        .setApplyIf(ConfigModuleRoot.enhancements::singleWandReplacementEnabled)
+        .addMixinClasses("gui.MixinGuiArcaneWorkbench_SingleWandReplacement")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
     PRIMAL_CRUSHER_OREDICT_COMPAT(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -324,6 +324,11 @@ public enum Mixins {
         .setApplyIf(ConfigModuleRoot.enhancements.staffterNameTooltip::isEnabled)
         .addMixinClasses("items.MixinItemWandCasting_NamedStaffters")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    SINGLE_WAND_REPLACEMENT(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(() -> (ConfigModuleRoot.enhancements.replaceWandCapsSettings.isEnabled() || ConfigModuleRoot.enhancements.replaceWandCoreSettings.isEnabled()) && ConfigModuleRoot.enhancements.allowSingleWandReplacement.isEnabled())
+        .addMixinClasses("container.MixinContainerArcaneWorkbench_SingleWandReplacement")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
     PRIMAL_CRUSHER_OREDICT_COMPAT(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)
         .setApplyIf(ConfigModuleRoot.enhancements.primalCrusherOredict::isEnabled)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -1,15 +1,17 @@
 package dev.rndmorris.salisarcana.mixins.late.container;
 
-import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
-import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
-import dev.rndmorris.salisarcana.lib.AspectHelper;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
+import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
+import dev.rndmorris.salisarcana.lib.AspectHelper;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.container.ContainerArcaneWorkbench;
 import thaumcraft.common.items.wands.ItemWandCasting;
@@ -17,43 +19,55 @@ import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(ContainerArcaneWorkbench.class)
 public class MixinContainerArcaneWorkbench_SingleWandReplacement {
+
     @Shadow(remap = false)
     private TileArcaneWorkbench tileEntity;
 
     @Shadow(remap = false)
     private InventoryPlayer ip;
 
-    @Inject(method = "onCraftMatrixChanged", at = @At(value = "INVOKE", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;setInventorySlotContentsSoftly(ILnet/minecraft/item/ItemStack;)V", ordinal = 0, shift = At.Shift.AFTER, remap = false))
+    @Inject(
+        method = "onCraftMatrixChanged",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;setInventorySlotContentsSoftly(ILnet/minecraft/item/ItemStack;)V",
+            ordinal = 0,
+            shift = At.Shift.AFTER,
+            remap = false))
     public void useGridWandForReplacement(CallbackInfo ci) {
         // Exclusive with the normal arcane recipe check, since this requires no wand present
-        if(this.tileEntity.getStackInSlot(9) == null && this.tileEntity.getStackInSlot(10) == null) {
+        if (this.tileEntity.getStackInSlot(9) == null && this.tileEntity.getStackInSlot(10) == null) {
             // If a replacement recipe matches
             ItemStack outputWand;
             AspectList visPrice;
 
-            if(CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player)) {
+            if (CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe
+                .matches(this.tileEntity, this.ip.player.worldObj, this.ip.player)) {
                 outputWand = CustomRecipes.replaceWandCapsRecipe.getCraftingResult(this.tileEntity);
                 visPrice = CustomRecipes.replaceWandCapsRecipe.getAspects(this.tileEntity);
-            } else if(CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player)) {
-                outputWand = CustomRecipes.replaceWandCoreRecipe.getCraftingResult(this.tileEntity);
-                visPrice = CustomRecipes.replaceWandCoreRecipe.getAspects(this.tileEntity);
-            } else {
-                return;
-            }
+            } else if (CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe
+                .matches(this.tileEntity, this.ip.player.worldObj, this.ip.player)) {
+                    outputWand = CustomRecipes.replaceWandCoreRecipe.getCraftingResult(this.tileEntity);
+                    visPrice = CustomRecipes.replaceWandCoreRecipe.getAspects(this.tileEntity);
+                } else {
+                    return;
+                }
 
-            if(!(outputWand.getItem() instanceof ItemWandCasting itemWand)) return;
+            // Mostly here so my compiler would stop yelling at me.
+            if (!(outputWand.getItem() instanceof ItemWandCasting itemWand)) return;
 
             ItemStack originalWand = null;
-            for(int i=0; i < 9; i++) {
+            for (int i = 0; i < 9; i++) {
                 final ItemStack slot = this.tileEntity.getStackInSlot(i);
-                if(slot.getItem() instanceof ItemWandCasting) {
+                if (slot != null && slot.getItem() instanceof ItemWandCasting) {
                     originalWand = slot.copy();
                     break;
                 }
             }
 
-            if(itemWand.consumeAllVisCrafting(originalWand, this.ip.player, visPrice, true)) {
-                if(ConfigModuleRoot.enhancements.preserveWandVis.isEnabled()) {
+            // Vis is spent using the original wand, which is why that loop above is necessary.
+            if (itemWand.consumeAllVisCrafting(originalWand, this.ip.player, visPrice, true)) {
+                if (ConfigModuleRoot.enhancements.preserveWandVis.isEnabled()) {
                     // Copied from ReplaceWandCoreRecipe. Thank you, Morris.
                     final var maxVis = itemWand.getMaxVis(outputWand);
                     final var newVis = new AspectList();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -1,0 +1,72 @@
+package dev.rndmorris.salisarcana.mixins.late.container;
+
+import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
+import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
+import dev.rndmorris.salisarcana.lib.AspectHelper;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.container.ContainerArcaneWorkbench;
+import thaumcraft.common.items.wands.ItemWandCasting;
+import thaumcraft.common.tiles.TileArcaneWorkbench;
+
+@Mixin(ContainerArcaneWorkbench.class)
+public class MixinContainerArcaneWorkbench_SingleWandReplacement {
+    @Shadow(remap = false)
+    private TileArcaneWorkbench tileEntity;
+
+    @Shadow(remap = false)
+    private InventoryPlayer ip;
+
+    @Inject(method = "onCraftMatrixChanged", at = @At(value = "INVOKE", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;setInventorySlotContentsSoftly(ILnet/minecraft/item/ItemStack;)V", ordinal = 0, shift = At.Shift.AFTER, remap = false))
+    public void useGridWandForReplacement(CallbackInfo ci) {
+        // Exclusive with the normal arcane recipe check, since this requires no wand present
+        if(this.tileEntity.getStackInSlot(9) == null && this.tileEntity.getStackInSlot(10) == null) {
+            // If a replacement recipe matches
+            ItemStack outputWand;
+            AspectList visPrice;
+
+            if(CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player)) {
+                outputWand = CustomRecipes.replaceWandCapsRecipe.getCraftingResult(this.tileEntity);
+                visPrice = CustomRecipes.replaceWandCapsRecipe.getAspects(this.tileEntity);
+            } else if(CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player)) {
+                outputWand = CustomRecipes.replaceWandCoreRecipe.getCraftingResult(this.tileEntity);
+                visPrice = CustomRecipes.replaceWandCoreRecipe.getAspects(this.tileEntity);
+            } else {
+                return;
+            }
+
+            if(!(outputWand.getItem() instanceof ItemWandCasting itemWand)) return;
+
+            ItemStack originalWand = null;
+            for(int i=0; i < 9; i++) {
+                final ItemStack slot = this.tileEntity.getStackInSlot(i);
+                if(slot.getItem() instanceof ItemWandCasting) {
+                    originalWand = slot.copy();
+                    break;
+                }
+            }
+
+            if(itemWand.consumeAllVisCrafting(originalWand, this.ip.player, visPrice, true)) {
+                if(ConfigModuleRoot.enhancements.preserveWandVis.isEnabled()) {
+                    // Copied from ReplaceWandCoreRecipe. Thank you, Morris.
+                    final var maxVis = itemWand.getMaxVis(outputWand);
+                    final var newVis = new AspectList();
+                    final var originalVis = itemWand.getAllVis(originalWand);
+                    for (var entry : originalVis.aspects.entrySet()) {
+                        newVis.add(entry.getKey(), Integer.min(maxVis, entry.getValue()));
+                    }
+                    itemWand.storeAllVis(outputWand, newVis);
+                } else {
+                    itemWand.storeAllVis(outputWand, AspectHelper.primalList(0));
+                }
+                this.tileEntity.setInventorySlotContentsSoftly(9, outputWand);
+            }
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
@@ -59,8 +59,7 @@ public class MixinGuiArcaneWorkbench_SingleWandReplacement {
         method = "drawGuiContainerBackgroundLayer",
         at = @At(
             value = "INVOKE",
-            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;getStackInSlot(I)Lnet/minecraft/item/ItemStack;",
-            remap = false),
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;getStackInSlot(I)Lnet/minecraft/item/ItemStack;"),
         slice = @Slice(
             from = @At(
                 value = "INVOKE",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
@@ -1,0 +1,53 @@
+package dev.rndmorris.salisarcana.mixins.late.gui;
+
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import thaumcraft.client.gui.GuiArcaneWorkbench;
+import thaumcraft.common.items.wands.ItemWandCasting;
+import thaumcraft.common.tiles.TileArcaneWorkbench;
+
+@Mixin(GuiArcaneWorkbench.class)
+public class MixinGuiArcaneWorkbench_SingleWandReplacement {
+    @Shadow(remap = false)
+    private TileArcaneWorkbench tileEntity;
+
+    @Shadow(remap = false)
+    private InventoryPlayer ip;
+
+    @ModifyVariable(method = "drawGuiContainerBackgroundLayer", at = @At(value = "INVOKE", target = "Lthaumcraft/common/lib/crafting/ThaumcraftCraftingManager;findMatchingArcaneRecipeAspects(Lnet/minecraft/inventory/IInventory;Lnet/minecraft/entity/player/EntityPlayer;)Lthaumcraft/api/aspects/AspectList;", remap = false))
+    public ItemWandCasting captureWandInTable(final ItemWandCasting slot10, final @Share("wandStack") LocalRef<ItemStack> wandStack) {
+        if(slot10 == null) { // and Arcane Recipe found
+            for(int i=0; i<9; i++) {
+                final ItemStack slot = this.tileEntity.getStackInSlot(i);
+                if(slot.getItem() instanceof ItemWandCasting itemWand) {
+                    // Found a wand in table
+                    if((CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player))
+                        || (CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player))) {
+                        wandStack.set(slot);
+                        return itemWand;
+                    }
+                }
+            }
+            return null;
+        } else {
+            return slot10;
+        }
+    }
+
+    @ModifyArg(method = "drawGuiContainerBackgroundLayer", at = @At(value = "INVOKE", target = "Lthaumcraft/common/items/wands/ItemWandCasting;getConsumptionModifier(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/EntityPlayer;Lthaumcraft/api/aspects/Aspect;Z)F", remap = false), index = 0)
+    public ItemStack replaceWandConsumption(final ItemStack initial, final @Share("wandStack") LocalRef<ItemStack> wandStack) {
+        return initial == null ? wandStack.get() : initial;
+    }
+    @ModifyArg(method = "drawGuiContainerBackgroundLayer", at = @At(value = "INVOKE", target = "Lthaumcraft/common/items/wands/ItemWandCasting;getVis(Lnet/minecraft/item/ItemStack;Lthaumcraft/api/aspects/Aspect;)I", remap = false), index = 0)
+    public ItemStack replaceWandVis(final ItemStack initial, final @Share("wandStack") LocalRef<ItemStack> wandStack) {
+        return initial == null ? wandStack.get() : initial;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
@@ -1,36 +1,49 @@
 package dev.rndmorris.salisarcana.mixins.late.gui;
 
-import com.llamalad7.mixinextras.sugar.Share;
-import com.llamalad7.mixinextras.sugar.ref.LocalRef;
-import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
 import net.minecraft.entity.player.InventoryPlayer;
 import net.minecraft.item.ItemStack;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.Slice;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
+
+import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
 import thaumcraft.client.gui.GuiArcaneWorkbench;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(GuiArcaneWorkbench.class)
 public class MixinGuiArcaneWorkbench_SingleWandReplacement {
+
     @Shadow(remap = false)
     private TileArcaneWorkbench tileEntity;
 
     @Shadow(remap = false)
     private InventoryPlayer ip;
 
-    @ModifyVariable(method = "drawGuiContainerBackgroundLayer", at = @At(value = "INVOKE", target = "Lthaumcraft/common/lib/crafting/ThaumcraftCraftingManager;findMatchingArcaneRecipeAspects(Lnet/minecraft/inventory/IInventory;Lnet/minecraft/entity/player/EntityPlayer;)Lthaumcraft/api/aspects/AspectList;", remap = false))
-    public ItemWandCasting captureWandInTable(final ItemWandCasting slot10, final @Share("wandStack") LocalRef<ItemStack> wandStack) {
-        if(slot10 == null) { // and Arcane Recipe found
-            for(int i=0; i<9; i++) {
+    @ModifyVariable(
+        method = "drawGuiContainerBackgroundLayer",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/lib/crafting/ThaumcraftCraftingManager;findMatchingArcaneRecipeAspects(Lnet/minecraft/inventory/IInventory;Lnet/minecraft/entity/player/EntityPlayer;)Lthaumcraft/api/aspects/AspectList;",
+            remap = false))
+    public ItemWandCasting captureWandInTable(final ItemWandCasting slot10,
+        final @Share("wandStack") LocalRef<ItemStack> wandStack) {
+        if (slot10 == null) { // and Arcane Recipe found
+            for (int i = 0; i < 9; i++) {
                 final ItemStack slot = this.tileEntity.getStackInSlot(i);
-                if(slot.getItem() instanceof ItemWandCasting itemWand) {
+                if (slot != null && slot.getItem() instanceof ItemWandCasting itemWand) {
                     // Found a wand in table
-                    if((CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player))
-                        || (CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe.matches(this.tileEntity, this.ip.player.worldObj, this.ip.player))) {
+                    if ((CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe
+                        .matches(this.tileEntity, this.ip.player.worldObj, this.ip.player))
+                        || (CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe
+                            .matches(this.tileEntity, this.ip.player.worldObj, this.ip.player))) {
                         wandStack.set(slot);
                         return itemWand;
                     }
@@ -42,12 +55,19 @@ public class MixinGuiArcaneWorkbench_SingleWandReplacement {
         }
     }
 
-    @ModifyArg(method = "drawGuiContainerBackgroundLayer", at = @At(value = "INVOKE", target = "Lthaumcraft/common/items/wands/ItemWandCasting;getConsumptionModifier(Lnet/minecraft/item/ItemStack;Lnet/minecraft/entity/player/EntityPlayer;Lthaumcraft/api/aspects/Aspect;Z)F", remap = false), index = 0)
-    public ItemStack replaceWandConsumption(final ItemStack initial, final @Share("wandStack") LocalRef<ItemStack> wandStack) {
-        return initial == null ? wandStack.get() : initial;
-    }
-    @ModifyArg(method = "drawGuiContainerBackgroundLayer", at = @At(value = "INVOKE", target = "Lthaumcraft/common/items/wands/ItemWandCasting;getVis(Lnet/minecraft/item/ItemStack;Lthaumcraft/api/aspects/Aspect;)I", remap = false), index = 0)
-    public ItemStack replaceWandVis(final ItemStack initial, final @Share("wandStack") LocalRef<ItemStack> wandStack) {
+    @ModifyExpressionValue(
+        method = "drawGuiContainerBackgroundLayer",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;getStackInSlot(I)Lnet/minecraft/item/ItemStack;",
+            remap = false),
+        slice = @Slice(
+            from = @At(
+                value = "INVOKE",
+                target = "Lthaumcraft/common/lib/crafting/ThaumcraftCraftingManager;findMatchingArcaneRecipeAspects(Lnet/minecraft/inventory/IInventory;Lnet/minecraft/entity/player/EntityPlayer;)Lthaumcraft/api/aspects/AspectList;",
+                remap = false)))
+    public ItemStack replaceWandStack(final ItemStack initial,
+        final @Share("wandStack") LocalRef<ItemStack> wandStack) {
         return initial == null ? wandStack.get() : initial;
     }
 }


### PR DESCRIPTION
It's only slightly hacky...

(Note: this technically does have one flaw. If you set up a replacement recipe in the GUI, and then a Dispenser equips you with Vis Discount gear, that discount won't apply until you move an item in the GUI. If you try to craft immediately after, you will not gain the benefits of the gear you have equipped.)