### PR TITLE
Solution to #30 by dynamically adding extra translations

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -8,6 +8,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import cpw.mods.fml.common.event.FMLPreInitializationEvent;
+import dev.rndmorris.salisarcana.client.ResearchTranslationGenerator;
 import dev.rndmorris.salisarcana.client.ThaumicInventoryScanner;
 import dev.rndmorris.salisarcana.common.commands.CommandExportResearch;
 import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
@@ -19,6 +20,9 @@ public class ClientProxy extends CommonProxy {
     @Override
     public void preInit(FMLPreInitializationEvent event) {
         super.preInit(event);
+
+        ResearchTranslationGenerator.initialize();
+
         if (ConfigModuleRoot.commands.exportResearch.isEnabled()) {
             ClientCommandHandler.instance.registerCommand(new CommandExportResearch());
         }

--- a/src/main/java/dev/rndmorris/salisarcana/client/ResearchTranslationGenerator.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/ResearchTranslationGenerator.java
@@ -1,0 +1,50 @@
+package dev.rndmorris.salisarcana.client;
+
+import java.io.ByteArrayInputStream;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.resources.IReloadableResourceManager;
+import net.minecraft.client.resources.IResourceManager;
+import net.minecraft.client.resources.IResourceManagerReloadListener;
+import net.minecraft.util.StringTranslate;
+
+import org.apache.commons.io.Charsets;
+
+import dev.rndmorris.salisarcana.lib.TranslationHelper;
+import thaumcraft.api.research.ResearchCategories;
+
+public class ResearchTranslationGenerator implements IResourceManagerReloadListener {
+
+    public static void injectResearchProxyKeys() {
+        StringBuilder dynamicKeys = new StringBuilder();
+
+        for (final var category : ResearchCategories.researchCategories.values()) {
+            for (final var research : category.research.values()) {
+                String researchKey = TranslationHelper.getResearchTranslationKey(research);
+
+                if (researchKey.startsWith("salisarcana.research_proxy.")) {
+                    dynamicKeys.append(researchKey);
+                    dynamicKeys.append('=');
+                    dynamicKeys.append(research.getName());
+                    dynamicKeys.append('\n');
+                }
+            }
+        }
+
+        StringTranslate.inject(
+            new ByteArrayInputStream(
+                dynamicKeys.toString()
+                    .getBytes(Charsets.UTF_8)));
+    }
+
+    public static void initialize() {
+        ((IReloadableResourceManager) Minecraft.getMinecraft()
+            .getResourceManager()).registerReloadListener(new ResearchTranslationGenerator());
+        ResearchTranslationGenerator.injectResearchProxyKeys();
+    }
+
+    @Override
+    public void onResourceManagerReload(IResourceManager p_110549_1_) {
+        ResearchTranslationGenerator.injectResearchProxyKeys();
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -40,7 +40,7 @@ import thaumcraft.common.lib.network.PacketHandler;
 import thaumcraft.common.lib.network.playerdata.PacketPlayerCompleteToServer;
 import thaumcraft.common.lib.research.ResearchManager;
 
-public class ResearchHelper {
+public final class ResearchHelper {
 
     private static Gson _researchGson;
 
@@ -53,6 +53,10 @@ public class ResearchHelper {
     }
 
     private static FakePlayer knowItAll;
+
+    private ResearchHelper() {
+        // Forbid initialization of this class
+    }
 
     /**
      * A fake player whose entire purpose is to know all Thaumcraft research (created to support
@@ -112,13 +116,15 @@ public class ResearchHelper {
                 if (!filter.test(research)) {
                     continue;
                 }
-                anyInCategory = true;
-                final var item = formatResearch(research);
 
-                researchMessage.appendSibling(item);
-                if (research$.hasNext()) {
+                if (anyInCategory) {
                     researchMessage.appendText(", ");
                 }
+
+                anyInCategory = true;
+
+                final var item = formatResearch(research);
+                researchMessage.appendSibling(item);
             }
 
             if (anyInCategory) {
@@ -152,7 +158,7 @@ public class ResearchHelper {
         final var style = new ChatStyle().setColor(formatting)
             .setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ChatComponentText(research.key)));
         return new ChatComponentText("[").setChatStyle(style)
-            .appendSibling(new ChatComponentTranslation(String.format("tc.research_name.%s", research.key)))
+            .appendSibling(new ChatComponentTranslation(TranslationHelper.getResearchTranslationKey(research)))
             .appendText("]");
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/lib/TranslationHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/TranslationHelper.java
@@ -1,0 +1,33 @@
+package dev.rndmorris.salisarcana.lib;
+
+import java.util.WeakHashMap;
+
+import net.minecraft.util.StatCollector;
+
+import thaumcraft.api.research.ResearchItem;
+
+public final class TranslationHelper {
+
+    private static final WeakHashMap<ResearchItem, String> researchKeyCache = new WeakHashMap<>();
+
+    private TranslationHelper() {}
+
+    public static String getResearchTranslationKey(ResearchItem research) {
+        // Step 1: Check the cache
+        String key = researchKeyCache.get(research);
+        if (key != null) return key;
+
+        // Step 2: Check whether it follows the standard pattern.
+        key = "tc.research_name." + research.key;
+        if (research.getName() == StatCollector.translateToLocal(key)) {
+            // Note: I'm intentionally avoiding .equals() here, since both strings will come from the same HashMap entry
+            researchKeyCache.put(research, key);
+            return key;
+        }
+
+        // Step 3: Fallback on dynamically generated keys
+        key = "salisarcana.research_proxy." + research.key;
+        researchKeyCache.put(research, key);
+        return key;
+    }
+}


### PR DESCRIPTION
Solves #30 by adding new translation keys for any researches missing keys.

Several questions remain:
- Should I attempt to run a reverse lookup on the research keys not matching the pattern, or just let them go?
- Should I have put the dynamically generated keys in `tc.research_name.KEY` instead to force every mod to follow the pattern?
- Should I be keeping a cache of the `ResearchItem` translation keys (which can get large, since the client will cache every single research key because of the `ResearchTranslationGenerator`) or should I not keep a cache?