### PR TITLE
Add recipes for removing upgrades from wand foci

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -39,7 +39,7 @@ dependencies {
     api("com.github.GTNewHorizons:Baubles:1.0.4:dev")
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly(rfg.deobf("curse.maven:tc4tweaks-431297:6019390"))
-    runtimeOnly(rfg.deobf"curse.maven:tcneiplugin-225095:2241913")
+    api(rfg.deobf"curse.maven:tcneiplugin-225095:2241913")
     compileOnly("curse.maven:hodgepodge-688899:6039713")
     compileOnly("maven.modrinth:bugtorch:1.2.13")
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))

--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -227,35 +227,38 @@ Add a recipe to convert flesh blocks back into rotten flesh.
 ## Config option: `crystalClusterUncrafting`
 Add crafting recipes to convert crystal cluster blocks back into primal shards. Does not work for mixed crystal clusters.
 
+## Config option: `_enabledFocusDowngradingRecipeResearch`
+Add crafting recipes to remove one or more upgrades from wand foci.
+
 # Enhancements - Wand Component Replacement
 
-## Config option: `enableReplaceWandCapsRecipe`
+## Config option: `_enabledReplaceWandCapsRecipe`
 If `true`, enables an Arcane Worktable recipe to replace a wand, scepter, or staff's caps.
 
 ## Config option: `replaceCapsResearchCategory`, `replaceCapsResearchColumn` and `replaceCapsResearchRow`
 
-Requires `enableReplaceWandCapsRecipe=true`.
+Requires `_enabledReplaceWandCapsRecipe=true`.
 
 Used to set the tab of the Thaumonomicon on which the "Wand Cap Substitution" research appears, and its position on that tab.
 
-## Config option: `enableReplaceWandCoreRecipe`
+## Config option: `_enabledReplaceWandCoreRecipe`
 If `true`, enables an Arcane Worktable recipe to replace a wand, scepter, or staff's core.
 
 ## Config option: `replaceCoreResearchCategory`, `replaceCoreResearchColumn` and `replaceCoreResearchRow`
 
-Requires `enableReplaceWandCoreRecipe=true`.
+Requires `_enabledReplaceWandCoreRecipe=true`.
 
 Used to set the tab of the Thaumonomicon on which the "Wand Core Substitution" research appears, and its position on that tab.
 
 ## Config option: `enforceWandCoreTypes`
 
-Requires `enableReplaceWandCoreRecipe=true`.
+Requires `_enableReplaceWandCoreRecipe=true`.
 
 If enabled, prevents swapping a wand core with a staff core or a staff core with a wand core. Disable to allow converting a wand to a staff and vice versa.
 
 ## Config option: `allowSingleWandReplacement`
 
-Requires `enableReplaceWandCapsRecipe=true` or `enableReplaceWandCoreRecipe=true`.
+Requires `_enabledReplaceWandCapsRecipe=true` or `_enabledReplaceWandCoreRecipe=true`.
 
 Requires `arcaneWorkbenchGhostItemFix=true` in the bugfixes module.
 

--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -100,6 +100,13 @@ public class CommonProxy {
         return false;
     }
 
+    public boolean isServerThread() {
+        // there's gotta be a better way that doesn't require passing in a world object
+        return "Server thread".equals(
+            Thread.currentThread()
+                .getName());
+    }
+
     @SubscribeEvent
     public void onClientConnect(PlayerEvent.PlayerLoggedInEvent event) {
         CustomResearch.registerResearchFromFiles();

--- a/src/main/java/dev/rndmorris/salisarcana/api/INeiOnlyRecipeRegistry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/api/INeiOnlyRecipeRegistry.java
@@ -21,41 +21,43 @@ public interface INeiOnlyRecipeRegistry {
     /**
      * Register a shaped arcane recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeShapedArcaneRecipe(ShapedArcaneRecipe recipe);
+    ShapedArcaneRecipe registerFakeShapedArcaneRecipe(ShapedArcaneRecipe recipe);
 
     /**
      * Register a shaped arcane recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeShapedArcaneRecipe(String research, ItemStack result, AspectList aspects, Object... recipe);
+    ShapedArcaneRecipe registerFakeShapedArcaneRecipe(String research, ItemStack result, AspectList aspects,
+        Object... recipe);
 
     /**
      * Register a shapeless arcane recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeShapelessArcaneRecipe(ShapelessArcaneRecipe recipe);
+    ShapelessArcaneRecipe registerFakeShapelessArcaneRecipe(ShapelessArcaneRecipe recipe);
 
     /**
      * Register a shapeless arcane recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeShapelessArcaneRecipe(String research, ItemStack result, AspectList aspects, Object... recipe);
+    ShapelessArcaneRecipe registerFakeShapelessArcaneRecipe(String research, ItemStack result, AspectList aspects,
+        Object... recipe);
 
     /**
      * Register a crucible recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeCrucibleRecipeHandler(CrucibleRecipe recipe);
+    CrucibleRecipe registerFakeCrucibleRecipeHandler(CrucibleRecipe recipe);
 
     /**
      * Register a crucible recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeCrucibleRecipeHandler(String key, ItemStack result, Object catalyst, AspectList tags);
+    CrucibleRecipe registerFakeCrucibleRecipeHandler(String key, ItemStack result, Object catalyst, AspectList tags);
 
     /**
      * Register an infusion recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeInfusionRecipeHandler(InfusionRecipe recipe);
+    InfusionRecipe registerFakeInfusionRecipeHandler(InfusionRecipe recipe);
 
     /**
      * Register an infusion recipe that only appears in NEI and should not be registered as a functional recipe.
      */
-    void registerFakeInfusionRecipeHandler(String research, Object result, int instability, AspectList aspects,
-        ItemStack input, ItemStack[] recipe);
+    InfusionRecipe registerFakeInfusionRecipeHandler(String research, Object result, int instability,
+        AspectList aspects, ItemStack input, ItemStack[] recipe);
 }

--- a/src/main/java/dev/rndmorris/salisarcana/api/INeiOnlyRecipeRegistry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/api/INeiOnlyRecipeRegistry.java
@@ -11,6 +11,7 @@ import thaumcraft.api.crafting.ShapelessArcaneRecipe;
 
 /**
  * Methods to register Thaumcraft recipes that will appear in NEI but should not be registered as a functional recipe.
+ * No effect if {@code "tcneiplugin=false"} in {@code "mod_integrations.cfg"}.
  */
 public interface INeiOnlyRecipeRegistry {
 

--- a/src/main/java/dev/rndmorris/salisarcana/api/INeiOnlyRecipeRegistry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/api/INeiOnlyRecipeRegistry.java
@@ -1,0 +1,61 @@
+package dev.rndmorris.salisarcana.api;
+
+import net.minecraft.item.ItemStack;
+
+import dev.rndmorris.salisarcana.common.recipes.NeiOnlyRecipeRegistry;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.crafting.ShapedArcaneRecipe;
+import thaumcraft.api.crafting.ShapelessArcaneRecipe;
+
+/**
+ * Methods to register Thaumcraft recipes that will appear in NEI but should not be registered as a functional recipe.
+ */
+public interface INeiOnlyRecipeRegistry {
+
+    static INeiOnlyRecipeRegistry getInstance() {
+        return NeiOnlyRecipeRegistry.getInstance();
+    }
+
+    /**
+     * Register a shaped arcane recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeShapedArcaneRecipe(ShapedArcaneRecipe recipe);
+
+    /**
+     * Register a shaped arcane recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeShapedArcaneRecipe(String research, ItemStack result, AspectList aspects, Object... recipe);
+
+    /**
+     * Register a shapeless arcane recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeShapelessArcaneRecipe(ShapelessArcaneRecipe recipe);
+
+    /**
+     * Register a shapeless arcane recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeShapelessArcaneRecipe(String research, ItemStack result, AspectList aspects, Object... recipe);
+
+    /**
+     * Register a crucible recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeCrucibleRecipeHandler(CrucibleRecipe recipe);
+
+    /**
+     * Register a crucible recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeCrucibleRecipeHandler(String key, ItemStack result, Object catalyst, AspectList tags);
+
+    /**
+     * Register an infusion recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeInfusionRecipeHandler(InfusionRecipe recipe);
+
+    /**
+     * Register an infusion recipe that only appears in NEI and should not be registered as a functional recipe.
+     */
+    void registerFakeInfusionRecipeHandler(String research, Object result, int instability, AspectList aspects,
+        ItemStack input, ItemStack[] recipe);
+}

--- a/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
@@ -365,7 +365,12 @@ public class CustomResearch {
 
         final var pages = new ArrayList<ResearchPage>();
         pages.add(new ResearchPage("tc.research_page." + fullKey + ".0"));
-        pages.add(new ResearchPage(CustomRecipes.cleanFocusExamples.toArray(new ShapelessArcaneRecipe[0])));
+
+        pages.add(new ResearchPage(CustomRecipes.Examples.oneUpgrade.toArray(new ShapelessArcaneRecipe[0])));
+        pages.add(new ResearchPage(CustomRecipes.Examples.twoUpgrade.toArray(new ShapelessArcaneRecipe[0])));
+        pages.add(new ResearchPage(CustomRecipes.Examples.threeUpgrade.toArray(new ShapelessArcaneRecipe[0])));
+        pages.add(new ResearchPage(CustomRecipes.Examples.fourUpgrade.toArray(new ShapelessArcaneRecipe[0])));
+        pages.add(new ResearchPage(CustomRecipes.Examples.fiveUpgrade.toArray(new ShapelessArcaneRecipe[0])));
 
         research.setPages(pages.toArray(new ResearchPage[0]));
 

--- a/src/main/java/dev/rndmorris/salisarcana/common/interfaces/ISuppressCraftingWarp.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/interfaces/ISuppressCraftingWarp.java
@@ -1,0 +1,21 @@
+package dev.rndmorris.salisarcana.common.interfaces;
+
+import javax.annotation.Nullable;
+
+import thaumcraft.common.Thaumcraft;
+
+public interface ISuppressCraftingWarp {
+
+    /**
+     * Returns this extensions instance, if it is enabled, otherwise {@code null}.
+     */
+    static @Nullable ISuppressCraftingWarp getInstance() {
+        return Thaumcraft.instance.worldEventHandler instanceof ISuppressCraftingWarp extension ? extension : null;
+    }
+
+    /**
+     * Skip giving warp the next time a crafting recipe that would give warp would give warp.
+     * No effect if called anywhere except from the server thread.
+     */
+    void skipNextCraftingWarp();
+}

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CleanFocusRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CleanFocusRecipe.java
@@ -2,7 +2,6 @@ package dev.rndmorris.salisarcana.common.recipes;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -13,7 +12,6 @@ import net.minecraft.world.World;
 
 import dev.rndmorris.salisarcana.lib.ArrayHelper;
 import dev.rndmorris.salisarcana.lib.AspectHelper;
-import dev.rndmorris.salisarcana.lib.R;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.IArcaneRecipe;
 import thaumcraft.api.wands.ItemFocusBasic;
@@ -22,8 +20,6 @@ import thaumcraft.common.config.ConfigItems;
 public class CleanFocusRecipe implements IArcaneRecipe {
 
     private int focusIndex;
-
-    private final HashMap<ItemFocusBasic, R> focusReflectors = new HashMap<>();
 
     private final List<SlotPredicate> predicates = Collections.unmodifiableList(new PredicateList() {
 
@@ -97,17 +93,12 @@ public class CleanFocusRecipe implements IArcaneRecipe {
             return null;
         }
 
-        final R focusReflector;
-        if (!focusReflectors.containsKey(itemFocus)) {
-            focusReflector = new R(itemFocus);
-            focusReflectors.put(itemFocus, focusReflector);
-        } else {
-            focusReflector = focusReflectors.get(itemFocus);
-        }
         final var outputStack = focusStack.copy();
 
         // private method, so reflect to call it
-        focusReflector.call("setFocusUpgradeTagList", outputStack, new short[] { -1, -1, -1, -1, -1 });
+        CustomRecipes.withItemFocusReflection(
+            itemFocus,
+            (r) -> r.call("setFocusUpgradeTagList", outputStack, new short[] { -1, -1, -1, -1, -1 }));
 
         return outputStack;
     }

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CleanFocusRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CleanFocusRecipe.java
@@ -10,6 +10,7 @@ import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.world.World;
 
+import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
 import dev.rndmorris.salisarcana.lib.ArrayHelper;
 import dev.rndmorris.salisarcana.lib.AspectHelper;
 import thaumcraft.api.aspects.AspectList;
@@ -140,7 +141,7 @@ public class CleanFocusRecipe implements IArcaneRecipe {
 
     @Override
     public String getResearch() {
-        return "FOCALMANIPULATION";
+        return ConfigModuleRoot.enhancements.focusDowngradeRecipe.researchName;
     }
 }
 

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CleanFocusRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CleanFocusRecipe.java
@@ -1,0 +1,178 @@
+package dev.rndmorris.salisarcana.common.recipes;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.function.Predicate;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import dev.rndmorris.salisarcana.lib.ArrayHelper;
+import dev.rndmorris.salisarcana.lib.AspectHelper;
+import dev.rndmorris.salisarcana.lib.R;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.api.wands.ItemFocusBasic;
+import thaumcraft.common.config.ConfigItems;
+
+public class CleanFocusRecipe implements IArcaneRecipe {
+
+    private int focusIndex;
+
+    private final HashMap<ItemFocusBasic, R> focusReflectors = new HashMap<>();
+
+    private final List<SlotPredicate> predicates = Collections.unmodifiableList(new PredicateList() {
+
+        {
+            final var balancedShardDamage = 6;
+            final var clothDamage = 7;
+            focusIndex = this.autoCount;
+            add(i -> i != null && i.getItem() instanceof ItemFocusBasic);
+            add(i -> i != null && i.getItem() == ConfigItems.itemShard && i.getItemDamage() == balancedShardDamage);
+            add(i -> i != null && i.getItem() == ConfigItems.itemResource && i.getItemDamage() == clothDamage);
+        }
+    });
+
+    private ItemStack[] getMatchedItems(IInventory inventory) {
+        final var outputs = new ItemStack[predicates.size()];
+
+        final var predicates = new ArrayList<>(this.predicates);
+        for (var slot = 0; slot < inventory.getSizeInventory() - 2 /* exclude the output and wand slots */ ; slot++) {
+            int matchedPredicateIndex = -1;
+            final var slotItem = inventory.getStackInSlot(slot);
+            for (var predIndex = 0; predIndex < predicates.size(); ++predIndex) {
+                final var predicate = predicates.get(predIndex);
+                if (!predicate.predicate.test(slotItem)) {
+                    continue;
+                }
+                outputs[predicate.index] = slotItem;
+                matchedPredicateIndex = predIndex;
+                break;
+            }
+            if (matchedPredicateIndex > -1) {
+                predicates.remove(matchedPredicateIndex);
+            } else if (slotItem != null) {
+                return null;
+            }
+        }
+
+        if (!predicates.isEmpty()) {
+            return null;
+        }
+
+        return outputs;
+    }
+
+    @Override
+    public boolean matches(IInventory inventory, World world, EntityPlayer player) {
+        final var invItems = getMatchedItems(inventory);
+
+        final var focusStack = ArrayHelper.tryGet(invItems, focusIndex)
+            .data();
+        // extra sanity check, also to get the ItemFocusBasic instance
+        if (focusStack == null || !(focusStack.getItem() instanceof ItemFocusBasic focusItem)) {
+            return false;
+        }
+        final var appliedUpgrades = focusItem.getAppliedUpgrades(focusStack);
+        ArrayHelper.TryGetShortResult getResult;
+        // we want to have at least one focus upgrade on the focus
+        if ((getResult = ArrayHelper.tryGet(appliedUpgrades, 0)).success() && getResult.data() < 0) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(IInventory inventory) {
+        final var invItems = getMatchedItems(inventory);
+        final var focusStack = ArrayHelper.tryGet(invItems, focusIndex)
+            .data();
+
+        if (focusStack == null || !(focusStack.getItem() instanceof ItemFocusBasic itemFocus)) {
+            return null;
+        }
+
+        final R focusReflector;
+        if (!focusReflectors.containsKey(itemFocus)) {
+            focusReflector = new R(itemFocus);
+            focusReflectors.put(itemFocus, focusReflector);
+        } else {
+            focusReflector = focusReflectors.get(itemFocus);
+        }
+        final var outputStack = focusStack.copy();
+
+        // private method, so reflect to call it
+        focusReflector.call("setFocusUpgradeTagList", outputStack, new short[] { -1, -1, -1, -1, -1 });
+
+        return outputStack;
+    }
+
+    @Override
+    public int getRecipeSize() {
+        return 3;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput() {
+        return null;
+    }
+
+    @Override
+    public AspectList getAspects() {
+        return null;
+    }
+
+    @Override
+    public AspectList getAspects(IInventory inventory) {
+        final var invItems = getMatchedItems(inventory);
+        final var focusStack = ArrayHelper.tryGet(invItems, focusIndex)
+            .data();
+        if (focusStack == null || !(focusStack.getItem() instanceof ItemFocusBasic itemFocus)) {
+            return new AspectList();
+        }
+        final var focusUpgrades = itemFocus.getAppliedUpgrades(focusStack);
+        var costMultiplier = 0;
+
+        for (var upgrade : focusUpgrades) {
+            if (upgrade > 0) {
+                costMultiplier += 1;
+            }
+        }
+
+        return AspectHelper.primalList(costMultiplier * 10);
+    }
+
+    @Override
+    public String getResearch() {
+        return "FOCALMANIPULATION";
+    }
+}
+
+class PredicateList extends ArrayList<SlotPredicate> {
+
+    public int autoCount = 0;
+
+    /**
+     * Automatically register a predicate with a sequential output index.
+     */
+    public boolean add(Predicate<ItemStack> predicate) {
+        return this.add(new SlotPredicate(autoCount++, predicate));
+    }
+
+}
+
+class SlotPredicate {
+
+    public int index;
+    public Predicate<ItemStack> predicate;
+
+    public SlotPredicate(int index, Predicate<ItemStack> predicate) {
+        this.index = index;
+        this.predicate = predicate;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -16,7 +16,6 @@ import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.nbt.NBTTagCompound;
 import net.minecraftforge.common.MinecraftForge;
 import net.minecraftforge.oredict.OreDictionary;
 import net.minecraftforge.oredict.ShapedOreRecipe;

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -317,33 +317,30 @@ public class CustomRecipes {
             if (!(item instanceof ItemFocusBasic itemFocus)) {
                 continue;
             }
-            final var subItemStacks = new ArrayList<ItemStack>();
-            itemFocus.getSubItems(itemFocus, null, subItemStacks);
-            for (var subItemStack : subItemStacks) {
-                final var inputStacks = prepareFocusInputStacks(itemFocus, subItemStack);
-                final var outputStack = prepareFocusOutputFocus(itemFocus, subItemStack);
 
-                for (var index = 0; index < 5; ++index) {
-                    final var inputs = new ArrayList<ItemStack>(3 + index);
-                    inputs.add(inputStacks.get(index));
-                    inputs.add(cloth);
-                    for (var strength = 0; strength <= index; ++strength) {
-                        inputs.add(salt);
-                    }
+            final var inputStacks = prepareFocusInputStacks(itemFocus, new ItemStack(itemFocus));
+            final var outputStack = prepareFocusOutputFocus(itemFocus, new ItemStack(itemFocus));
 
-                    final var recipe = registry.registerFakeShapelessArcaneRecipe(
-                        MODID + ":" + ConfigModuleRoot.enhancements.focusDowngradeRecipe.researchName,
-                        outputStack,
-                        AspectHelper.primalList((index + 1) * 10),
-                        inputs.toArray(new Object[0]));
-                    (switch (index) {
-                        case 0 -> Examples.oneUpgrade;
-                        case 1 -> Examples.twoUpgrade;
-                        case 2 -> Examples.threeUpgrade;
-                        case 3 -> Examples.fourUpgrade;
-                        default -> Examples.fiveUpgrade;
-                    }).add(recipe);
+            for (var index = 0; index < 5; ++index) {
+                final var inputs = new ArrayList<ItemStack>(3 + index);
+                inputs.add(inputStacks.get(index));
+                inputs.add(cloth);
+                for (var strength = 0; strength <= index; ++strength) {
+                    inputs.add(salt);
                 }
+
+                final var recipe = registry.registerFakeShapelessArcaneRecipe(
+                    MODID + ":" + ConfigModuleRoot.enhancements.focusDowngradeRecipe.researchName,
+                    outputStack,
+                    AspectHelper.primalList((index + 1) * 10),
+                    inputs.toArray(new Object[0]));
+                (switch (index) {
+                    case 0 -> Examples.oneUpgrade;
+                    case 1 -> Examples.twoUpgrade;
+                    case 2 -> Examples.threeUpgrade;
+                    case 3 -> Examples.fourUpgrade;
+                    default -> Examples.fiveUpgrade;
+                }).add(recipe);
             }
         }
     }
@@ -364,8 +361,6 @@ public class CustomRecipes {
     }
 
     private static ItemStack prepareFocusOutputFocus(ItemFocusBasic itemFocus, ItemStack outputStack) {
-        final NBTTagCompound itemTag;
-
         withItemFocusReflection(
             itemFocus,
             (r) -> r.call("setFocusUpgradeTagList", outputStack, new short[] { -1, -1, -1, -1, -1, }));

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -45,6 +45,8 @@ public class CustomRecipes {
     public static @Nullable ReplaceWandCapsRecipe replaceWandCapsRecipe = null;
     public static @Nullable ReplaceWandCoreRecipe replaceWandCoreRecipe = null;
 
+    public static final List<ShapelessArcaneRecipe> cleanFocusExamples = new ArrayList<>();
+
     private static final HashMap<ItemFocusBasic, R> focusReflectors = new HashMap<>();
 
     public static void withItemFocusReflection(ItemFocusBasic itemFocusBasic, Consumer<R> callback) {
@@ -314,13 +316,14 @@ public class CustomRecipes {
                 final var outputStack = prepareFocusOutputFocus(itemFocus, subItemStack);
 
                 for (var index = 0; index < 5; ++index) {
-                    registry.registerFakeShapelessArcaneRecipe(
+                    final var recipe = registry.registerFakeShapelessArcaneRecipe(
                         "FOCALMANIPULATION",
                         outputStack,
                         AspectHelper.primalList((index + 1) * 10),
                         inputStacks.get(index),
                         cloth,
                         shard);
+                    cleanFocusExamples.add(recipe);
                 }
             }
         }

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -30,6 +30,7 @@ import thaumcraft.common.config.ConfigResearch;
 
 public class CustomRecipes {
 
+    public static @Nullable CleanFocusRecipe cleanFocusRecipe = null;
     public static @Nullable ReplaceWandCapsRecipe replaceWandCapsRecipe = null;
     public static @Nullable ReplaceWandCoreRecipe replaceWandCoreRecipe = null;
 
@@ -88,6 +89,9 @@ public class CustomRecipes {
         }
         if (ConfigModuleRoot.bugfixes.fixEFRRecipes.isEnabled() && Loader.isModLoaded("etfuturum")) {
             registerEFRRecipes();
+        }
+        if (ConfigModuleRoot.enhancements.focusDowngradeRecipe.isEnabled()) {
+            registerFocusDowngradeRecipes();
         }
     }
 
@@ -267,6 +271,12 @@ public class CustomRecipes {
         // noinspection unchecked
         ThaumcraftApi.getCraftingRecipes()
             .addAll(toAdd);
+    }
+
+    private static void registerFocusDowngradeRecipes() {
+        // noinspection unchecked
+        ThaumcraftApi.getCraftingRecipes()
+            .add(cleanFocusRecipe = new CleanFocusRecipe());
     }
 
     private static ShapedArcaneRecipe createCopy(ShapedArcaneRecipe inputRecipe) {

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/NeiOnlyRecipeRegistry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/NeiOnlyRecipeRegistry.java
@@ -28,57 +28,59 @@ public class NeiOnlyRecipeRegistry implements INeiOnlyRecipeRegistry {
     public final ArrayList<InfusionRecipe> infusionRecipes = new ArrayList<>();
 
     @Override
-    public void registerFakeShapedArcaneRecipe(ShapedArcaneRecipe recipe) {
-        if (recipe == null) {
-            return;
+    public ShapedArcaneRecipe registerFakeShapedArcaneRecipe(ShapedArcaneRecipe recipe) {
+        if (recipe != null) {
+            shapedRecipes.add(recipe);
         }
-        shapedRecipes.add(recipe);
+        return recipe;
     }
 
     @Override
-    public void registerFakeShapedArcaneRecipe(String research, ItemStack result, AspectList aspects,
+    public ShapedArcaneRecipe registerFakeShapedArcaneRecipe(String research, ItemStack result, AspectList aspects,
         Object... recipe) {
-        registerFakeShapedArcaneRecipe(new ShapedArcaneRecipe(research, result, aspects, recipe));
+        return registerFakeShapedArcaneRecipe(new ShapedArcaneRecipe(research, result, aspects, recipe));
     }
 
     @Override
-    public void registerFakeShapelessArcaneRecipe(ShapelessArcaneRecipe recipe) {
-        if (recipe == null) {
-            return;
+    public ShapelessArcaneRecipe registerFakeShapelessArcaneRecipe(ShapelessArcaneRecipe recipe) {
+        if (recipe != null) {
+            shapelessArcaneRecipes.add(recipe);
         }
-        shapelessArcaneRecipes.add(recipe);
+        return recipe;
     }
 
     @Override
-    public void registerFakeShapelessArcaneRecipe(String research, ItemStack result, AspectList aspects,
-        Object... recipe) {
-        registerFakeShapelessArcaneRecipe(new ShapelessArcaneRecipe(research, result, aspects, recipe));
+    public ShapelessArcaneRecipe registerFakeShapelessArcaneRecipe(String research, ItemStack result,
+        AspectList aspects, Object... recipe) {
+        return registerFakeShapelessArcaneRecipe(new ShapelessArcaneRecipe(research, result, aspects, recipe));
     }
 
     @Override
-    public void registerFakeCrucibleRecipeHandler(CrucibleRecipe recipe) {
-        if (recipe == null) {
-            return;
+    public CrucibleRecipe registerFakeCrucibleRecipeHandler(CrucibleRecipe recipe) {
+        if (recipe != null) {
+            crucibleRecipes.add(recipe);
         }
-        crucibleRecipes.add(recipe);
+        return recipe;
     }
 
     @Override
-    public void registerFakeCrucibleRecipeHandler(String key, ItemStack result, Object catalyst, AspectList tags) {
-        registerFakeCrucibleRecipeHandler(new CrucibleRecipe(key, result, catalyst, tags));
+    public CrucibleRecipe registerFakeCrucibleRecipeHandler(String key, ItemStack result, Object catalyst,
+        AspectList tags) {
+        return registerFakeCrucibleRecipeHandler(new CrucibleRecipe(key, result, catalyst, tags));
     }
 
     @Override
-    public void registerFakeInfusionRecipeHandler(InfusionRecipe recipe) {
-        if (recipe == null) {
-            return;
+    public InfusionRecipe registerFakeInfusionRecipeHandler(InfusionRecipe recipe) {
+        if (recipe != null) {
+            infusionRecipes.add(recipe);
         }
-        infusionRecipes.add(recipe);
+        return recipe;
     }
 
     @Override
-    public void registerFakeInfusionRecipeHandler(String research, Object result, int instability, AspectList aspects,
-        ItemStack input, ItemStack[] recipe) {
-        registerFakeInfusionRecipeHandler(new InfusionRecipe(research, result, instability, aspects, input, recipe));
+    public InfusionRecipe registerFakeInfusionRecipeHandler(String research, Object result, int instability,
+        AspectList aspects, ItemStack input, ItemStack[] recipe) {
+        return registerFakeInfusionRecipeHandler(
+            new InfusionRecipe(research, result, instability, aspects, input, recipe));
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/NeiOnlyRecipeRegistry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/NeiOnlyRecipeRegistry.java
@@ -1,0 +1,84 @@
+package dev.rndmorris.salisarcana.common.recipes;
+
+import java.util.ArrayList;
+
+import net.minecraft.item.ItemStack;
+
+import dev.rndmorris.salisarcana.api.INeiOnlyRecipeRegistry;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.CrucibleRecipe;
+import thaumcraft.api.crafting.InfusionRecipe;
+import thaumcraft.api.crafting.ShapedArcaneRecipe;
+import thaumcraft.api.crafting.ShapelessArcaneRecipe;
+
+public class NeiOnlyRecipeRegistry implements INeiOnlyRecipeRegistry {
+
+    private static NeiOnlyRecipeRegistry instance;
+
+    public static synchronized NeiOnlyRecipeRegistry getInstance() {
+        if (instance == null) {
+            instance = new NeiOnlyRecipeRegistry();
+        }
+        return instance;
+    }
+
+    public final ArrayList<ShapedArcaneRecipe> shapedRecipes = new ArrayList<>();
+    public final ArrayList<ShapelessArcaneRecipe> shapelessArcaneRecipes = new ArrayList<>();
+    public final ArrayList<CrucibleRecipe> crucibleRecipes = new ArrayList<>();
+    public final ArrayList<InfusionRecipe> infusionRecipes = new ArrayList<>();
+
+    @Override
+    public void registerFakeShapedArcaneRecipe(ShapedArcaneRecipe recipe) {
+        if (recipe == null) {
+            return;
+        }
+        shapedRecipes.add(recipe);
+    }
+
+    @Override
+    public void registerFakeShapedArcaneRecipe(String research, ItemStack result, AspectList aspects,
+        Object... recipe) {
+        registerFakeShapedArcaneRecipe(new ShapedArcaneRecipe(research, result, aspects, recipe));
+    }
+
+    @Override
+    public void registerFakeShapelessArcaneRecipe(ShapelessArcaneRecipe recipe) {
+        if (recipe == null) {
+            return;
+        }
+        shapelessArcaneRecipes.add(recipe);
+    }
+
+    @Override
+    public void registerFakeShapelessArcaneRecipe(String research, ItemStack result, AspectList aspects,
+        Object... recipe) {
+        registerFakeShapelessArcaneRecipe(new ShapelessArcaneRecipe(research, result, aspects, recipe));
+    }
+
+    @Override
+    public void registerFakeCrucibleRecipeHandler(CrucibleRecipe recipe) {
+        if (recipe == null) {
+            return;
+        }
+        crucibleRecipes.add(recipe);
+    }
+
+    @Override
+    public void registerFakeCrucibleRecipeHandler(String key, ItemStack result, Object catalyst, AspectList tags) {
+        registerFakeCrucibleRecipeHandler(new CrucibleRecipe(key, result, catalyst, tags));
+    }
+
+    @Override
+    public void registerFakeInfusionRecipeHandler(InfusionRecipe recipe) {
+        if (recipe == null) {
+            return;
+        }
+        infusionRecipes.add(recipe);
+    }
+
+    @Override
+    public void registerFakeInfusionRecipeHandler(String research, Object result, int instability, AspectList aspects,
+        ItemStack input, ItemStack[] recipe) {
+        registerFakeInfusionRecipeHandler(new InfusionRecipe(research, result, instability, aspects, input, recipe));
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -21,7 +21,7 @@ public class EnhancementsModule extends BaseConfigModule {
     public final ToggleSetting rotatedFociRecipes;
     public final ToggleSetting rotatedThaumometerRecipe;
 
-    public final CustomResearchSetting replaceWandCapsSettings;
+    public final ReplaceWandComponentSettings replaceWandCapsSettings;
     public final ReplaceWandComponentSettings replaceWandCoreSettings;
     public final ToggleSetting enforceWandCoreTypes;
     public final ToggleSetting preserveWandVis;
@@ -65,7 +65,7 @@ public class EnhancementsModule extends BaseConfigModule {
 
     public final ToggleSetting staffterNameTooltip;
     public final ToggleSetting primalCrusherOredict;
-    public final ToggleSetting focusDowngradeRecipe;
+    public final CustomResearchSetting focusDowngradeRecipe;
 
     public EnhancementsModule() {
         // spotless:off
@@ -82,12 +82,12 @@ public class EnhancementsModule extends BaseConfigModule {
                 "rotatedFoci",
                 "Add rotated recipes for the fire, shock, frost, equal rade, excavation, and primal wand foci.")
                     .setCategory("recipes"),
-            focusDowngradeRecipe = new ToggleSetting(
+            focusDowngradeRecipe = new CustomResearchSetting(
                 this,
                 ConfigPhase.LATE,
-                "focusDowngradeRecipe",
-                "Add an arcane crafting recipe to wipe a wand foci's upgrades.")
-                    .setCategory("recipes"),
+                "focusDowngradingRecipe",
+                "Add arcane crafting recipes to remove upgrades from wand foci.", new CustomResearchSetting.ResearchInfo("FOCUSCLEANING", "THAUMATURGY", -2, -9).setAspects("instrumentum:5", "pannus:3", "vacuos:3").setPurchasable(true).setDifficulty(1).setParents("FOCALMANIPULATION"))
+                    .setCategory("focus_downgrading"),
             rotatedThaumometerRecipe = new ToggleSetting(
                 this,
                 ConfigPhase.LATE,

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -65,6 +65,7 @@ public class EnhancementsModule extends BaseConfigModule {
 
     public final ToggleSetting staffterNameTooltip;
     public final ToggleSetting primalCrusherOredict;
+    public final ToggleSetting focusDowngradeRecipe;
 
     public EnhancementsModule() {
         // spotless:off
@@ -80,6 +81,12 @@ public class EnhancementsModule extends BaseConfigModule {
                 ConfigPhase.LATE,
                 "rotatedFoci",
                 "Add rotated recipes for the fire, shock, frost, equal rade, excavation, and primal wand foci.")
+                    .setCategory("recipes"),
+            focusDowngradeRecipe = new ToggleSetting(
+                this,
+                ConfigPhase.LATE,
+                "focusDowngradeRecipe",
+                "Add an arcane crafting recipe to wipe a wand foci's upgrades.")
                     .setCategory("recipes"),
             rotatedThaumometerRecipe = new ToggleSetting(
                 this,

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/ModCompatModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/ModCompatModule.java
@@ -3,14 +3,22 @@ package dev.rndmorris.salisarcana.config.modules;
 import javax.annotation.Nonnull;
 
 import dev.rndmorris.salisarcana.config.ConfigPhase;
+import dev.rndmorris.salisarcana.config.settings.ToggleSetting;
 import dev.rndmorris.salisarcana.config.settings.compat.UBCCompatSettings;
 
 public class ModCompatModule extends BaseConfigModule {
 
     public final UBCCompatSettings undergroundBiomes;
+    public final ToggleSetting tcneiplugin;
 
     public ModCompatModule() {
-        addSettings(undergroundBiomes = new UBCCompatSettings(this, ConfigPhase.LATE));
+        addSettings(
+            undergroundBiomes = new UBCCompatSettings(this, ConfigPhase.LATE),
+            tcneiplugin = new ToggleSetting(
+                this,
+                ConfigPhase.EARLY,
+                "tcneiplugin",
+                "Enable compatibility with the Thaumcraft NEI Plugin mod. Used for (e.g.) registering fake crafting recipes with NEI."));
     }
 
     @Nonnull

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
@@ -39,6 +39,7 @@ public class CustomResearchSetting extends Setting {
         this.researchCategory = researchInfo.getResearchCategory();
         this.researchCol = researchInfo.getResearchCol();
         this.researchRow = researchInfo.getResearchRow();
+        this.purchasable = researchInfo.isPurchasable();
         this.parentResearches = researchInfo.getParents();
         this.difficulty = researchInfo.getDifficulty();
         this.autoUnlock = researchInfo.getAutoUnlock();

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ArrayHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ArrayHelper.java
@@ -30,7 +30,7 @@ public class ArrayHelper {
     }
 
     public static <E> TryGetResult<E> tryGet(E[] arr, int index) {
-        if (0 <= index && index < arr.length) {
+        if (arr != null && 0 <= index && index < arr.length) {
             return TryGetResult.success(arr[index]);
         }
         return TryGetResult.failure();

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ArrayHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ArrayHelper.java
@@ -29,6 +29,13 @@ public class ArrayHelper {
         return false;
     }
 
+    public static TryGetShortResult tryGet(short[] arr, int index) {
+        if (arr != null && 0 <= index && index < arr.length) {
+            return TryGetShortResult.success(arr[index]);
+        }
+        return TryGetShortResult.failure();
+    }
+
     public static <E> TryGetResult<E> tryGet(E[] arr, int index) {
         if (arr != null && 0 <= index && index < arr.length) {
             return TryGetResult.success(arr[index]);
@@ -49,6 +56,18 @@ public class ArrayHelper {
             Collections.addAll(result, arr);
         }
         return result;
+    }
+
+    @Desugar
+    public record TryGetShortResult(boolean success, short data) {
+
+        public static TryGetShortResult failure() {
+            return new TryGetShortResult(false, (short) 0);
+        }
+
+        public static TryGetShortResult success(short data) {
+            return new TryGetShortResult(true, data);
+        }
     }
 
     @Desugar

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -35,7 +35,6 @@ import dev.rndmorris.salisarcana.config.settings.ResearchEntry;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchCategoryList;
 import thaumcraft.api.research.ResearchItem;
-import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.lib.network.PacketHandler;
 import thaumcraft.common.lib.network.playerdata.PacketPlayerCompleteToServer;
 import thaumcraft.common.lib.research.ResearchManager;
@@ -60,7 +59,7 @@ public class ResearchHelper {
      *
      * @return The fake player.
      */
-    public static FakePlayer knowItAll() {
+    public static synchronized FakePlayer knowItAll() {
         if (knowItAll == null) {
             knowItAll = new FakePlayer(
                 MinecraftServer.getServer()
@@ -71,8 +70,7 @@ public class ResearchHelper {
                     if (ResearchManager.isResearchComplete(knowItAll.getCommandSenderName(), researchItem.key)) {
                         continue;
                     }
-                    Thaumcraft.proxy.getResearchManager()
-                        .completeResearch(knowItAll, researchItem.key);
+                    ResearchManager.completeResearchUnsaved(knowItAll.getCommandSenderName(), researchItem.key);
                 }
             }
         }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -350,7 +350,7 @@ public enum Mixins {
 
     NEI_FAKE_RECIPES(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)
-        .setApplyIf(() -> true)
+        .setApplyIf(ConfigModuleRoot.modCompat.tcneiplugin::isEnabled)
         .addMixinClasses(
             "addons.thaumcraftneiplugin.MixinArcaneShapedRecipeHandler_FakeRecipes",
             "addons.thaumcraftneiplugin.MixinArcaneShapelessRecipeHandler_FakeRecipes",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -346,7 +346,17 @@ public enum Mixins {
         .setSide(Side.BOTH)
         .setApplyIf(ConfigModuleRoot.enhancements.primalCrusherOredict::isEnabled)
         .addMixinClasses("items.PrimalCrusher_StoneOredictCompat")
-        .addTargetedMod(TargetedMod.THAUMCRAFT));
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
+
+    NEI_FAKE_RECIPES(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(() -> true)
+        .addMixinClasses(
+            "addons.thaumcraftneiplugin.MixinArcaneShapedRecipeHandler_FakeRecipes",
+            "addons.thaumcraftneiplugin.MixinArcaneShapelessRecipeHandler_FakeRecipes",
+            "addons.thaumcraftneiplugin.MixinCrucibleRecipeHandler_FakeRecipes",
+            "addons.thaumcraftneiplugin.MixinInfusionRecipeHandler_FakeRecipes")
+        .addTargetedMod(TargetedMod.THAUMCRAFTNEIPLUGIN)),;
 
     private final List<String> mixinClasses;
     private final List<TargetedMod> targetedMods;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -319,6 +319,14 @@ public enum Mixins {
         .addMixinClasses("tiles.MixinTileEldritchAltar_SpawnMobs")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
+    CRAFTING_WARP_SUPPRESSION(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.enhancements.focusDowngradeRecipe::isEnabled)
+        .addMixinClasses(
+            "container.MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade",
+            "events.MixinEventHandlerWorld_SuppressCraftingWarp")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
+
     NAMED_STAFFTERS(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)
         .setApplyIf(ConfigModuleRoot.enhancements.staffterNameTooltip::isEnabled)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
@@ -11,8 +11,7 @@ public enum TargetedMod {
     VANILLA("Minecraft", null),
     THAUMCRAFT("Thaumcraft", null, "Thaumcraft"), // "thaumcraft.codechicken.core.launch.DepLoader"
     HODGEPODGE("Hodgepodge", null, "hodgepodge"),
-
-    ;
+    THAUMCRAFTNEIPLUGIN("Thaumcraft NEI Plugin", null, "thaumcraftneiplugin"),;
 
     /** The "name" in the {@link Mod @Mod} annotation */
     public final String modName;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinArcaneShapedRecipeHandler_FakeRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinArcaneShapedRecipeHandler_FakeRecipes.java
@@ -1,0 +1,32 @@
+package dev.rndmorris.salisarcana.mixins.late.addons.thaumcraftneiplugin;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.ArcaneShapedRecipeHandler;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.common.recipes.NeiOnlyRecipeRegistry;
+
+@Mixin(value = ArcaneShapedRecipeHandler.class, remap = false)
+public abstract class MixinArcaneShapedRecipeHandler_FakeRecipes {
+
+    @WrapOperation(
+        method = { "loadCraftingRecipes(Ljava/lang/String;[Ljava/lang/Object;)V",
+            "loadCraftingRecipes(Lnet/minecraft/item/ItemStack;)V",
+            "loadUsageRecipes(Lnet/minecraft/item/ItemStack;)V" },
+        at = @At(value = "INVOKE", target = "Lthaumcraft/api/ThaumcraftApi;getCraftingRecipes()Ljava/util/List;"))
+    private List<Object> wrapLoadCraftingRecipes(Operation<List<Object>> original) {
+        return Stream.concat(
+            original.call()
+                .stream(),
+            NeiOnlyRecipeRegistry.getInstance().shapedRecipes.stream())
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinArcaneShapelessRecipeHandler_FakeRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinArcaneShapelessRecipeHandler_FakeRecipes.java
@@ -1,0 +1,32 @@
+package dev.rndmorris.salisarcana.mixins.late.addons.thaumcraftneiplugin;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.ArcaneShapelessRecipeHandler;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.common.recipes.NeiOnlyRecipeRegistry;
+
+@Mixin(value = ArcaneShapelessRecipeHandler.class, remap = false)
+public abstract class MixinArcaneShapelessRecipeHandler_FakeRecipes {
+
+    @WrapOperation(
+        method = { "loadCraftingRecipes(Ljava/lang/String;[Ljava/lang/Object;)V",
+            "loadCraftingRecipes(Lnet/minecraft/item/ItemStack;)V",
+            "loadUsageRecipes(Lnet/minecraft/item/ItemStack;)V" },
+        at = @At(value = "INVOKE", target = "Lthaumcraft/api/ThaumcraftApi;getCraftingRecipes()Ljava/util/List;"))
+    private List<Object> wrapLoadCraftingRecipes(Operation<List<Object>> original) {
+        return Stream.concat(
+            original.call()
+                .stream(),
+            NeiOnlyRecipeRegistry.getInstance().shapelessArcaneRecipes.stream())
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinCrucibleRecipeHandler_FakeRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinCrucibleRecipeHandler_FakeRecipes.java
@@ -1,0 +1,32 @@
+package dev.rndmorris.salisarcana.mixins.late.addons.thaumcraftneiplugin;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.CrucibleRecipeHandler;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.common.recipes.NeiOnlyRecipeRegistry;
+
+@Mixin(value = CrucibleRecipeHandler.class, remap = false)
+public abstract class MixinCrucibleRecipeHandler_FakeRecipes {
+
+    @WrapOperation(
+        method = { "loadCraftingRecipes(Ljava/lang/String;[Ljava/lang/Object;)V",
+            "loadCraftingRecipes(Lnet/minecraft/item/ItemStack;)V",
+            "loadUsageRecipes(Lnet/minecraft/item/ItemStack;)V" },
+        at = @At(value = "INVOKE", target = "Lthaumcraft/api/ThaumcraftApi;getCraftingRecipes()Ljava/util/List;"))
+    private List<Object> wrapLoadCraftingRecipes(Operation<List<Object>> original) {
+        return Stream.concat(
+            original.call()
+                .stream(),
+            NeiOnlyRecipeRegistry.getInstance().crucibleRecipes.stream())
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinInfusionRecipeHandler_FakeRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/thaumcraftneiplugin/MixinInfusionRecipeHandler_FakeRecipes.java
@@ -1,0 +1,32 @@
+package dev.rndmorris.salisarcana.mixins.late.addons.thaumcraftneiplugin;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.djgiannuzz.thaumcraftneiplugin.nei.recipehandler.InfusionRecipeHandler;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.common.recipes.NeiOnlyRecipeRegistry;
+
+@Mixin(value = InfusionRecipeHandler.class, remap = false)
+public abstract class MixinInfusionRecipeHandler_FakeRecipes {
+
+    @WrapOperation(
+        method = { "loadCraftingRecipes(Ljava/lang/String;[Ljava/lang/Object;)V",
+            "loadCraftingRecipes(Lnet/minecraft/item/ItemStack;)V",
+            "loadUsageRecipes(Lnet/minecraft/item/ItemStack;)V" },
+        at = @At(value = "INVOKE", target = "Lthaumcraft/api/ThaumcraftApi;getCraftingRecipes()Ljava/util/List;"))
+    private List<Object> wrapLoadCraftingRecipes(Operation<List<Object>> original) {
+        return Stream.concat(
+            original.call()
+                .stream(),
+            NeiOnlyRecipeRegistry.getInstance().infusionRecipes.stream())
+            .collect(Collectors.toList());
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade.java
@@ -14,7 +14,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import dev.rndmorris.salisarcana.common.interfaces.ISuppressCraftingWarp;
-import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
+import dev.rndmorris.salisarcana.common.recipes.CleanFocusRecipe;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.crafting.IArcaneRecipe;
 import thaumcraft.common.config.Config;
@@ -50,7 +50,7 @@ public abstract class MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFo
                 break;
             }
         }
-        if (matchedRecipe == CustomRecipes.cleanFocusRecipe) {
+        if (matchedRecipe instanceof CleanFocusRecipe) {
             // this recipe shouldn't give warp
             final var extendedEventWorldHandler = ISuppressCraftingWarp.getInstance();
             if (extendedEventWorldHandler != null) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade.java
@@ -32,7 +32,8 @@ public abstract class MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFo
         method = "onPickupFromSlot",
         at = @At(
             value = "INVOKE",
-            target = "Lcpw/mods/fml/common/FMLCommonHandler;firePlayerCraftingEvent(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/item/ItemStack;Lnet/minecraft/inventory/IInventory;)V"))
+            target = "Lcpw/mods/fml/common/FMLCommonHandler;firePlayerCraftingEvent(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/item/ItemStack;Lnet/minecraft/inventory/IInventory;)V",
+            remap = false))
     private void wrapFirePlayerCraftingEvent(FMLCommonHandler instance, EntityPlayer player, ItemStack itemStack,
         IInventory inventory, Operation<Void> original, @Local(argsOnly = true) ItemStack par1ItemStack) {
         if (Config.wuss || ThaumcraftApi.getWarp(par1ItemStack) <= 0) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade.java
@@ -1,0 +1,62 @@
+package dev.rndmorris.salisarcana.mixins.late.container;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.SlotCrafting;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import dev.rndmorris.salisarcana.common.interfaces.ISuppressCraftingWarp;
+import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
+import thaumcraft.api.ThaumcraftApi;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.common.config.Config;
+import thaumcraft.common.container.SlotCraftingArcaneWorkbench;
+
+@Mixin(value = SlotCraftingArcaneWorkbench.class)
+public abstract class MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade extends SlotCrafting {
+
+    public MixinSlotCraftingArcaneWorkbench_SuppressCraftingWarpForFocusDowngrade(EntityPlayer p_i1823_1_,
+        IInventory p_i1823_2_, IInventory p_i1823_3_, int p_i1823_4_, int p_i1823_5_, int p_i1823_6_) {
+        super(p_i1823_1_, p_i1823_2_, p_i1823_3_, p_i1823_4_, p_i1823_5_, p_i1823_6_);
+    }
+
+    @WrapOperation(
+        method = "onPickupFromSlot",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcpw/mods/fml/common/FMLCommonHandler;firePlayerCraftingEvent(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/item/ItemStack;Lnet/minecraft/inventory/IInventory;)V"))
+    private void wrapFirePlayerCraftingEvent(FMLCommonHandler instance, EntityPlayer player, ItemStack itemStack,
+        IInventory inventory, Operation<Void> original, @Local(argsOnly = true) ItemStack par1ItemStack) {
+        if (Config.wuss || ThaumcraftApi.getWarp(par1ItemStack) <= 0) {
+            // this only matters if the output would give the crafting player warp
+            original.call(instance, player, itemStack, inventory);
+            return;
+        }
+
+        IArcaneRecipe matchedRecipe = null;
+        for (var recipe : ThaumcraftApi.getCraftingRecipes()) {
+            if (recipe instanceof IArcaneRecipe arcaneRecipe
+                && arcaneRecipe.matches(inventory, player.getEntityWorld(), player)) {
+                matchedRecipe = arcaneRecipe;
+                break;
+            }
+        }
+        if (matchedRecipe == CustomRecipes.cleanFocusRecipe) {
+            // this recipe shouldn't give warp
+            final var extendedEventWorldHandler = ISuppressCraftingWarp.getInstance();
+            if (extendedEventWorldHandler != null) {
+                extendedEventWorldHandler.skipNextCraftingWarp();
+            }
+        }
+        original.call(instance, player, itemStack, inventory);
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/events/MixinEventHandlerWorld_SuppressCraftingWarp.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/events/MixinEventHandlerWorld_SuppressCraftingWarp.java
@@ -1,0 +1,45 @@
+package dev.rndmorris.salisarcana.mixins.late.events;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.SalisArcana;
+import dev.rndmorris.salisarcana.common.interfaces.ISuppressCraftingWarp;
+import thaumcraft.common.lib.events.EventHandlerWorld;
+
+@Mixin(value = EventHandlerWorld.class, remap = false)
+public class MixinEventHandlerWorld_SuppressCraftingWarp implements ISuppressCraftingWarp {
+
+    @Unique
+    private int sa$skipNextCraftingWarp = 0;
+
+    @WrapOperation(
+        method = "onCrafting",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/Thaumcraft;addStickyWarpToPlayer(Lnet/minecraft/entity/player/EntityPlayer;I)V"))
+    private void wrapAddCraftingWarp(EntityPlayer player, int amount, Operation<Void> original) {
+        if (sa$skipNextCraftingWarp != 0) {
+            sa$skipNextCraftingWarp -= sa$skipNextCraftingWarp > 0 ? 1 : 0;
+            return;
+        }
+        original.call(player, amount);
+    }
+
+    @SuppressWarnings("AddedMixinMembersNamePattern")
+    @Override
+    public void skipNextCraftingWarp() {
+        if (!SalisArcana.proxy.isServerThread()) {
+            return;
+        }
+        if (sa$skipNextCraftingWarp >= 0) {
+            sa$skipNextCraftingWarp += 1;
+        }
+    }
+}

--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -143,4 +143,8 @@ tc.research_name.salisarcana:CHESTSCAN=Container Scanning
 tc.research_text.salisarcana:CHESTSCAN=Looking a little closer
 tc.research_page.salisarcana:CHESTSCAN.0=Thanks to your research about deconstructing items, you've learned to look inside other blocks with your Thaumometer by using it to "deconstruct" the block magically. You can scan any block that can hold items, such as a chest or hopper, to scan all contained items automatically.
 
+tc.research_name.salisarcana:FOCUSCLEANING=Focus Upgrade Removal
+tc.research_text.salisarcana:FOCUSCLEANING=Ctrl+A, Delete
+tc.research_page.salisarcana:FOCUSCLEANING.0=A patch of enchanted fabric, when lined with a generous helping of vis-imbued salis mundus, is capable of scrubbing upgrades from a wand focus. Upgrades are removed in last-on-first-off order, but multiple upgrades can be removed simultaneously by increasing the amount of salis mundus used.   
+
 item.Wand.staffter.obj=Staffter


### PR DESCRIPTION
To resolve #151. I'm disinclined to implement XP refunds in addition to effectively refunding the materials used in the focus.