### PR TITLE
Add checks for fake players

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -62,6 +62,16 @@ Affected items include:
 
 Add a safety check to prevent the creation of Thaumcraft shards with invalid metadata.
 
+## Fake Player Safety Checks
+
+**Config option:** `warpFakePlayerCheck`
+
+Adds a safety check to prevent warp effects from trying to send packets to fake players.
+
+**Config option:** `crimsonRitesFakePlayerCheck`
+
+Adds a safety check in case of a fake player not being castable to `EntityPlayerMP`. (For example, putting Crimson Rites into a Dynamism Tablet from Thaumic Tinkerer.)
+
 ## TC4 Ores Redstone Fix
 
 **Config option:** `renderRedstoneFix`

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
@@ -15,6 +15,8 @@ public class BugfixesModule extends BaseConfigModule {
     public final ToggleSetting integerInfusionMatrixMath;
     public final ToggleSetting itemMetadataSafetyCheck;
     public final ToggleSetting itemShardColor;
+    public final ToggleSetting warpFakePlayerCheck;
+    public final ToggleSetting crimsonRitesFakePlayerCheck;
     public final ToggleSetting renderRedstoneFix;
     public final ToggleSetting slabBurnTimeFix;
     public final ToggleSetting strictInfusionMatrixInputChecks;
@@ -51,7 +53,18 @@ public class BugfixesModule extends BaseConfigModule {
                 this,
                 "itemMetadataFix",
                 "Add a safety check to several Thaumcraft items to prevent crashes when creating those items with invalid metadata."),
-            itemShardColor = new ToggleSetting(this, "shardMetadataCrash", "Fixes a crash with invalid shard metadata"),
+            itemShardColor = new ToggleSetting(
+                this,
+                "shardMetadataCrash",
+                "Fixes a crash with invalid shard metadata"),
+            warpFakePlayerCheck = new ToggleSetting(
+                this,
+                "warpFakePlayerCheck",
+                "Adds a safety check to prevent warp effects from trying to send packets to fake players."),
+            crimsonRitesFakePlayerCheck = new ToggleSetting(
+                this,
+                "crimsonRitesFakePlayerCheck",
+                "Adds a safety check in case of a fake player not being castable to EntityPlayerMP."),
             renderRedstoneFix = new ToggleSetting(
                 this,
                 "renderRedstoneFix",

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
@@ -53,10 +53,7 @@ public class BugfixesModule extends BaseConfigModule {
                 this,
                 "itemMetadataFix",
                 "Add a safety check to several Thaumcraft items to prevent crashes when creating those items with invalid metadata."),
-            itemShardColor = new ToggleSetting(
-                this,
-                "shardMetadataCrash",
-                "Fixes a crash with invalid shard metadata"),
+            itemShardColor = new ToggleSetting(this, "shardMetadataCrash", "Fixes a crash with invalid shard metadata"),
             warpFakePlayerCheck = new ToggleSetting(
                 this,
                 "warpFakePlayerCheck",

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -35,7 +35,6 @@ import dev.rndmorris.salisarcana.config.settings.ResearchEntry;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchCategoryList;
 import thaumcraft.api.research.ResearchItem;
-import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.lib.network.PacketHandler;
 import thaumcraft.common.lib.network.playerdata.PacketPlayerCompleteToServer;
 import thaumcraft.common.lib.research.ResearchManager;
@@ -66,13 +65,11 @@ public class ResearchHelper {
                 MinecraftServer.getServer()
                     .worldServerForDimension(0),
                 new GameProfile(null, SalisArcana.MODID + ":KnowItAll"));
+
+            final String commandSenderName = knowItAll.getCommandSenderName();
             for (var category : ResearchCategories.researchCategories.values()) {
                 for (var researchItem : category.research.values()) {
-                    if (ResearchManager.isResearchComplete(knowItAll.getCommandSenderName(), researchItem.key)) {
-                        continue;
-                    }
-                    Thaumcraft.proxy.getResearchManager()
-                        .completeResearch(knowItAll, researchItem.key);
+                    ResearchManager.completeResearchUnsaved(commandSenderName, researchItem.key);
                 }
             }
         }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -201,6 +201,16 @@ public enum Mixins {
         .setApplyIf(ConfigModuleRoot.bugfixes.negativeBossSpawnCount::isEnabled)
         .addMixinClasses("tiles.MixinTileEldritchLock")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    WARP_FAKE_PLAYER(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.bugfixes.warpFakePlayerCheck::isEnabled)
+        .addMixinClasses("common.MixinThaumcraft_FakePlayerWarp")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    CRIMSON_RITES_FAKE_PLAYER(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.bugfixes.crimsonRitesFakePlayerCheck::isEnabled)
+        .addMixinClasses("items.MixinItemEldritchObject_FakePlayerFix")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Enhancements
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/common/MixinThaumcraft_FakePlayerWarp.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/common/MixinThaumcraft_FakePlayerWarp.java
@@ -1,0 +1,44 @@
+package dev.rndmorris.salisarcana.mixins.late.common;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraftforge.common.util.FakePlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import thaumcraft.common.Thaumcraft;
+
+@Mixin(Thaumcraft.class)
+public class MixinThaumcraft_FakePlayerWarp {
+
+    @Inject(method = "addWarpToPlayer", at = @At("HEAD"), remap = false, cancellable = true)
+    private static void cancelFakePlayers(EntityPlayer player, int amount, boolean temporary, CallbackInfo ci) {
+        if (!(player instanceof EntityPlayerMP) || player instanceof FakePlayer) {
+            ci.cancel();
+            final var knowledge = Thaumcraft.proxy.getPlayerKnowledge();
+            final String name = player.getCommandSenderName();
+            if (name != null && knowledge != null) {
+                if (temporary) {
+                    knowledge.addWarpTemp(name, amount);
+                } else if (amount > 0) {
+                    knowledge.addWarpPerm(name, amount);
+                }
+            }
+        }
+    }
+
+    @Inject(method = "addStickyWarpToPlayer", at = @At("HEAD"), remap = false, cancellable = true)
+    private static void cancelFakePlayersSticky(EntityPlayer player, int amount, CallbackInfo ci) {
+        if (!(player instanceof EntityPlayerMP) || player instanceof FakePlayer) {
+            ci.cancel();
+            final var knowledge = Thaumcraft.proxy.getPlayerKnowledge();
+            final String name = player.getCommandSenderName();
+            if (name != null && knowledge != null) {
+                knowledge.addWarpSticky(name, amount);
+            }
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/common/MixinThaumcraft_FakePlayerWarp.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/common/MixinThaumcraft_FakePlayerWarp.java
@@ -5,19 +5,19 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraftforge.common.util.FakePlayer;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 
 import thaumcraft.common.Thaumcraft;
 
 @Mixin(Thaumcraft.class)
 public class MixinThaumcraft_FakePlayerWarp {
 
-    @Inject(method = "addWarpToPlayer", at = @At("HEAD"), remap = false, cancellable = true)
-    private static void cancelFakePlayers(EntityPlayer player, int amount, boolean temporary, CallbackInfo ci) {
+    @WrapMethod(method = "addWarpToPlayer", remap = false)
+    private static void cancelFakePlayers(EntityPlayer player, int amount, boolean temporary,
+        Operation<Void> original) {
         if (!(player instanceof EntityPlayerMP) || player instanceof FakePlayer) {
-            ci.cancel();
             final var knowledge = Thaumcraft.proxy.getPlayerKnowledge();
             final String name = player.getCommandSenderName();
             if (name != null && knowledge != null) {
@@ -27,18 +27,21 @@ public class MixinThaumcraft_FakePlayerWarp {
                     knowledge.addWarpPerm(name, amount);
                 }
             }
+        } else {
+            original.call(player, amount, temporary);
         }
     }
 
-    @Inject(method = "addStickyWarpToPlayer", at = @At("HEAD"), remap = false, cancellable = true)
-    private static void cancelFakePlayersSticky(EntityPlayer player, int amount, CallbackInfo ci) {
+    @WrapMethod(method = "addStickyWarpToPlayer", remap = false)
+    private static void cancelFakePlayersSticky(EntityPlayer player, int amount, Operation<Void> original) {
         if (!(player instanceof EntityPlayerMP) || player instanceof FakePlayer) {
-            ci.cancel();
             final var knowledge = Thaumcraft.proxy.getPlayerKnowledge();
             final String name = player.getCommandSenderName();
             if (name != null && knowledge != null) {
                 knowledge.addWarpSticky(name, amount);
             }
+        } else {
+            original.call(player, amount);
         }
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemEldritchObject_FakePlayerFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemEldritchObject_FakePlayerFix.java
@@ -1,0 +1,35 @@
+package dev.rndmorris.salisarcana.mixins.late.items;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.FakePlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import thaumcraft.common.items.ItemEldritchObject;
+import thaumcraft.common.lib.research.ResearchManager;
+
+@Mixin(ItemEldritchObject.class)
+public class MixinItemEldritchObject_FakePlayerFix {
+
+    @WrapMethod(method = "onItemRightClick")
+    private ItemStack cancelFakePlayer(ItemStack stack, World par2World, EntityPlayer player,
+        Operation<ItemStack> original) {
+        final String name = player.getCommandSenderName();
+        if (name == null) return stack;
+
+        if (!(player instanceof EntityPlayerMP) || player instanceof FakePlayer) {
+            if (!par2World.isRemote) {
+                ResearchManager.completeResearchUnsaved(name, "CRIMSON");
+            }
+            return stack;
+        }
+
+        return original.call(stack, par2World, player);
+    }
+}


### PR DESCRIPTION
Fixes:
- Dynamism Tablet using Crimson Rites causing an error
- `/salisarcana-upgrade-focus` tab completion spamming errors
- and any future errors with warp being applied to fake players.

(note: `completeResearchUnsaved` already does the check for completion.)