### PR TITLE
Make /forget-research actually remove warp & synchonize changes in multiplayer

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/network/MessageForgetResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/network/MessageForgetResearch.java
@@ -1,0 +1,62 @@
+package dev.rndmorris.salisarcana.network;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.client.Minecraft;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import dev.rndmorris.salisarcana.SalisArcana;
+import io.netty.buffer.ByteBuf;
+import thaumcraft.common.Thaumcraft;
+
+public class MessageForgetResearch implements IMessage, IMessageHandler<MessageForgetResearch, IMessage> {
+
+    private List<String> researchKeys;
+
+    public MessageForgetResearch() {}
+
+    public MessageForgetResearch(List<String> researchKeys) {
+        this.researchKeys = researchKeys;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.researchKeys = new ArrayList<>();
+        int length;
+
+        while ((length = buf.readByte() & 0xFF) > 0) {
+            byte[] key = new byte[length];
+            buf.readBytes(key);
+            this.researchKeys.add(new String(key, StandardCharsets.UTF_8));
+        }
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        for (final String key : researchKeys) {
+            byte[] encoded = key.getBytes(StandardCharsets.UTF_8);
+            if (encoded.length == 0) continue;
+            if (encoded.length > 255) {
+                SalisArcana.LOG.error("Cannot transmit forget-research research key - key is too long.");
+                continue;
+            }
+            buf.writeByte(encoded.length);
+            buf.writeBytes(encoded);
+        }
+        buf.writeByte(0);
+    }
+
+    @Override
+    public IMessage onMessage(MessageForgetResearch message, MessageContext ctx) {
+        final var playerResearch = Thaumcraft.proxy.getPlayerKnowledge().researchCompleted
+            .get(Minecraft.getMinecraft().thePlayer.getCommandSenderName());
+
+        playerResearch.removeAll(message.researchKeys);
+
+        return null;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/network/NetworkHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/network/NetworkHandler.java
@@ -15,5 +15,6 @@ public class NetworkHandler {
         instance.registerMessage(MessageScanIInventory.class, MessageScanIInventory.class, 3, Side.SERVER);
         instance.registerMessage(MessageSendResearch.class, MessageSendResearch.class, 4, Side.CLIENT);
         instance.registerMessage(MessageInvalidateCache.class, MessageInvalidateCache.class, 5, Side.CLIENT);
+        instance.registerMessage(MessageForgetResearch.class, MessageForgetResearch.class, 6, Side.CLIENT);
     }
 }


### PR DESCRIPTION
Fixed bugs:
- `/salisarcana-forget-research` didn't remove warp when command completed.
- `/salisarcana-forget-research` wouldn't synchronize research to the client, which caused bugs like flickering and ghost items in the Arcane Workbench, or the Disenchant Focus icon being visible in #160.