### PR TITLE
Add --retain-warp flag to `/forget-research` and make its success messages much clearer

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -61,6 +61,7 @@ Remove research from a player's knowledge.
 | `--research-key <key>` | Conditionally | Specify the id of the research to remove. Required if `--all` is not provided. Can be provided multiple times to specify additional research to remove. Mutually exclusive with `--all`. |
 | `--player <username>`  |      No       | Specify the player whose completed research will be altered. If not provided, defaults to the research of the user executing this command.                                               |
 |      `--scalpel`       |      No       | If set, remove *only* the specified research. None of its siblings or descendants will be affected. This may have unexpected side effects. Mutually exclusive with `--all`.              |
+|    `--retain-warp`     |      No       | If set, any permanent and/or sticky warp associated with the removed research will be **kept**, rather than removed.                                                                     |
 
 **Default aliases:**
 * `/forget-research`

--- a/src/main/java/dev/rndmorris/salisarcana/common/commands/ForgetResearchCommand.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/commands/ForgetResearchCommand.java
@@ -143,23 +143,27 @@ public class ForgetResearchCommand extends ArcanaCommandBase<ForgetResearchComma
         }
 
         final var target = arguments.targetPlayer;
-        final var knowledge = Thaumcraft.proxy.getPlayerKnowledge();
-        if (permWarp > 0) {
-            knowledge.addWarpPerm(target.getCommandSenderName(), -permWarp);
-            PacketHandler.INSTANCE.sendTo(new PacketSyncWarp(target, (byte) 0), target);
-        }
-        if (stickyWarp > 0) {
-            knowledge.addWarpSticky(target.getCommandSenderName(), -stickyWarp);
-            PacketHandler.INSTANCE.sendTo(new PacketSyncWarp(target, (byte) 1), target);
-        }
-        if (permWarp > 0 || stickyWarp > 0) {
-            knowledge
-                .setWarpCounter(target.getCommandSenderName(), knowledge.getWarpTotal(target.getCommandSenderName()));
+        if (!arguments.retainWarp) {
+            final var knowledge = Thaumcraft.proxy.getPlayerKnowledge();
+            if (permWarp > 0) {
+                knowledge.addWarpPerm(target.getCommandSenderName(), -permWarp);
+                PacketHandler.INSTANCE.sendTo(new PacketSyncWarp(target, (byte) 0), target);
+            }
+            if (stickyWarp > 0) {
+                knowledge.addWarpSticky(target.getCommandSenderName(), -stickyWarp);
+                PacketHandler.INSTANCE.sendTo(new PacketSyncWarp(target, (byte) 1), target);
+            }
+            if (permWarp > 0 || stickyWarp > 0) {
+                knowledge.setWarpCounter(
+                    target.getCommandSenderName(),
+                    knowledge.getWarpTotal(target.getCommandSenderName()));
+            }
         }
         NetworkHandler.instance.sendTo(new MessageForgetResearch(removed), arguments.targetPlayer);
         sender.addChatMessage(
             new ChatComponentTranslation(
-                "salisarcana:command.forget-research.success",
+                arguments.retainWarp ? "salisarcana:command.forget-research.retain"
+                    : "salisarcana:command.forget-research.remove",
                 removedCount,
                 permWarp,
                 stickyWarp));
@@ -187,5 +191,8 @@ public class ForgetResearchCommand extends ArcanaCommandBase<ForgetResearchComma
 
         @FlagArg(name = "--scalpel", excludes = { "--all" }, descLangKey = "scalpel")
         public boolean scalpel;
+
+        @FlagArg(name = "--retain-warp", descLangKey = "retain-warp")
+        public boolean retainWarp;
     }
 }

--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -24,8 +24,10 @@ salisarcana:command.forget-research.args.all=§7<--all>§r Remove all research f
 salisarcana:command.forget-research.args.research=§7<--research-key>§r Specify the id of the research to remove. Can be provided multiple times. Required if §7all§r is not set. Mutually exclusive with §7all§r.
 salisarcana:command.forget-research.args.player=§7[--player <username>]§r Specify the player whose research will be altered. If not provided, defaults to the player executing this command.
 salisarcana:command.forget-research.args.scalpel=§7[--scalpel]§r If set, the specified research will be removed, but not any of its siblings or descendants. This may have unexpected side effects. Mutually exclusive with §7all§r.
+salisarcana:command.forget-research.args.retain-warp=§7[--retain-warp]§r If set, any permanent and/or sticky warp associated with the removed research will be kept.
 
-salisarcana:command.forget-research.success=§9Success:§r Removed %d research items collectively worth %d permanent warp and %d sticky warp.
+salisarcana:command.forget-research.remove=§9Success:§r Removed %d research items and any associated warp, collectively removing %d permanent warp and %d sticky warp.
+salisarcana:command.forget-research.retain=§9Success:§r Removed %d research items. (%d permanent warp and %d sticky warp was §lnot§r removed.)
 
 salisarcana:command.forget-scanned.desc=Resets the lists of things a player has scanned, allowing those things to be scanned again.
 salisarcana:command.forget-scanned.usage=§7/salisarcana-forget-scanned §7[--player §7<username>] §7[--objects] §7[--entities] §7[--nodes] §7[--all] §7[--aspects <...>]§r


### PR DESCRIPTION
@rndmorris, you said that not removing warp was an intentional feature, so this simple PR adds the feature back in using a flag.