### PR TITLE
Fix research names

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,4 +44,5 @@ dependencies {
     compileOnly("maven.modrinth:bugtorch:1.2.13")
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))
     compileOnly(rfg.deobf("curse.maven:undergroundbiomesconstructs-72744:2304497"))
+    runtimeOnlyNonPublishable(rfg.deobf("curse.maven:tc4tweaks-431297:6278191"))
 }

--- a/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
@@ -219,7 +219,7 @@ public class CustomResearch {
         if (!settings.isEnabled()) {
             return null;
         }
-        final var fullKey = settings.researchName;
+        final var fullKey = settings.getInternalName();
         final var category = settings.researchCategory;
         final var col = settings.researchCol;
         final var row = settings.researchRow;

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
@@ -49,52 +49,50 @@ public class CustomResearchSetting extends Setting {
     }
 
     public String getInternalName() {
-        return MODID + ":" + researchName;
+        return MODID + ":" + this.researchName;
     }
 
     @Override
     public void loadFromConfiguration(Configuration configuration) {
         this.enabled = configuration
             .getBoolean("_enabled" + this.configName, this.getCategory(), this.enabled, this.configComment);
-        researchName = configuration
-            .getString(configName + "Name", this.getCategory(), researchName, "The research entry ID");
 
-        researchCategory = configuration.getString(
-            configName + "Category",
+        this.researchCategory = configuration.getString(
+            this.configName + "Category",
             this.getCategory(),
-            researchCategory,
+            this.researchCategory,
             "The tab in the Thaumonomicon in which the research should appear");
 
-        researchCol = configuration.getInt(
-            configName + "Col",
+        this.researchCol = configuration.getInt(
+            this.configName + "Col",
             this.getCategory(),
-            researchCol,
+            this.researchCol,
             Integer.MIN_VALUE,
             Integer.MAX_VALUE,
             "The column in the given category at which the research should appear");
 
-        researchRow = configuration.getInt(
-            configName + "Row",
+        this.researchRow = configuration.getInt(
+            this.configName + "Row",
             this.getCategory(),
-            researchRow,
+            this.researchRow,
             Integer.MIN_VALUE,
             Integer.MAX_VALUE,
             "The row in the given category at which the research should appear");
 
-        parentResearches = configuration.getStringList(
-            configName + "Parents",
+        this.parentResearches = configuration.getStringList(
+            this.configName + "Parents",
             this.getCategory(),
-            parentResearches,
+            this.parentResearches,
             "The research entry IDs of the parent research entries");
 
-        purchasable = configuration.getBoolean(
-            configName + "Purchasable",
+        this.purchasable = configuration.getBoolean(
+            this.configName + "Purchasable",
             this.getCategory(),
-            purchasable,
+            this.purchasable,
             "Whether the research should be purchasable with aspects instead of the normal minigame");
 
         this.aspectStrings = configuration.getStringList(
-            configName + "Aspects",
+            this.configName + "Aspects",
             this.getCategory(),
             this.aspectStrings,
             "The aspects required for the research entry");
@@ -103,7 +101,7 @@ public class CustomResearchSetting extends Setting {
 
     public AspectList getAspects() {
         AspectList researchAspects = new AspectList();
-        for (String aspect : aspectStrings) {
+        for (String aspect : this.aspectStrings) {
             String[] aspectParts = aspect.split(":");
             if (aspectParts.length == 2) {
                 if (Aspect.aspects.get(aspectParts[0]) == null) {
@@ -186,39 +184,39 @@ public class CustomResearchSetting extends Setting {
         }
 
         public String getResearchName() {
-            return researchName;
+            return this.researchName;
         }
 
         public String getResearchCategory() {
-            return researchCategory;
+            return this.researchCategory;
         }
 
         public int getResearchCol() {
-            return researchCol;
+            return this.researchCol;
         }
 
         public int getResearchRow() {
-            return researchRow;
+            return this.researchRow;
         }
 
         public String[] getParents() {
-            return researchParents;
+            return this.researchParents;
         }
 
         public boolean isPurchasable() {
-            return purchasable;
+            return this.purchasable;
         }
 
         public String[] getResearchAspects() {
-            return researchAspects;
+            return this.researchAspects;
         }
 
         public int getDifficulty() {
-            return difficulty;
+            return this.difficulty;
         }
 
         public boolean getAutoUnlock() {
-            return autoUnlock;
+            return this.autoUnlock;
         }
 
     }

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
@@ -48,6 +48,10 @@ public class CustomResearchSetting extends Setting {
 
     }
 
+    public String getInternalName() {
+        return MODID + ":" + researchName;
+    }
+
     @Override
     public void loadFromConfiguration(Configuration configuration) {
         this.enabled = configuration
@@ -130,14 +134,14 @@ public class CustomResearchSetting extends Setting {
         private boolean autoUnlock = false;
 
         public ResearchInfo(String researchName, String researchCategory, int researchCol, int researchRow) {
-            this.researchName = MODID + ":" + researchName;
+            this.researchName = researchName;
             this.researchCategory = researchCategory;
             this.researchCol = researchCol;
             this.researchRow = researchRow;
         }
 
         public ResearchInfo setResearchName(String researchName) {
-            this.researchName = MODID + ":" + researchName;
+            this.researchName = researchName;
             return this;
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This ensures config entries aren't created with the salisarcana: prefix to completely avoid any possibilities of double research names

**What is the current behavior?** (You can also link to an open issue here)
config entries are created with the salisarcana: prefix which is incorrect

**What is the new behavior (if this is a feature change)?**
It fixes that issue by changing the default config behavior

**Does this PR introduce a breaking change?**
the current default config is broken and would need changed, though I can add a check to strip the prefix if you'd like

**Other information**:
