### PR TITLE
Add IResearchItemExtended to Salis Arcana's API

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -44,4 +44,8 @@ dependencies {
     compileOnly("maven.modrinth:bugtorch:1.2.13")
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))
     compileOnly(rfg.deobf("curse.maven:undergroundbiomesconstructs-72744:2304497"))
+
+    /* Patched TC4 addons */
+    compileOnly("com.github.GTNewHorizons:ThaumicTinkerer:2.6.2:dev")
+    compileOnly(rfg.deobf("curse.maven:automagy-222153:2285272"))
 }

--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -73,6 +73,14 @@ Config Option: `primalCrusherMinesOredictionaryStone`
 
 Allows the primal crusher to 3x3 mine blocks registered as stone, cobblestone, or stoneBricks in the ore dictionary.
 
+## Research Item Extensions
+
+Config Option: `researchItemExtensions`
+
+Adds additional functionality to internal research data. Used for compatibility with other mods (e.g. Automagy, Thaumic Tinkerer).
+
+Mod authors: this controls whether Thaumcraft's `ResearchItem` class implements `IResearchItemExtended` from Salis Arcana's API package.
+
 ## Enhancements - Creative Mode
 
 **Config option:** `suppressWarpEventsInCreative`
@@ -278,3 +286,4 @@ Requires `enableReplaceWandCapsRecipe=true` or `enableReplaceWandCoreRecipe=true
 Requires `arcaneWorkbenchGhostItemFix=true` in the bugfixes module.
 
 If enabled, allows swapping a wand's components using vis from the wand being modified.
+

--- a/src/main/java/dev/rndmorris/salisarcana/api/IResearchItemExtended.java
+++ b/src/main/java/dev/rndmorris/salisarcana/api/IResearchItemExtended.java
@@ -1,0 +1,19 @@
+package dev.rndmorris.salisarcana.api;
+
+/**
+ * Implement this on your {@link thaumcraft.api.research.ResearchItem} derivative to enable compatibility with Salis
+ * Arcana.
+ */
+public interface IResearchItemExtended {
+
+    /**
+     * The translation key at which this research's human-readable name can be found.
+     */
+    String getNameTranslationKey();
+
+    /**
+     * The translation key at which this research's human-readable subtitle/lore text can be found.
+     */
+    String getTextTranslationKey();
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -66,6 +66,7 @@ public class EnhancementsModule extends BaseConfigModule {
     public final ToggleSetting primalCrusherOredict;
 
     public final IntSetting thaumometerDuration;
+    public final ToggleSetting researchItemExtensions;
 
     public EnhancementsModule() {
         // spotless:off
@@ -223,7 +224,11 @@ public class EnhancementsModule extends BaseConfigModule {
                 this,
                 "thaumometerDuration",
                 "The duration in ticks that the thaumometer takes to scan an object.",
-                20).setMinValue(1)
+                20).setMinValue(1),
+            researchItemExtensions = new ToggleSetting(
+                this,
+                "researchItemExtensions",
+                "Adds additional functionality to internal research data. Used for compatibility with other mods (e.g. Automagy, Thaumic Tinkerer).")
         );
 
         // spotless:on

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -20,6 +20,7 @@ import net.minecraftforge.common.util.FakePlayer;
 import com.mojang.authlib.GameProfile;
 
 import dev.rndmorris.salisarcana.SalisArcana;
+import dev.rndmorris.salisarcana.api.IResearchItemExtended;
 import dev.rndmorris.salisarcana.common.commands.PrerequisitesCommand;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchItem;
@@ -124,10 +125,14 @@ public class ResearchHelper {
     }
 
     public static IChatComponent formatResearch(ResearchItem research, EnumChatFormatting formatting) {
+        final var researchKeyName = research instanceof IResearchItemExtended extended
+            ? extended.getNameTranslationKey()
+            : String.format("tc.research_name.%s", research.key);
+
         final var style = new ChatStyle().setColor(formatting)
             .setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ChatComponentText(research.key)));
         return new ChatComponentText("[").setChatStyle(style)
-            .appendSibling(new ChatComponentTranslation(String.format("tc.research_name.%s", research.key)))
+            .appendSibling(new ChatComponentTranslation(researchKeyName))
             .appendText("]");
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -372,6 +372,22 @@ public enum Mixins {
         .setSide(Side.BOTH)
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
+    RESEARCH_ITEM_EXTENDED(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.enhancements.researchItemExtensions::isEnabled)
+        .addMixinClasses("api.ResearchItem_Extended")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    RESEARCH_ITEM_EXTENDED_THAUMIC_TINKERER(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.enhancements.researchItemExtensions::isEnabled)
+        .addMixinClasses("addons.ThaumicTinkerer.TTResearchItem_Extended")
+        .addTargetedMod(TargetedMod.THAUMIC_TINKERER)),
+    RESEARCH_ITEM_EXTENDED_AUTOMAGY(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.enhancements.researchItemExtensions::isEnabled)
+        .addMixinClasses("addons.Automagy.ModResearchItem_Extended")
+        .addTargetedMod(TargetedMod.AUTOMAGY)),
+
     ;
     // spotless:on
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
@@ -12,7 +12,8 @@ public enum TargetedMod {
     THAUMCRAFT("Thaumcraft", null, "Thaumcraft"), // "thaumcraft.codechicken.core.launch.DepLoader"
     HODGEPODGE("Hodgepodge", null, "hodgepodge"),
 
-    ;
+    THAUMIC_TINKERER("Thaumic Tinkerer", null, "ThaumicTinkerer"),
+    AUTOMAGY("Automagy", null, "Automagy"),;
 
     /** The "name" in the {@link Mod @Mod} annotation */
     public final String modName;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/Automagy/ModResearchItem_Extended.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/Automagy/ModResearchItem_Extended.java
@@ -1,0 +1,27 @@
+
+package dev.rndmorris.salisarcana.mixins.late.addons.Automagy;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import dev.rndmorris.salisarcana.api.IResearchItemExtended;
+import thaumcraft.api.research.ResearchItem;
+import tuhljin.automagy.config.ModResearchItem;
+
+@SuppressWarnings("AddedMixinMembersNamePattern")
+@Mixin(value = ModResearchItem.class, remap = false)
+public abstract class ModResearchItem_Extended extends ResearchItem implements IResearchItemExtended {
+
+    public ModResearchItem_Extended(String key, String category) {
+        super(key, category);
+    }
+
+    @Override
+    public String getNameTranslationKey() {
+        return String.format("Automagy.research_name.%s", this.key);
+    }
+
+    @Override
+    public String getTextTranslationKey() {
+        return String.format("Automagy.research_text.%s", this.key);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/ThaumicTinkerer/TTResearchItem_Extended.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/ThaumicTinkerer/TTResearchItem_Extended.java
@@ -1,0 +1,26 @@
+package dev.rndmorris.salisarcana.mixins.late.addons.ThaumicTinkerer;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import dev.rndmorris.salisarcana.api.IResearchItemExtended;
+import thaumcraft.api.research.ResearchItem;
+import thaumic.tinkerer.common.research.TTResearchItem;
+
+@SuppressWarnings("AddedMixinMembersNamePattern")
+@Mixin(value = TTResearchItem.class, remap = false)
+public abstract class TTResearchItem_Extended extends ResearchItem implements IResearchItemExtended {
+
+    public TTResearchItem_Extended(String key, String category) {
+        super(key, category);
+    }
+
+    @Override
+    public String getNameTranslationKey() {
+        return String.format("ttresearch.name.%s", this.key);
+    }
+
+    @Override
+    public String getTextTranslationKey() {
+        return String.format("ttresearch.lore.%s", this.key);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/api/ResearchItem_Extended.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/api/ResearchItem_Extended.java
@@ -1,0 +1,27 @@
+package dev.rndmorris.salisarcana.mixins.late.api;
+
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import dev.rndmorris.salisarcana.api.IResearchItemExtended;
+import thaumcraft.api.research.ResearchItem;
+
+@SuppressWarnings("AddedMixinMembersNamePattern")
+@Mixin(value = ResearchItem.class, remap = false)
+public abstract class ResearchItem_Extended implements IResearchItemExtended {
+
+    @Shadow
+    @Final
+    public String key;
+
+    @Override
+    public String getNameTranslationKey() {
+        return String.format("tc.research_name.%s", this.key);
+    }
+
+    @Override
+    public String getTextTranslationKey() {
+        return String.format("tc.research_text.%s", this.key);
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature + big fix

**What is the current behavior?** (You can also link to an open issue here)

There is currently no clean way to retrieve a research item's langkeys. This is partly the cause of #30.

**What is the new behavior (if this is a feature change)?**

If enabled, `ResearchItem` will implement `IResearchItemExtended`, which adds methods to retrieve the research's name and text langkeys.

Thaumic Tinkerer and Automagy, if present, are mixed into to account for their nonstandard langkey formats.

**Does this PR introduce a breaking change?**
No.

**Other information**:

Originally merged into `dev`.