### PR TITLE
R::set now works with final parent fields, don't lookup toSet twice

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/lib/R.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/R.java
@@ -95,9 +95,9 @@ public class R {
     public R set(String name, Object value) {
         try {
             Field toSet = findField(name, clazz);
-            Field modifiersField = findField("modifiers", Field.class);
+            Field modifiersField = findField("modifiers", toSet.getClass());
             modifiersField.setInt(toSet, toSet.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
-            findField(name, clazz).set(instance, value);
+            toSet.set(instance, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
R::set now works with parent fields, don't lookup toSet twice

**What is the current behavior?** (You can also link to an open issue here)
r doesn't set final modifier on parent fields, and looks up toSet twice which is unnecessary

**What is the new behavior (if this is a feature change)?**
R::set now works with final parent fields, and doesn't lookup toSet twice

**Does this PR introduce a breaking change?**
no

**Other information**:
