### PR TITLE
fix R::set with newer java versions that don't have a modifiers field

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/lib/R.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/R.java
@@ -12,6 +12,14 @@ import java.util.Objects;
 
 public class R {
 
+    private static boolean oldJavaCompat = false;
+    static {
+        try {
+            Field.class.getDeclaredField("modifiers");
+            oldJavaCompat = true;
+        } catch (NoSuchFieldException ignore) {}
+    }
+
     private final Object instance;
     private final Class<?> clazz;
 
@@ -95,8 +103,10 @@ public class R {
     public R set(String name, Object value) {
         try {
             Field toSet = findField(name, clazz);
-            Field modifiersField = findField("modifiers", toSet.getClass());
-            modifiersField.setInt(toSet, toSet.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+            if (oldJavaCompat) {
+                Field modifiersField = findField("modifiers", toSet.getClass());
+                modifiersField.setInt(toSet, toSet.getModifiers() & ~java.lang.reflect.Modifier.FINAL);
+            }
             toSet.set(instance, value);
         } catch (NoSuchFieldException | IllegalAccessException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes R::set with new java versions

**What is the current behavior?** (You can also link to an open issue here)
If you try to R.set a field in new javas (at least 21, probably earlier) it will crash with a FieldNotFoundException

**What is the new behavior (if this is a feature change)?**
it doesn't crash

**Does this PR introduce a breaking change?**
No

**Other information**:
Apparently it just worked originally for those new versions, and the need for modifying the `modifiers` field is only in older versions before that field was removed.