### PR TITLE
Workbench Multiplayer Container Fix

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -104,7 +104,13 @@ Fixes ghost items being crafted in the arcane workbench after the wand runs out 
 
 Allows players to craft after the wand in the GUI runs out of vis and is recharged by a Vis Charge Relay.
 
-### Use Forge fishing lists for fishing golem loot
+### Multiplayer Duplication Bugfix & Per-Player Output Slots
+
+**Config option:** `arcaneWorkbenchMultiContainer`
+
+Prevents bugs related to multiple players opening an Arcane Workbench's GUI at the same time, including a duplication bug, research verification bug, and some others.
+
+## Use Forge fishing lists for fishing golem loot
 
 **Config option:** `useForgeFishingLists`
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
@@ -24,6 +24,7 @@ public class BugfixesModule extends BaseConfigModule {
     public final ToggleSetting staffFocusEffectFix;
     public final ToggleSetting arcaneWorkbenchGhostItemFix;
     public final ToggleSetting arcaneWorkbenchAllowRechargeCrafting;
+    public final ToggleSetting arcaneWorkbenchMultiContainer;
     public final ToggleSetting negativeBossSpawnCount;
     public final ToggleSetting useForgeFishingLists;
 
@@ -91,6 +92,10 @@ public class BugfixesModule extends BaseConfigModule {
                 this,
                 "arcaneWorkbenchAllowRechargeCrafting",
                 "Allows players to craft after the wand in the GUI runs out of vis and is recharged by a Vis Charge Relay."),
+            arcaneWorkbenchMultiContainer = new ToggleSetting(
+                this,
+                "arcaneWorkbenchMultiContainer",
+                "Prevents bugs related to multiple players opening an Arcane Workbench's GUI at the same time."),
             negativeBossSpawnCount = new ToggleSetting(
                 this,
                 "negativeBossSpawnCount",

--- a/src/main/java/dev/rndmorris/salisarcana/lib/MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/MultiContainer.java
@@ -1,0 +1,50 @@
+package dev.rndmorris.salisarcana.lib;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+
+import java.util.ArrayList;
+
+public class MultiContainer extends Container {
+    private final ArrayList<Container> multiContainer = new ArrayList<>(4);
+
+    private MultiContainer(Container a, Container b) {
+        multiContainer.add(a);
+        multiContainer.add(b);
+    }
+
+    public static Container mergeContainers(final Container initial, final Container addition) {
+        if(initial == null) {
+            return addition;
+        } else if (initial instanceof MultiContainer multi) {
+            multi.multiContainer.add(addition);
+            return multi;
+        } else {
+            return new MultiContainer(initial, addition);
+        }
+    }
+
+    public static Container removeContainer(final Container initial, final Container removal) {
+        if(initial == removal) {
+            return null;
+        } else if (initial instanceof MultiContainer multi) {
+            multi.multiContainer.remove(removal);
+            return multi.multiContainer.size() == 1 ? multi.multiContainer.get(0) : multi;
+        } else {
+            return initial;
+        }
+    }
+
+    @Override
+    public boolean canInteractWith(EntityPlayer player) {
+        return false;
+    }
+
+    @Override
+    public void onCraftMatrixChanged(IInventory inventory) {
+        for (final Container container : multiContainer) {
+            container.onCraftMatrixChanged(inventory);
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/MultiContainer.java
@@ -1,12 +1,13 @@
 package dev.rndmorris.salisarcana.lib;
 
+import java.util.ArrayList;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 
-import java.util.ArrayList;
-
 public class MultiContainer extends Container {
+
     private final ArrayList<Container> multiContainer = new ArrayList<>(4);
 
     private MultiContainer(Container a, Container b) {
@@ -15,7 +16,7 @@ public class MultiContainer extends Container {
     }
 
     public static Container mergeContainers(final Container initial, final Container addition) {
-        if(initial == null) {
+        if (initial == null) {
             return addition;
         } else if (initial instanceof MultiContainer multi) {
             multi.multiContainer.add(addition);
@@ -26,7 +27,7 @@ public class MultiContainer extends Container {
     }
 
     public static Container removeContainer(final Container initial, final Container removal) {
-        if(initial == removal) {
+        if (initial == removal) {
             return null;
         } else if (initial instanceof MultiContainer multi) {
             multi.multiContainer.remove(removal);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -196,6 +196,11 @@ public enum Mixins {
         .setApplyIf(ConfigModuleRoot.bugfixes.arcaneWorkbenchAllowRechargeCrafting::isEnabled)
         .addMixinClasses("tiles.MixinTileMagicWorkbenchCharger")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    ARCANE_WORKBENCH_MULTI_CONTAINER(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.bugfixes.arcaneWorkbenchMultiContainer::isEnabled)
+        .addMixinClasses("container.MixinContainerArcaneWorkbench_MultiContainer")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
     NEGATIVE_BOSS_SPAWN_COUNT(new Builder().setPhase(Phase.LATE)
         .setSide(Side.BOTH)
         .setApplyIf(ConfigModuleRoot.bugfixes.negativeBossSpawnCount::isEnabled)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
@@ -1,15 +1,18 @@
 package dev.rndmorris.salisarcana.mixins.late.container;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import dev.rndmorris.salisarcana.lib.MultiContainer;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.IInventory;
 import net.minecraft.item.ItemStack;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.lib.MultiContainer;
 import thaumcraft.common.container.ContainerArcaneWorkbench;
 import thaumcraft.common.container.InventoryFake;
 import thaumcraft.common.container.SlotCraftingArcaneWorkbench;
@@ -17,30 +20,54 @@ import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(ContainerArcaneWorkbench.class)
 public abstract class MixinContainerArcaneWorkbench_MultiContainer extends Container {
+
     @Unique
     private final InventoryFake salisArcana$outputSlot = new InventoryFake(new ItemStack[1]);
 
-    @WrapOperation(method = "<init>", at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"), remap = false)
+    @WrapOperation(
+        method = "<init>",
+        at = @At(
+            value = "FIELD",
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"),
+        remap = false)
     public void setEventHandler(TileArcaneWorkbench instance, Container value, Operation<Void> original) {
         original.call(instance, MultiContainer.mergeContainers(instance.eventHandler, value));
     }
 
-    @WrapOperation(method = "onContainerClosed", at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"))
+    @WrapOperation(
+        method = "onContainerClosed",
+        at = @At(
+            value = "FIELD",
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"))
     public void removeEventHandler(TileArcaneWorkbench instance, Container value, Operation<Void> original) {
         original.call(instance, MultiContainer.removeContainer(instance.eventHandler, this));
     }
 
-    @WrapOperation(method = "<init>", at = @At(value = "NEW", target = "thaumcraft/common/container/SlotCraftingArcaneWorkbench", remap = false), remap = false)
-    public SlotCraftingArcaneWorkbench useFakeOutputSlot(EntityPlayer player, IInventory matrix, IInventory output, int slotNum, int xPos, int yPos, Operation<SlotCraftingArcaneWorkbench> original) {
+    @WrapOperation(
+        method = "<init>",
+        at = @At(value = "NEW", target = "thaumcraft/common/container/SlotCraftingArcaneWorkbench", remap = false),
+        remap = false)
+    public SlotCraftingArcaneWorkbench useFakeOutputSlot(EntityPlayer player, IInventory matrix, IInventory output,
+        int slotNum, int xPos, int yPos, Operation<SlotCraftingArcaneWorkbench> original) {
         return original.call(player, matrix, salisArcana$outputSlot, 0, xPos, yPos);
     }
 
-    @WrapOperation(method = "onCraftMatrixChanged", at = @At(value = "INVOKE", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;setInventorySlotContentsSoftly(ILnet/minecraft/item/ItemStack;)V", remap = false))
+    @WrapOperation(
+        method = "onCraftMatrixChanged",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;setInventorySlotContentsSoftly(ILnet/minecraft/item/ItemStack;)V",
+            remap = false))
     public void setOutputSlot(TileArcaneWorkbench instance, int i, ItemStack itemStack, Operation<Void> original) {
         salisArcana$outputSlot.setInventorySlotContents(0, itemStack);
     }
 
-    @WrapOperation(method = "onCraftMatrixChanged", at = @At(value = "INVOKE", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;getStackInSlot(I)Lnet/minecraft/item/ItemStack;", ordinal = 1))
+    @WrapOperation(
+        method = "onCraftMatrixChanged",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;getStackInSlot(I)Lnet/minecraft/item/ItemStack;",
+            ordinal = 1))
     public ItemStack getOutputSlot(TileArcaneWorkbench instance, int i, Operation<ItemStack> original) {
         return salisArcana$outputSlot.getStackInSlot(0);
     }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
@@ -28,7 +28,8 @@ public abstract class MixinContainerArcaneWorkbench_MultiContainer extends Conta
         method = "<init>",
         at = @At(
             value = "FIELD",
-            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"),
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;",
+            remap = false),
         remap = false)
     public void setEventHandler(TileArcaneWorkbench instance, Container value, Operation<Void> original) {
         original.call(instance, MultiContainer.mergeContainers(instance.eventHandler, value));
@@ -38,7 +39,8 @@ public abstract class MixinContainerArcaneWorkbench_MultiContainer extends Conta
         method = "onContainerClosed",
         at = @At(
             value = "FIELD",
-            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"))
+            target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;",
+            remap = false))
     public void removeEventHandler(TileArcaneWorkbench instance, Container value, Operation<Void> original) {
         original.call(instance, MultiContainer.removeContainer(instance.eventHandler, this));
     }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
@@ -1,0 +1,47 @@
+package dev.rndmorris.salisarcana.mixins.late.container;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import dev.rndmorris.salisarcana.lib.MultiContainer;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import thaumcraft.common.container.ContainerArcaneWorkbench;
+import thaumcraft.common.container.InventoryFake;
+import thaumcraft.common.container.SlotCraftingArcaneWorkbench;
+import thaumcraft.common.tiles.TileArcaneWorkbench;
+
+@Mixin(ContainerArcaneWorkbench.class)
+public abstract class MixinContainerArcaneWorkbench_MultiContainer extends Container {
+    @Unique
+    private final InventoryFake salisArcana$outputSlot = new InventoryFake(new ItemStack[1]);
+
+    @WrapOperation(method = "<init>", at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"), remap = false)
+    public void setEventHandler(TileArcaneWorkbench instance, Container value, Operation<Void> original) {
+        original.call(instance, MultiContainer.mergeContainers(instance.eventHandler, value));
+    }
+
+    @WrapOperation(method = "onContainerClosed", at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;eventHandler:Lnet/minecraft/inventory/Container;"))
+    public void removeEventHandler(TileArcaneWorkbench instance, Container value, Operation<Void> original) {
+        original.call(instance, MultiContainer.removeContainer(instance.eventHandler, this));
+    }
+
+    @WrapOperation(method = "<init>", at = @At(value = "NEW", target = "thaumcraft/common/container/SlotCraftingArcaneWorkbench", remap = false), remap = false)
+    public SlotCraftingArcaneWorkbench useFakeOutputSlot(EntityPlayer player, IInventory matrix, IInventory output, int slotNum, int xPos, int yPos, Operation<SlotCraftingArcaneWorkbench> original) {
+        return original.call(player, matrix, salisArcana$outputSlot, 0, xPos, yPos);
+    }
+
+    @WrapOperation(method = "onCraftMatrixChanged", at = @At(value = "INVOKE", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;setInventorySlotContentsSoftly(ILnet/minecraft/item/ItemStack;)V", remap = false))
+    public void setOutputSlot(TileArcaneWorkbench instance, int i, ItemStack itemStack, Operation<Void> original) {
+        salisArcana$outputSlot.setInventorySlotContents(0, itemStack);
+    }
+
+    @WrapOperation(method = "onCraftMatrixChanged", at = @At(value = "INVOKE", target = "Lthaumcraft/common/tiles/TileArcaneWorkbench;getStackInSlot(I)Lnet/minecraft/item/ItemStack;", ordinal = 1))
+    public ItemStack getOutputSlot(TileArcaneWorkbench instance, int i, Operation<ItemStack> original) {
+        return salisArcana$outputSlot.getStackInSlot(0);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -37,7 +37,6 @@ public abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extend
             remap = false))
     public void useGridWandForReplacement(CallbackInfo ci) {
         // Exclusive with the normal arcane recipe check, since this requires no wand present
-        // TODO Double-check modification to code.
         if (this.getSlot(0)
             .getStack() == null && this.tileEntity.getStackInSlot(10) == null) {
             // If a replacement recipe matches

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -1,6 +1,7 @@
 package dev.rndmorris.salisarcana.mixins.late.container;
 
 import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.inventory.Container;
 import net.minecraft.item.ItemStack;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -18,7 +19,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(ContainerArcaneWorkbench.class)
-public class MixinContainerArcaneWorkbench_SingleWandReplacement {
+public abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extends Container {
 
     @Shadow(remap = false)
     private TileArcaneWorkbench tileEntity;
@@ -36,7 +37,8 @@ public class MixinContainerArcaneWorkbench_SingleWandReplacement {
             remap = false))
     public void useGridWandForReplacement(CallbackInfo ci) {
         // Exclusive with the normal arcane recipe check, since this requires no wand present
-        if (this.tileEntity.getStackInSlot(9) == null && this.tileEntity.getStackInSlot(10) == null) {
+        // TODO Double-check modification to code.
+        if (this.getSlot(0).getStack() == null && this.tileEntity.getStackInSlot(10) == null) {
             // If a replacement recipe matches
             ItemStack outputWand;
             AspectList visPrice;
@@ -79,7 +81,12 @@ public class MixinContainerArcaneWorkbench_SingleWandReplacement {
                 } else {
                     itemWand.storeAllVis(outputWand, AspectHelper.primalList(0));
                 }
-                this.tileEntity.setInventorySlotContentsSoftly(9, outputWand);
+
+                if(ConfigModuleRoot.bugfixes.arcaneWorkbenchMultiContainer.isEnabled()) {
+                    this.getSlot(0).putStack(outputWand);
+                } else {
+                    this.tileEntity.setInventorySlotContentsSoftly(9, outputWand);
+                }
             }
         }
     }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -38,7 +38,8 @@ public abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extend
     public void useGridWandForReplacement(CallbackInfo ci) {
         // Exclusive with the normal arcane recipe check, since this requires no wand present
         // TODO Double-check modification to code.
-        if (this.getSlot(0).getStack() == null && this.tileEntity.getStackInSlot(10) == null) {
+        if (this.getSlot(0)
+            .getStack() == null && this.tileEntity.getStackInSlot(10) == null) {
             // If a replacement recipe matches
             ItemStack outputWand;
             AspectList visPrice;
@@ -82,8 +83,9 @@ public abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extend
                     itemWand.storeAllVis(outputWand, AspectHelper.primalList(0));
                 }
 
-                if(ConfigModuleRoot.bugfixes.arcaneWorkbenchMultiContainer.isEnabled()) {
-                    this.getSlot(0).putStack(outputWand);
+                if (ConfigModuleRoot.bugfixes.arcaneWorkbenchMultiContainer.isEnabled()) {
+                    this.getSlot(0)
+                        .putStack(outputWand);
                 } else {
                     this.tileEntity.setInventorySlotContentsSoftly(9, outputWand);
                 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbenchCharger.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbenchCharger.java
@@ -31,7 +31,7 @@ public class MixinTileMagicWorkbenchCharger {
     public void updateGUI(CallbackInfo ci, @Share("workbench") LocalRef<TileMagicWorkbench> workbenchRef) {
         TileMagicWorkbench workbench = workbenchRef.get();
 
-        if (workbench != null && workbench.eventHandler != null && workbench.getStackInSlot(9) == null) {
+        if (workbench != null && workbench.eventHandler != null) {
             workbench.eventHandler.onCraftMatrixChanged(workbench);
         }
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Gives each players a personal output slot in the Arcane Workbench and updates all the players upon the inventory getting changed.

**What is the current behavior?** (You can also link to an open issue here)
#168 

**What is the new behavior (if this is a feature change)?**
Two players can use the workbench without causing duplication bugs or interfering with each other.

**Does this PR introduce a breaking change?**
No

**Other information**:
This PR makes slot 9 of all Arcane Workbenches to be null when two or more players are using them. For this reason, some of our mixins had to be modified so they would function correctly.