### PR TITLE
Create Ore Dictionary name for heating crucibles and thaumatoriums

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -45,6 +45,13 @@ Config Option: `taintedItemDecayChance`
 
 The probability each tick that tainted goo and taint tendrils will decay. Lower numbers are more probable, higher numbers are less probable. Set to -1 to disable decay entirely.
 
+## Crucible+Thaumatorium Heat Source Ore Dict
+Config Option: `heatSourceOreDict`
+
+If enabled, blocks with the ore dictionary tag `salisarcana:heatSource` will be treated as crucible heat sources.
+
+Mod devs: for added convenience, this string constant is available through Salis Arcan's API.
+
 ## Container Scanning
 
 Config Option: `thaumometerScanContainers`

--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -63,8 +63,9 @@ public class CommonProxy {
             fixGolemFishingLists();
         }
 
-        // todo: wrap in config check?
-        CrucibleHeatLogic.registerOreDictName();
+        if (ConfigModuleRoot.enhancements.heatSourceOreDict.isEnabled()) {
+            CrucibleHeatLogic.registerOreDictName();
+        }
 
         FMLCommonHandler.instance()
             .bus()

--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -40,12 +40,6 @@ import thaumcraft.common.entities.ai.interact.AIFish;
 
 public class CommonProxy {
 
-    private int _crucibleHeatSourceId = -1;
-
-    public int crucibleHeatSourceId() {
-        return _crucibleHeatSourceId;
-    }
-
     public CommonProxy() {
         FMLCommonHandler.instance()
             .bus()

--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -30,6 +30,7 @@ import dev.rndmorris.salisarcana.common.item.PlaceholderItem;
 import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
 import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
 import dev.rndmorris.salisarcana.config.settings.CommandSettings;
+import dev.rndmorris.salisarcana.lib.CrucibleHeatLogic;
 import dev.rndmorris.salisarcana.lib.R;
 import dev.rndmorris.salisarcana.lib.ResearchHelper;
 import dev.rndmorris.salisarcana.network.NetworkHandler;
@@ -38,6 +39,12 @@ import dev.rndmorris.salisarcana.notifications.Updater;
 import thaumcraft.common.entities.ai.interact.AIFish;
 
 public class CommonProxy {
+
+    private int _crucibleHeatSourceId = -1;
+
+    public int crucibleHeatSourceId() {
+        return _crucibleHeatSourceId;
+    }
 
     public CommonProxy() {
         FMLCommonHandler.instance()
@@ -55,6 +62,9 @@ public class CommonProxy {
         if (ConfigModuleRoot.bugfixes.useForgeFishingLists.isEnabled()) {
             fixGolemFishingLists();
         }
+
+        // todo: wrap in config check?
+        CrucibleHeatLogic.registerOreDictName();
 
         FMLCommonHandler.instance()
             .bus()

--- a/src/main/java/dev/rndmorris/salisarcana/api/OreDict.java
+++ b/src/main/java/dev/rndmorris/salisarcana/api/OreDict.java
@@ -1,0 +1,14 @@
+package dev.rndmorris.salisarcana.api;
+
+/**
+ * Ore dictionary names used by Salis Arcana.
+ */
+public class OreDict {
+
+    /**
+     * Blocks that will be used as heat sources for the crucible and thaumatorium.
+     */
+    public static final String HEAT_SOURCE = "salisarcana:heatSource";
+    public static final String GREATWOOD_PLANKS = "plankGreatwood";
+    public static final String SILVERWOOD_PLANKS = "plankSilverwood";
+}

--- a/src/main/java/dev/rndmorris/salisarcana/common/blocks/CustomBlocks.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/blocks/CustomBlocks.java
@@ -5,6 +5,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import cpw.mods.fml.common.registry.GameRegistry;
+import dev.rndmorris.salisarcana.api.OreDict;
 import dev.rndmorris.salisarcana.common.item.BlockPlankItem;
 import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
 import thaumcraft.common.config.ConfigBlocks;
@@ -12,9 +13,6 @@ import thaumcraft.common.config.ConfigBlocks;
 public class CustomBlocks {
 
     public static Block blockPlank;
-
-    public static final String ORE_DICT_GREATWOOD_PLANKS = "plankGreatwood";
-    public static final String ORE_DICT_SILVERWOOD_PLANKS = "plankSilverwood";
 
     public static void registerBlocks() {
 
@@ -30,11 +28,11 @@ public class CustomBlocks {
         // To-do: is this needed? It appears to break the ore-dicted slab and stair recipes
         OreDictionary.registerOre("plankWood", new ItemStack(blockPlank, 1, OreDictionary.WILDCARD_VALUE));
 
-        OreDictionary.registerOre(ORE_DICT_GREATWOOD_PLANKS, new ItemStack(blockPlank, 1, 0));
-        OreDictionary.registerOre(ORE_DICT_SILVERWOOD_PLANKS, new ItemStack(blockPlank, 1, 1));
+        OreDictionary.registerOre(OreDict.GREATWOOD_PLANKS, new ItemStack(blockPlank, 1, 0));
+        OreDictionary.registerOre(OreDict.SILVERWOOD_PLANKS, new ItemStack(blockPlank, 1, 1));
 
-        OreDictionary.registerOre(ORE_DICT_GREATWOOD_PLANKS, new ItemStack(ConfigBlocks.blockWoodenDevice, 1, 6));
-        OreDictionary.registerOre(ORE_DICT_SILVERWOOD_PLANKS, new ItemStack(ConfigBlocks.blockWoodenDevice, 1, 7));
+        OreDictionary.registerOre(OreDict.GREATWOOD_PLANKS, new ItemStack(ConfigBlocks.blockWoodenDevice, 1, 6));
+        OreDictionary.registerOre(OreDict.SILVERWOOD_PLANKS, new ItemStack(ConfigBlocks.blockWoodenDevice, 1, 7));
     }
 
 }

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -18,6 +18,7 @@ import net.minecraftforge.oredict.ShapedOreRecipe;
 
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.registry.GameRegistry;
+import dev.rndmorris.salisarcana.api.OreDict;
 import dev.rndmorris.salisarcana.common.blocks.CustomBlocks;
 import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
 import thaumcraft.api.ThaumcraftApi;
@@ -155,13 +156,12 @@ public class CustomRecipes {
         // Greatwood Slabs
         final var greatwoodSlabs = new ItemStack(ConfigBlocks.blockSlabWood, 6, 0);
         registerSlabRecipes(greatwoodSlabs, thaumGreatwoodPlanks, arcanaGreatwoodPlanks);
-        GameRegistry.addRecipe(new ShapedOreRecipe(greatwoodSlabs, "PPP", 'P', CustomBlocks.ORE_DICT_GREATWOOD_PLANKS));
+        GameRegistry.addRecipe(new ShapedOreRecipe(greatwoodSlabs, "PPP", 'P', OreDict.GREATWOOD_PLANKS));
 
         // Silverwood Slabs
         final var silverwoodSlabs = new ItemStack(ConfigBlocks.blockSlabWood, 6, 1);
         registerSlabRecipes(silverwoodSlabs, thaumSilverwoodPlanks, arcanaSilverwoodPlanks);
-        GameRegistry
-            .addRecipe(new ShapedOreRecipe(silverwoodSlabs, "PPP", 'P', CustomBlocks.ORE_DICT_SILVERWOOD_PLANKS));
+        GameRegistry.addRecipe(new ShapedOreRecipe(silverwoodSlabs, "PPP", 'P', OreDict.SILVERWOOD_PLANKS));
 
         // Greatwood Stairs
         GameRegistry.addRecipe(
@@ -171,7 +171,7 @@ public class CustomRecipes {
                 "PP ",
                 "PPP",
                 'P',
-                CustomBlocks.ORE_DICT_GREATWOOD_PLANKS));
+                OreDict.GREATWOOD_PLANKS));
 
         // Silverwood Stairs
         GameRegistry.addRecipe(
@@ -181,7 +181,7 @@ public class CustomRecipes {
                 "PP ",
                 "PPP",
                 'P',
-                CustomBlocks.ORE_DICT_SILVERWOOD_PLANKS));
+                OreDict.SILVERWOOD_PLANKS));
     }
 
     private static void registerSlabRecipes(ItemStack output, ItemStack tcPlanks, ItemStack tfPlanks) {

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/EnhancementsModule.java
@@ -68,6 +68,8 @@ public class EnhancementsModule extends BaseConfigModule {
     public final IntSetting thaumometerDuration;
     public final ToggleSetting researchItemExtensions;
 
+    public final ToggleSetting heatSourceOreDict;
+
     public EnhancementsModule() {
         // spotless:off
         addSettings(
@@ -317,6 +319,12 @@ public class EnhancementsModule extends BaseConfigModule {
                     .setParents("DECONSTRUCTOR")
                     .setAspects("ordo:10", "perditio:10", "permutatio:10")).setCategory("thaumometer_container_scan"));
 
+        // temporary placement, will be moved during the config rework
+        addSettings(
+            heatSourceOreDict = new ToggleSetting(
+                this,
+                "heatSourceOreDict",
+                "Enable ore dictionary support for crucible and thaumatorium heat sources."));
     }
 
     public boolean singleWandReplacementEnabled() {

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ArrayHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ArrayHelper.java
@@ -21,6 +21,15 @@ public class ArrayHelper {
         return list.toArray(new String[0]);
     }
 
+    public static int indexOf(int[] array, int key) {
+        for (var index = 0; index < array.length; ++index) {
+            if (array[index] == key) {
+                return index;
+            }
+        }
+        return -1;
+    }
+
     public static boolean tryAssign(boolean[] arr, int index, boolean value) {
         if (0 <= index && index < arr.length) {
             arr[index] = value;

--- a/src/main/java/dev/rndmorris/salisarcana/lib/CrucibleHeatLogic.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/CrucibleHeatLogic.java
@@ -1,0 +1,40 @@
+package dev.rndmorris.salisarcana.lib;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.init.Blocks;
+import net.minecraft.item.ItemStack;
+import net.minecraftforge.oredict.OreDictionary;
+
+import dev.rndmorris.salisarcana.api.OreDict;
+import thaumcraft.common.config.ConfigBlocks;
+
+public class CrucibleHeatLogic {
+
+    public static void registerOreDictName() {
+        heatSourceId = OreDictionary.getOreID(OreDict.HEAT_SOURCE);
+        // todo: remove before merging
+        OreDictionary.registerOre(OreDict.HEAT_SOURCE, Blocks.command_block);
+    }
+
+    private static int heatSourceId = -1;
+
+    /**
+     * Meant to be called from the relevant TileCrucible and TileThaumatorium mixins, where we target the
+     * {@code mat == Material.lava} check.
+     * All of these parameters already exist as locals in the relevant target methods, so we re-use them instead of
+     * getting them again ourselves.
+     */
+    public static boolean isCrucibleHeatSource(Block block, int blockMetadata, Material blockMaterial) {
+        // Maintain default behavior. If the block's material is lava or fire, or the block is Nitor, it can already
+        // heat the crucible.
+        if (blockMaterial == Material.lava || blockMaterial == Material.fire
+            || (block == ConfigBlocks.blockAiry && blockMetadata == 1)) {
+            return true;
+        }
+
+        // Then check the ore dictionary.
+        final var oreIds = OreDictionary.getOreIDs(new ItemStack(block, 1, blockMetadata));
+        return ArrayHelper.indexOf(oreIds, heatSourceId) > -1;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/CrucibleHeatLogic.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/CrucibleHeatLogic.java
@@ -2,7 +2,6 @@ package dev.rndmorris.salisarcana.lib;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
-import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
@@ -13,8 +12,6 @@ public class CrucibleHeatLogic {
 
     public static void registerOreDictName() {
         heatSourceId = OreDictionary.getOreID(OreDict.HEAT_SOURCE);
-        // todo: remove before merging
-        OreDictionary.registerOre(OreDict.HEAT_SOURCE, Blocks.command_block);
     }
 
     private static int heatSourceId = -1;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -388,6 +388,11 @@ public enum Mixins {
         .addMixinClasses("addons.Automagy.ModResearchItem_Extended")
         .addTargetedMod(TargetedMod.AUTOMAGY)),
 
+    CRUCIBLE_HEAT_SOURCES(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.enhancements.heatSourceOreDict::isEnabled)
+        .addMixinClasses("tiles.MixinTileCrucible_HeatSources", "tiles.MixinTileThaumatorium_HeatSources")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
     ;
     // spotless:on
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_HeatSources.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_HeatSources.java
@@ -31,7 +31,7 @@ public abstract class MixinTileCrucible_HeatSources extends TileThaumcraft {
             target = "Lnet/minecraft/block/material/Material;lava:Lnet/minecraft/block/material/Material;"))
     private Material checkHeatSource(Operation<Material> original, @Local(name = "bi") Block block,
         @Local(name = "md") int md, @Local(name = "mat") Material blockMaterial) {
-        return CrucibleHeatLogic.isCrucibleHeatSource(block, md, blockMaterial) ? blockMaterial : null;
+        return CrucibleHeatLogic.isCrucibleHeatSource(block, md, blockMaterial) ? blockMaterial : original.call();
     }
 
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_HeatSources.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_HeatSources.java
@@ -1,0 +1,37 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import dev.rndmorris.salisarcana.lib.CrucibleHeatLogic;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.common.tiles.TileCrucible;
+
+@Mixin(value = TileCrucible.class)
+public abstract class MixinTileCrucible_HeatSources extends TileThaumcraft {
+
+    /**
+     * Tap into the {@code mat == Material.lava} comparison and, if it's not a vanilla thaum heat source, check if the
+     * block meets our additional
+     * acceptable criteria.
+     * Because of our mixin point, we can force a successful "can heat crucible" check by returning {@code mat} from the
+     * original method, since it should always equal itself.
+     */
+    @WrapOperation(
+        method = "updateEntity",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/block/material/Material;lava:Lnet/minecraft/block/material/Material;"))
+    private Material checkHeatSource(Operation<Material> original, @Local(name = "bi") Block block,
+        @Local(name = "md") int md, @Local(name = "mat") Material blockMaterial) {
+        return CrucibleHeatLogic.isCrucibleHeatSource(block, md, blockMaterial) ? blockMaterial : null;
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileThaumatorium_HeatSources.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileThaumatorium_HeatSources.java
@@ -1,0 +1,36 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import dev.rndmorris.salisarcana.lib.CrucibleHeatLogic;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.common.tiles.TileThaumatorium;
+
+@Mixin(value = TileThaumatorium.class)
+public abstract class MixinTileThaumatorium_HeatSources extends TileThaumcraft {
+
+    /**
+     * Tap into the {@code mat == Material.lava} comparison and, if it's not a vanilla thaum heat source, check if the
+     * block meets our additional
+     * acceptable criteria.
+     * Because of our mixin point, we can force a successful "can heat crucible" check by returning {@code mat} from the
+     * original method, since it should always equal itself.
+     */
+    @WrapOperation(
+        method = "checkHeat",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/block/material/Material;lava:Lnet/minecraft/block/material/Material;"))
+    private Material checkHeatSource(Operation<Material> original, @Local(name = "bi") Block block,
+        @Local(name = "md") int md, @Local(name = "mat") Material blockMaterial) {
+        return CrucibleHeatLogic.isCrucibleHeatSource(block, md, blockMaterial) ? blockMaterial : null;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileThaumatorium_HeatSources.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileThaumatorium_HeatSources.java
@@ -28,9 +28,10 @@ public abstract class MixinTileThaumatorium_HeatSources extends TileThaumcraft {
         method = "checkHeat",
         at = @At(
             value = "FIELD",
-            target = "Lnet/minecraft/block/material/Material;lava:Lnet/minecraft/block/material/Material;"))
+            target = "Lnet/minecraft/block/material/Material;lava:Lnet/minecraft/block/material/Material;"),
+        remap = false)
     private Material checkHeatSource(Operation<Material> original, @Local(name = "bi") Block block,
         @Local(name = "md") int md, @Local(name = "mat") Material blockMaterial) {
-        return CrucibleHeatLogic.isCrucibleHeatSource(block, md, blockMaterial) ? blockMaterial : null;
+        return CrucibleHeatLogic.isCrucibleHeatSource(block, md, blockMaterial) ? blockMaterial : original.call();
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature/tweak

**What is the current behavior?** (You can also link to an open issue here)
Blocks that can heat crucibles are hardcoded. (See #203)

**What is the new behavior (if this is a feature change)?**
Blocks with the new ore dictionary name can also heat crucubles

**Does this PR introduce a breaking change?**
No

**Other information**:
