### PR TITLE
XP shouldn't be automatically sent to a player when a focus is disenchanted

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator_CanStoreXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator_CanStoreXP.java
@@ -61,9 +61,6 @@ public class MixinTileFocalManipulator_CanStoreXP extends TileThaumcraftInventor
     @Override
     public void salisArcana$addXP(int xp) {
         salisArcana$storedXP += xp;
-        if (!this.salisArcana$playersConnected.isEmpty()) {
-            this.salisArcana$transferXpToPlayer(this.salisArcana$playersConnected.get(0));
-        }
     }
 
     @Override


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tweak

**What is the current behavior?** (You can also link to an open issue here)
XP is sent to the player as soon as a focus is finished disenchanting

**What is the new behavior (if this is a feature change)?**
It no longer does that

**Does this PR introduce a breaking change?**
No

**Other information**:
