### PR TITLE
Don't spam players for using ingredients in the crucible

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
@@ -1,9 +1,17 @@
 package dev.rndmorris.salisarcana.mixins.late.tiles;
 
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -19,6 +27,13 @@ import thaumcraft.common.tiles.TileCrucible;
 
 @Mixin(TileCrucible.class)
 public class MixinTileCrucible_MissingRecipe extends TileEntity {
+
+    // player -> crucible recipe -> last time the player matched that recipe
+    // WeakHashMap ensures that the data being tracked can get garbage collected after the player entity does (such as
+    // when they log off)
+    @Unique
+    private static final Map<EntityPlayer, ConcurrentHashMap<CrucibleRecipe, LocalDateTime>> sa$warnings = Collections
+        .synchronizedMap(new WeakHashMap<>());
 
     @WrapOperation(
         method = "attemptSmelt",
@@ -36,11 +51,21 @@ public class MixinTileCrucible_MissingRecipe extends TileEntity {
             lastItem);
 
         if (recipe != null && !ResearchManager.isResearchComplete(username, recipe.key)) {
-            if (!sentMessage.get()) {
-                final var player = this.worldObj.getPlayerEntityByName(username);
-                if (player != null)
+            final var player = this.worldObj.getPlayerEntityByName(username);
+            LocalDateTime lastUsageTime;
+            if (player != null) {
+                lastUsageTime = sa$warnings.computeIfAbsent(player, (_key) -> new ConcurrentHashMap<>())
+                    .get(recipe);
+                // if the player hasn't been warned since they last logged in, OR if it's been five minutes
+                // since the player last tossed something in that matches this recipe
+                if (lastUsageTime == null || lastUsageTime.isBefore(
+                    LocalDateTime.now()
+                        .minusMinutes(5))) {
                     ResearchHelper.sendResearchError(player, recipe.key, "salisarcana:error_missing_research.crucible");
-                sentMessage.set(true);
+                }
+                // keeps the warning tied to a rolling window, to minimize spamming
+                sa$warnings.computeIfAbsent(player, (_key) -> new ConcurrentHashMap<>())
+                    .put(recipe, LocalDateTime.now());
             }
             return null;
         }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
@@ -16,8 +16,6 @@ import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.llamalad7.mixinextras.sugar.Share;
-import com.llamalad7.mixinextras.sugar.ref.LocalBooleanRef;
 
 import dev.rndmorris.salisarcana.lib.ResearchHelper;
 import thaumcraft.api.aspects.AspectList;
@@ -43,7 +41,7 @@ public class MixinTileCrucible_MissingRecipe extends TileEntity {
             remap = false),
         remap = false)
     public CrucibleRecipe captureCrucibleRecipe(String username, AspectList aspects, ItemStack lastItem,
-        Operation<CrucibleRecipe> original, @Share("sentMessage") LocalBooleanRef sentMessage) {
+        Operation<CrucibleRecipe> original) {
         final var recipe = original.call(
             ResearchHelper.knowItAll()
                 .getCommandSenderName(),


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
If you toss iron nuggets into a crucible for metellum without the metal transmutation research, you get spammed with chat messages.

**What is the new behavior (if this is a feature change)?**
Track when a player was last warned that they don't have the research for a recipe, and only warn them if they haven't been warned or it's been a while since the last warning (five minutes without matching on the recipe).

**Does this PR introduce a breaking change?**
No

**Other information**:
