### PR TITLE
Fix bugs and exploits around node recharging

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -54,7 +54,6 @@ public class CommonProxy {
         if (ConfigModuleRoot.enhancements.enableFocusDisenchanting.isEnabled()) {
             DisenchantFocusUpgrade.initialize();
         }
-
         CustomBlocks.registerBlocks();
         PlaceholderItem.registerPlaceholders();
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
@@ -28,6 +28,7 @@ public class BugfixesModule extends BaseConfigModule {
     public final ToggleSetting negativeBossSpawnCount;
     public final ToggleSetting useForgeFishingLists;
     public final ToggleSetting focalManipulatorForbidSwaps;
+    public final ToggleSetting nodesRechargeInGameTime;
 
     public BugfixesModule() {
         addSettings(
@@ -108,7 +109,11 @@ public class BugfixesModule extends BaseConfigModule {
             focalManipulatorForbidSwaps = new ToggleSetting(
                 this,
                 "focalManipulatorForbidSwaps",
-                "Prevents players from putting on conflicting or out-of-order upgrades onto a focus by swapping the focus being modified during the upgrade process."));
+                "Prevents players from putting on conflicting or out-of-order upgrades onto a focus by swapping the focus being modified during the upgrade process."),
+            nodesRechargeInGameTime = new ToggleSetting(
+                this,
+                "nodesRechargeInGameTime",
+                "Unloaded nodes will regenerate based on game time, not real life time."));
     }
 
     @Nonnull

--- a/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/modules/BugfixesModule.java
@@ -29,6 +29,7 @@ public class BugfixesModule extends BaseConfigModule {
     public final ToggleSetting useForgeFishingLists;
     public final ToggleSetting focalManipulatorForbidSwaps;
     public final ToggleSetting nodesRechargeInGameTime;
+    public final ToggleSetting nodesRememberBeingDrained;
 
     public BugfixesModule() {
         addSettings(
@@ -113,7 +114,11 @@ public class BugfixesModule extends BaseConfigModule {
             nodesRechargeInGameTime = new ToggleSetting(
                 this,
                 "nodesRechargeInGameTime",
-                "Unloaded nodes will regenerate based on game time, not real life time."));
+                "Unloaded nodes will regenerate based on game time, not real life time."),
+            nodesRememberBeingDrained = new ToggleSetting(
+                this,
+                "nodesRememberBeingDrained",
+                "Nodes will remember being drained, preventing rapidly loading, draining, then unloading nodes exploiting nodes' catch-up recharging."));
     }
 
     @Nonnull

--- a/src/main/java/dev/rndmorris/salisarcana/lib/TimeHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/TimeHelper.java
@@ -1,0 +1,8 @@
+package dev.rndmorris.salisarcana.lib;
+
+public class TimeHelper {
+
+    public static long ticksToMs(long ticks) {
+        return ticks * 50;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ifaces/IFocalManipulatorWithXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ifaces/IFocalManipulatorWithXP.java
@@ -1,4 +1,4 @@
-package dev.rndmorris.salisarcana.lib;
+package dev.rndmorris.salisarcana.lib.ifaces;
 
 import net.minecraft.entity.player.EntityPlayer;
 

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ifaces/IGameTimeNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ifaces/IGameTimeNode.java
@@ -1,0 +1,12 @@
+package dev.rndmorris.salisarcana.lib.ifaces;
+
+/**
+ * Implemented in nodes when the RechargeTime mixin is applied.
+ */
+public interface IGameTimeNode {
+
+    /**
+     * Update the node's lastTickActive field to the current world total time.
+     */
+    void sa$updateLastTickActive();
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -227,6 +227,12 @@ public enum Mixins {
         .addMixinClasses("tiles.MixinTileNode_RechargeTime")
         .addTargetedMod(TargetedMod.THAUMCRAFT)
     ),
+    NODE_REMEMBER_DRAINED(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.bugfixes.nodesRememberBeingDrained::isEnabled)
+        .addMixinClasses("tiles.MixinTileNode_RememberUpdates")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)
+    ),
 
     // Enhancements
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -221,6 +221,12 @@ public enum Mixins {
         .setApplyIf(ConfigModuleRoot.bugfixes.crimsonRitesFakePlayerCheck::isEnabled)
         .addMixinClasses("items.MixinItemEldritchObject_FakePlayerFix")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    NODE_RECHARGE_TIME(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(ConfigModuleRoot.bugfixes.nodesRechargeInGameTime::isEnabled)
+        .addMixinClasses("tiles.MixinTileNode_RechargeTime")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)
+    ),
 
     // Enhancements
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerFocalManipulator.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerFocalManipulator.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import dev.rndmorris.salisarcana.lib.IFocalManipulatorWithXP;
+import dev.rndmorris.salisarcana.lib.ifaces.IFocalManipulatorWithXP;
 import thaumcraft.common.container.ContainerFocalManipulator;
 import thaumcraft.common.tiles.TileFocalManipulator;
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator.java
@@ -14,7 +14,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
 import dev.rndmorris.salisarcana.common.DisenchantFocusUpgrade;
-import dev.rndmorris.salisarcana.lib.IFocalManipulatorWithXP;
+import dev.rndmorris.salisarcana.lib.ifaces.IFocalManipulatorWithXP;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.api.wands.ItemFocusBasic;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator_CanStoreXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator_CanStoreXP.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.Unique;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 
-import dev.rndmorris.salisarcana.lib.IFocalManipulatorWithXP;
+import dev.rndmorris.salisarcana.lib.ifaces.IFocalManipulatorWithXP;
 import thaumcraft.common.tiles.TileFocalManipulator;
 import thaumcraft.common.tiles.TileThaumcraftInventory;
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator_CancelReturnXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileFocalManipulator_CancelReturnXP.java
@@ -13,8 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 
-import dev.rndmorris.salisarcana.lib.IFocalManipulatorWithXP;
 import dev.rndmorris.salisarcana.lib.PlayerHelper;
+import dev.rndmorris.salisarcana.lib.ifaces.IFocalManipulatorWithXP;
 import thaumcraft.common.tiles.TileFocalManipulator;
 
 @Mixin(TileFocalManipulator.class)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_RechargeTime.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_RechargeTime.java
@@ -1,0 +1,130 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.Constants;
+
+import org.spongepowered.asm.lib.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.lib.TimeHelper;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.nodes.NodeModifier;
+import thaumcraft.common.tiles.TileNode;
+
+@Mixin(value = TileNode.class)
+public abstract class MixinTileNode_RechargeTime extends TileThaumcraft {
+
+    @Shadow(remap = false)
+    public abstract NodeModifier getNodeModifier();
+
+    @Unique
+    long sa$lastActiveTicks = -1;
+
+    /**
+     * Persist our custom field to NBT.
+     */
+    @WrapMethod(method = "writeToNBT")
+    private void writeToNBT(NBTTagCompound nbttagcompound, Operation<Void> original) {
+        original.call(nbttagcompound);
+        if (sa$lastActiveTicks >= 0) {
+            nbttagcompound.setLong("salisarcana:lastActiveTicks", sa$lastActiveTicks);
+        }
+    }
+
+    /**
+     * Re-load our custom field from NBT, if it was previously persisted there.
+     */
+    @WrapMethod(method = "readFromNBT")
+    private void readFromNBT(NBTTagCompound nbttagcompound, Operation<Void> original) {
+        original.call(nbttagcompound);
+        if (nbttagcompound.hasKey("salisarcana:lastActiveTicks", Constants.NBT.TAG_LONG)) {
+            sa$lastActiveTicks = nbttagcompound.getLong("salisarcana:lastActiveTicks");
+        }
+    }
+
+    /**
+     * If Salis has not yet taken over catch-up recharging, let TC do its thing. If not, verify that enough game
+     * time has elapsed to merit catch-up recharging.
+     */
+    @WrapOperation(
+        method = "handleRecharge",
+        remap = false,
+        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;catchUp:Z", opcode = Opcodes.GETFIELD))
+    private boolean shouldCatchUp(TileNode instance, Operation<Boolean> original) {
+        boolean catchUp = original.call(instance);
+        if (sa$lastActiveTicks < 0) {
+            // we don't have a recorded last active world time, so just let TC do its thing
+            return catchUp;
+        }
+        if (!catchUp) {
+            // if system time hasn't progressed enough for vanilla TC to regen
+            // it's highly unlikely world time has progressed
+            return false;
+        }
+        long regenRate = sa$regenRate();
+        long regenInterval = regenRate * 75L;
+        long worldTime = worldObj.getTotalWorldTime();
+        return regenRate > 0 && TimeHelper.ticksToMs(worldTime) > sa$lastActiveTicks + regenInterval;
+    }
+
+    /**
+     * If Salis has taken over catch-up recharging, use the game time for checking how long the node has been unloaded.
+     * Otherwise, let TC do its thing.
+     */
+    @WrapOperation(
+        method = "handleRecharge",
+        remap = false,
+        at = @At(value = "INVOKE", target = "Ljava/lang/System;currentTimeMillis()J", ordinal = 0))
+    private long captureCurrentTimeForRegen(Operation<Long> original) {
+        return sa$lastActiveTicks >= 0 ? TimeHelper.ticksToMs(worldObj.getTotalWorldTime()) : original.call();
+    }
+
+    /**
+     * If Salis has taken over catch-up recharging, use our saved game time for getting the last time the node was
+     * active. Otherwise let TC do its thing.
+     */
+    @WrapOperation(
+        method = "handleRecharge",
+        remap = false,
+        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;lastActive:J", opcode = Opcodes.GETFIELD))
+    private long captureLastActiveForRegen(TileNode instance, Operation<Long> original) {
+        return sa$lastActiveTicks >= 0 ? TimeHelper.ticksToMs(sa$lastActiveTicks) : original.call(instance);
+    }
+
+    /**
+     * Store when the node last recharged, and open the door for Salis to take over catch-up recharging if it hasn't
+     * already.
+     */
+    @WrapOperation(
+        method = "handleRecharge",
+        remap = false,
+        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;lastActive:J", opcode = Opcodes.PUTFIELD))
+    private void captureCurrentTimeForStorage(TileNode instance, long value, Operation<Void> original) {
+        original.call(instance, value);
+        sa$lastActiveTicks = worldObj.getTotalWorldTime();
+    }
+
+    /**
+     * Utility, put here just to keep the primary method clean
+     */
+    @Unique
+    private long sa$regenRate() {
+        var modifier = getNodeModifier();
+        if (modifier == null) {
+            return 600;
+        }
+        return switch (modifier) {
+            case BRIGHT -> 400;
+            case PALE -> 900;
+            case FADING -> 0;
+            default -> 600;
+        };
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_RememberUpdates.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_RememberUpdates.java
@@ -1,0 +1,44 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import dev.rndmorris.salisarcana.lib.ifaces.IGameTimeNode;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.common.tiles.TileNode;
+
+@Mixin(value = TileNode.class)
+public abstract class MixinTileNode_RememberUpdates extends TileThaumcraft {
+
+    @Shadow
+    long lastActive;
+
+    /**
+     * When the node is drained in some way, log that the node was active
+     */
+    @WrapMethod(method = "takeFromContainer(Lthaumcraft/api/aspects/Aspect;I)Z", remap = false)
+    private boolean updateLastActiveOnTake(Aspect aspect, int amount, Operation<Boolean> original) {
+        this.lastActive = System.currentTimeMillis();
+        if (this instanceof IGameTimeNode node) {
+            node.sa$updateLastTickActive();
+        }
+        return original.call(aspect, amount);
+    }
+
+    /**
+     * When vis is added to the node, log that it was active.
+     */
+    @WrapMethod(method = "addToContainer", remap = false)
+    private int updateLastActiveOnAdd(Aspect aspect, int amount, Operation<Integer> original) {
+        this.lastActive = System.currentTimeMillis();
+        if (this instanceof IGameTimeNode node) {
+            node.sa$updateLastTickActive();
+        }
+        return original.call(aspect, amount);
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_RememberUpdates.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_RememberUpdates.java
@@ -14,7 +14,7 @@ import thaumcraft.common.tiles.TileNode;
 @Mixin(value = TileNode.class)
 public abstract class MixinTileNode_RememberUpdates extends TileThaumcraft {
 
-    @Shadow
+    @Shadow(remap = false)
     long lastActive;
 
     /**


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tweak + bug fix

**What is the current behavior?** (You can also link to an open issue here)
* Nodes play catch-up based on system time
* Nodes can be drained then quickly unloaded and reloaded to instantly regenerate vis

**What is the new behavior (if this is a feature change)?**
* Nodes will play catch-up based on world time
* Nodes will track when they were last updated, so they don't play catch-up inappropriately

**Does this PR introduce a breaking change?**
No

**Other information**:
