### PR TITLE
Prevent scanning the result of a villager trade

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/client/ThaumicInventoryScanner.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/ThaumicInventoryScanner.java
@@ -16,6 +16,7 @@ import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Slot;
 import net.minecraft.inventory.SlotCrafting;
+import net.minecraft.inventory.SlotMerchantResult;
 import net.minecraft.item.Item;
 import net.minecraftforge.client.event.GuiScreenEvent;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
@@ -112,6 +113,7 @@ public class ThaumicInventoryScanner {
                 null,
                 "");
             if (hoveringSlot.canTakeStack(player) && !(hoveringSlot instanceof SlotCrafting)
+                && !(hoveringSlot instanceof SlotMerchantResult)
                 && ScanManager.isValidScanTarget(player, result, "@")
                 && !ScanManager.getScanAspects(result, Minecraft.getMinecraft().theWorld.provider.worldObj).aspects
                     .isEmpty()) {

--- a/src/main/java/dev/rndmorris/salisarcana/network/MessageScanSlot.java
+++ b/src/main/java/dev/rndmorris/salisarcana/network/MessageScanSlot.java
@@ -11,6 +11,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.Slot;
 import net.minecraft.inventory.SlotCrafting;
+import net.minecraft.inventory.SlotMerchantResult;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
@@ -52,7 +53,9 @@ public class MessageScanSlot implements IMessage, IMessageHandler<MessageScanSlo
         if (container != null && message.getSlotNumber() >= 0
             && message.getSlotNumber() < container.inventorySlots.size()) {
             Slot slot = container.inventorySlots.get(message.getSlotNumber());
-            if (slot.getStack() != null && slot.canTakeStack(entityPlayer) && !(slot instanceof SlotCrafting)) {
+            if (slot.getStack() != null && slot.canTakeStack(entityPlayer)
+                && !(slot instanceof SlotCrafting)
+                && !(slot instanceof SlotMerchantResult)) {
                 ItemStack itemStack = slot.getStack();
                 ScanResult result = new ScanResult(
                     (byte) 1,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
You can scan the result of a merchant/villager trade without making the trade.

**What is the new behavior (if this is a feature change)?**
Prevents doing that

**Does this PR introduce a breaking change?**
No

**Other information**:
Relevant fix location spotted by @Nikolay-Sitnikov.