### PR TITLE
disable lexica botania-style navigation for clarity

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -184,7 +184,8 @@ public class ConfigFeatures extends ConfigGroup {
     public final ToggleSetting nomiconSavePage = new ToggleSetting(
         nomiconRightClickClose,
         "Save Thaumonomicon Page",
-        "When closing the Thaumonomicon, it will remember the page you are on when it is reopened. Requires Right-Click Navigation to be enabled.");
+        "When closing the Thaumonomicon, it will remember the page you are on when it is reopened. Requires Right-Click Navigation to be enabled.")
+            .setEnabled(false);
 
     public final Setting nomiconShowResearchId = new ToggleSetting(
         this,


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
config tweak

**What is the current behavior?** (You can also link to an open issue here)
thaum save page setting is enabled by default

**What is the new behavior (if this is a feature change)?**
thaum save page setting is disabled by default

**Does this PR introduce a breaking change?**
no

**Other information**:
