### PR TITLE
Fix crash related to KnowItAll

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -1,6 +1,8 @@
 package dev.rndmorris.salisarcana;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
 import net.minecraftforge.common.MinecraftForge;
 
 import cpw.mods.fml.common.FMLCommonHandler;
@@ -41,5 +43,15 @@ public class ClientProxy extends CommonProxy {
     public boolean isSingleplayerClient() {
         return Minecraft.getMinecraft()
             .isSingleplayer();
+    }
+
+    @Override
+    public World getFakePlayerWorld() {
+        if (MinecraftServer.getServer() != null) {
+            return MinecraftServer.getServer()
+                .worldServerForDimension(0);
+        } else {
+            return Minecraft.getMinecraft().theWorld;
+        }
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -6,7 +6,10 @@ import static dev.rndmorris.salisarcana.config.ConfigModuleRoot.commands;
 import java.util.ArrayList;
 import java.util.function.Supplier;
 
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.World;
 import net.minecraftforge.common.FishingHooks;
+import net.minecraftforge.common.MinecraftForge;
 
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
@@ -32,8 +35,8 @@ import dev.rndmorris.salisarcana.common.item.PlaceholderItem;
 import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
 import dev.rndmorris.salisarcana.config.ConfigModuleRoot;
 import dev.rndmorris.salisarcana.config.settings.CommandSettings;
+import dev.rndmorris.salisarcana.lib.KnowItAll;
 import dev.rndmorris.salisarcana.lib.R;
-import dev.rndmorris.salisarcana.lib.ResearchHelper;
 import dev.rndmorris.salisarcana.network.NetworkHandler;
 import dev.rndmorris.salisarcana.notifications.StartupNotifications;
 import dev.rndmorris.salisarcana.notifications.Updater;
@@ -72,6 +75,7 @@ public class CommonProxy {
         FMLCommonHandler.instance()
             .bus()
             .register(new StartupNotifications());
+        MinecraftForge.EVENT_BUS.register(KnowItAll.EVENT_COLLECTOR);
     }
 
     private void updateHarvestLevels() {
@@ -111,8 +115,6 @@ public class CommonProxy {
 
     // register server commands in this event handler (Remove if not needed)
     public void serverStarting(FMLServerStartingEvent event) {
-        ResearchHelper.resetKnowItAll();
-
         maybeRegister(event, commands.createNode, CreateNodeCommand::new);
         maybeRegister(event, commands.forgetResearch, ForgetResearchCommand::new);
         maybeRegister(event, commands.forgetScanned, ForgetScannedCommand::new);
@@ -134,6 +136,11 @@ public class CommonProxy {
 
     public boolean isSingleplayerClient() {
         return false;
+    }
+
+    public World getFakePlayerWorld() {
+        return MinecraftServer.getServer()
+            .worldServerForDimension(0);
     }
 
     private void fixGolemFishingLists() {

--- a/src/main/java/dev/rndmorris/salisarcana/common/commands/arguments/handlers/FocusUpgradesHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/commands/arguments/handlers/FocusUpgradesHandler.java
@@ -24,7 +24,7 @@ import dev.rndmorris.salisarcana.common.commands.arguments.handlers.named.INamed
 import dev.rndmorris.salisarcana.common.commands.arguments.handlers.positional.IPositionalArgumentHandler;
 import dev.rndmorris.salisarcana.lib.ArrayHelper;
 import dev.rndmorris.salisarcana.lib.IntegerHelper;
-import dev.rndmorris.salisarcana.lib.ResearchHelper;
+import dev.rndmorris.salisarcana.lib.KnowItAll;
 import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.api.wands.ItemFocusBasic;
 
@@ -92,8 +92,7 @@ public class FocusUpgradesHandler implements INamedArgumentHandler, IPositionalA
 
         final var result = new ArrayList<String>(possibleUpgrades.length);
         for (var upgrade : possibleUpgrades) {
-            if (heldFocus
-                .canApplyUpgrade(workingItem, ResearchHelper.knowItAll(), upgrade, appliedUpgrades.size() + 1)) {
+            if (heldFocus.canApplyUpgrade(workingItem, KnowItAll.getInstance(), upgrade, appliedUpgrades.size() + 1)) {
                 result.add(formatUpgradeKey(upgrade));
             }
         }

--- a/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
@@ -34,7 +34,6 @@ public class KnowItAll extends EntityPlayer {
         public void onWorldUnload(WorldEvent.Unload event) {
             if (knowItAll != null && knowItAll.worldObj == event.world) {
                 knowItAll = null;
-                System.out.println("Unloaded KnowItAll");
             }
         }
     }

--- a/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
@@ -1,0 +1,91 @@
+package dev.rndmorris.salisarcana.lib;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.util.ChunkCoordinates;
+import net.minecraft.util.DamageSource;
+import net.minecraft.util.IChatComponent;
+import net.minecraft.world.World;
+import net.minecraftforge.event.world.WorldEvent;
+
+import com.mojang.authlib.GameProfile;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import dev.rndmorris.salisarcana.SalisArcana;
+import thaumcraft.api.research.ResearchCategories;
+import thaumcraft.common.lib.research.ResearchManager;
+
+public class KnowItAll extends EntityPlayer {
+
+    private static KnowItAll knowItAll = null;
+    public static final String USERNAME = SalisArcana.MODID + ":KnowItAll";
+    public static final EventCollector EVENT_COLLECTOR = new EventCollector();
+
+    public static KnowItAll getInstance() {
+        if (knowItAll == null) {
+            knowItAll = new KnowItAll(SalisArcana.proxy.getFakePlayerWorld());
+        }
+
+        return knowItAll;
+    }
+
+    public static class EventCollector {
+
+        @SubscribeEvent
+        public void onWorldUnload(WorldEvent.Unload event) {
+            if (knowItAll != null && knowItAll.worldObj == event.world) {
+                knowItAll = null;
+                System.out.println("Unloaded KnowItAll");
+            }
+        }
+    }
+
+    private static void teachKnowItAll() {
+        if (ResearchManager.getResearchForPlayerSafe(USERNAME) == null) {
+            for (final var category : ResearchCategories.researchCategories.values()) {
+                for (final var researchItem : category.research.values()) {
+                    ResearchManager.completeResearchUnsaved(USERNAME, researchItem.key);
+                }
+            }
+        }
+    }
+
+    public KnowItAll(World world) {
+        super(world, new GameProfile(null, USERNAME));
+        KnowItAll.teachKnowItAll();
+    }
+
+    @Override
+    public void addChatMessage(IChatComponent message) {}
+
+    @Override
+    public boolean canCommandSenderUseCommand(int i, String s) {
+        return false;
+    }
+
+    @Override
+    public ChunkCoordinates getPlayerCoordinates() {
+        return new ChunkCoordinates(0, 0, 0);
+    }
+
+    @Override
+    public void openGui(Object mod, int modGuiId, World world, int x, int y, int z) {}
+
+    @Override
+    public boolean isEntityInvulnerable() {
+        return true;
+    }
+
+    @Override
+    public boolean canAttackPlayer(EntityPlayer player) {
+        return false;
+    }
+
+    @Override
+    public void onDeath(DamageSource source) {}
+
+    @Override
+    public void onUpdate() {}
+
+    @Override
+    public void travelToDimension(int dim) {}
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -10,7 +10,6 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.event.ClickEvent;
 import net.minecraft.event.HoverEvent;
-import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.ChatComponentText;
 import net.minecraft.util.ChatComponentTranslation;
 import net.minecraft.util.ChatStyle;
@@ -18,50 +17,14 @@ import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.IChatComponent;
 import net.minecraftforge.common.util.FakePlayer;
 
-import com.mojang.authlib.GameProfile;
-
-import dev.rndmorris.salisarcana.SalisArcana;
 import dev.rndmorris.salisarcana.api.IResearchItemExtended;
 import dev.rndmorris.salisarcana.common.commands.PrerequisitesCommand;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchItem;
 import thaumcraft.common.lib.network.PacketHandler;
 import thaumcraft.common.lib.network.playerdata.PacketPlayerCompleteToServer;
-import thaumcraft.common.lib.research.ResearchManager;
 
 public class ResearchHelper {
-
-    private static FakePlayer knowItAll;
-
-    /**
-     * A fake player whose entire purpose is to know all Thaumcraft research (created to support
-     * {@link dev.rndmorris.salisarcana.common.commands.UpgradeFocusCommand}.
-     *
-     * @return The fake player.
-     */
-    public static FakePlayer knowItAll() {
-        if (knowItAll == null) {
-            knowItAll = new FakePlayer(
-                MinecraftServer.getServer()
-                    .worldServerForDimension(0),
-                new GameProfile(null, SalisArcana.MODID + ":KnowItAll"));
-
-            final String commandSenderName = knowItAll.getCommandSenderName();
-            for (var category : ResearchCategories.researchCategories.values()) {
-                for (var researchItem : category.research.values()) {
-                    ResearchManager.completeResearchUnsaved(commandSenderName, researchItem.key);
-                }
-            }
-        }
-        return knowItAll;
-    }
-
-    /**
-     * Reset the fake player, to be rebuilt later.
-     */
-    public static void resetKnowItAll() {
-        knowItAll = null;
-    }
 
     public static boolean matchesTerm(ResearchItem research, String searchTerm) {
         searchTerm = searchTerm.toLowerCase();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
@@ -18,7 +18,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 
 import dev.rndmorris.salisarcana.api.IMultipleResearchArcaneRecipe;
 import dev.rndmorris.salisarcana.lib.CraftingHelper;
-import dev.rndmorris.salisarcana.lib.ResearchHelper;
+import dev.rndmorris.salisarcana.lib.KnowItAll;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.client.gui.GuiArcaneWorkbench;
 import thaumcraft.common.items.wands.ItemWandCasting;
@@ -46,7 +46,7 @@ public abstract class MixinGuiArcaneWorkbench_MissingResearch extends GuiContain
         final var wand = this.tileEntity.getStackInSlot(10);
         if (wand == null || wand.getItem() == null && !(wand.getItem() instanceof ItemWandCasting)) return null;
 
-        final var recipe = CraftingHelper.INSTANCE.findArcaneRecipe(awb, ResearchHelper.knowItAll());
+        final var recipe = CraftingHelper.INSTANCE.findArcaneRecipe(awb, KnowItAll.getInstance());
 
         if (recipe != null && !recipe.matches(awb, player.worldObj, player)) {
             final var researchArray = (recipe instanceof IMultipleResearchArcaneRecipe multi)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
@@ -17,6 +17,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
+import dev.rndmorris.salisarcana.lib.KnowItAll;
 import dev.rndmorris.salisarcana.lib.ResearchHelper;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.CrucibleRecipe;
@@ -42,11 +43,7 @@ public class MixinTileCrucible_MissingRecipe extends TileEntity {
         remap = false)
     public CrucibleRecipe captureCrucibleRecipe(String username, AspectList aspects, ItemStack lastItem,
         Operation<CrucibleRecipe> original) {
-        final var recipe = original.call(
-            ResearchHelper.knowItAll()
-                .getCommandSenderName(),
-            aspects,
-            lastItem);
+        final var recipe = original.call(KnowItAll.USERNAME, aspects, lastItem);
 
         if (recipe != null && !ResearchManager.isResearchComplete(username, recipe.key)) {
             final var player = this.worldObj.getPlayerEntityByName(username);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileInfusionMatrix_MissingResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileInfusionMatrix_MissingResearch.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
+import dev.rndmorris.salisarcana.lib.KnowItAll;
 import dev.rndmorris.salisarcana.lib.ResearchHelper;
 import thaumcraft.api.crafting.InfusionEnchantmentRecipe;
 import thaumcraft.api.crafting.InfusionRecipe;
@@ -28,7 +29,7 @@ public class MixinTileInfusionMatrix_MissingResearch {
         remap = false)
     public InfusionRecipe captureInfusionRecipe(ArrayList<ItemStack> components, ItemStack centerItem,
         EntityPlayer player, Operation<InfusionRecipe> original) {
-        final var recipe = original.call(components, centerItem, ResearchHelper.knowItAll());
+        final var recipe = original.call(components, centerItem, KnowItAll.getInstance());
 
         if (recipe != null && !recipe.matches(components, centerItem, player.worldObj, player)) {
             ResearchHelper
@@ -48,7 +49,7 @@ public class MixinTileInfusionMatrix_MissingResearch {
         remap = false)
     public InfusionEnchantmentRecipe captureInfusionEnchantmentRecipe(ArrayList<ItemStack> components,
         ItemStack centerItem, EntityPlayer player, Operation<InfusionEnchantmentRecipe> original) {
-        final var recipe = original.call(components, centerItem, ResearchHelper.knowItAll());
+        final var recipe = original.call(components, centerItem, KnowItAll.getInstance());
 
         if (recipe != null && !recipe.matches(components, centerItem, player.worldObj, player)) {
             ResearchHelper


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Replaces the `KnowItAll` with a custom class which can be correctly instantiated on the client.

**What is the current behavior?** (You can also link to an open issue here)
Opening a workbench with an arcane recipe on a multiplayer server crashes the game.
https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/19522

**What is the new behavior (if this is a feature change)?**
No longer crashes, and the `KnowItAll` is properly disposed of when the world is closed.

**Does this PR introduce a breaking change?**
No, except if any PRs are relying on the old location of the `KnowItAll`.