### PR TITLE
Fix KnowItAll not getting initialized during Crucible recipes.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
@@ -17,8 +17,13 @@ import thaumcraft.common.lib.research.ResearchManager;
 public class KnowItAll extends EntityPlayer {
 
     private static KnowItAll knowItAll = null;
-    public static final String USERNAME = SalisArcana.MODID + ":KnowItAll";
+    private static final String USERNAME = SalisArcana.MODID + ":KnowItAll";
     public static final EventCollector EVENT_COLLECTOR = new EventCollector();
+
+    public static String getUsername() {
+        teachKnowItAll();
+        return USERNAME;
+    }
 
     public static KnowItAll getInstance() {
         if (knowItAll == null) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_MissingRecipe.java
@@ -43,7 +43,7 @@ public class MixinTileCrucible_MissingRecipe extends TileEntity {
         remap = false)
     public CrucibleRecipe captureCrucibleRecipe(String username, AspectList aspects, ItemStack lastItem,
         Operation<CrucibleRecipe> original) {
-        final var recipe = original.call(KnowItAll.USERNAME, aspects, lastItem);
+        final var recipe = original.call(KnowItAll.getUsername(), aspects, lastItem);
 
         if (recipe != null && !ResearchManager.isResearchComplete(username, recipe.key)) {
             final var player = this.worldObj.getPlayerEntityByName(username);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - Crucible recipes wouldn't work until you tried crafting something in an infusion altar (or opened an Arcane Workbench on singleplayer)

**What is the current behavior?** (You can also link to an open issue here)
See above, sometimes the Crucible is unusable.

**What is the new behavior (if this is a feature change)?**
The KnowItAll researches get properly initialized by the Crucible mixin.

**Does this PR introduce a breaking change?**
No

**Other information**:
This is also, unfortunately, a bug that highly impacts players. If it could be merged directly to main ASAP, it would be nice.