### PR TITLE
Do not rely on Forge to clean up server instances.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -47,7 +47,8 @@ public class ClientProxy extends CommonProxy {
 
     @Override
     public World getFakePlayerWorld() {
-        if (MinecraftServer.getServer() != null) {
+        if (Minecraft.getMinecraft()
+            .isSingleplayer()) {
             return MinecraftServer.getServer()
                 .worldServerForDimension(0);
         } else {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix - fixes a client-crash bug.

**What is the current behavior?** (You can also link to an open issue here)
If you enter singleplayer, leave singleplayer, enter remote multiplayer, and try to put a wand in an Arcane Workbench, your game crashes.

**What is the new behavior (if this is a feature change)?**
It doesn't crash anymore, because it now uses the correct method of checking for an active local server instance.

**Does this PR introduce a breaking change?**
No

**Other information**:
This one isn't my fault. Who'd expect that leaving a singleplayer world doesn't reset `MinecraftServer.getServer()` to null?