### PR TITLE
Fix Silverwood Logs having the wrong name in WAILA.

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -121,3 +121,9 @@ Prevents bugs related to multiple players opening an Arcane Workbench's GUI at t
 **Config option:** `useForgeFishingLists`
 
 Use Forge's fishing lists to determine what fish, junk, and treasure a fishing golem catches.
+
+## Rotated Silverwood Logs Display Correct Name in WAILA
+
+**Config option:** `silverwoodLogCorrectName`
+
+Non-vertical silverwood logs will be correctly named "Silverwood Log" in WAILA.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -125,6 +125,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "nodesRememberBeingDrained",
         "Nodes will remember being drained, preventing rapidly loading, draining, then unloading nodes exploiting nodes' catch-up recharging.");
 
+    public final ToggleSetting silverwoodLogCorrectName = new ToggleSetting(
+        this,
+        "silverwoodLogCorrectName",
+        "Non-vertical silverwood logs will be correctly named \"Silverwood Log\" in WAILA.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -136,6 +136,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.itemMetadataSafetyCheck::isEnabled)
         .addMixinClasses("items.Mixin_ItemIconFix", "items.MixinItemWandRod")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    SILVERWOOD_LOG_NAME_FIX(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.silverwoodLogCorrectName::isEnabled)
+        .addMixinClasses("blocks.MixinBlockMagicalLogItem")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockMagicalLogItem.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockMagicalLogItem.java
@@ -1,0 +1,19 @@
+package dev.rndmorris.salisarcana.mixins.late.blocks;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import thaumcraft.common.blocks.BlockMagicalLogItem;
+
+@Mixin(BlockMagicalLogItem.class)
+public class MixinBlockMagicalLogItem {
+
+    @ModifyExpressionValue(
+        method = "getUnlocalizedName",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;getItemDamage()I"))
+    public int limitToValidMetadata(int original) {
+        return original & 3;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - rotated silverwood logs would display their name as "Greatwood Log" in WAILA.

**What is the current behavior?** (You can also link to an open issue here)
See above.

**What is the new behavior (if this is a feature change)?**
They now correctly display "Silverwood Log"

**Does this PR introduce a breaking change?**
No