### PR TITLE
Re-render any blocks when the biome is changed, closes #245

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -127,3 +127,9 @@ Use Forge's fishing lists to determine what fish, junk, and treasure a fishing g
 **Config option:** `silverwoodLogCorrectName`
 
 Non-vertical silverwood logs will be correctly named "Silverwood Log" in WAILA.
+
+## Visually Update Biome Colors
+
+**Config option:** `updateBiomeColorRendering`
+
+Biome changes will correctly update the color of grass in chunks without needing a block to change.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -130,6 +130,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "silverwoodLogCorrectName",
         "Non-vertical silverwood logs will be correctly named \"Silverwood Log\" in WAILA.");
 
+    public final ToggleSetting updateBiomeColorRendering = new ToggleSetting(
+        this,
+        "updateBiomeColorRendering",
+        "Biome changes will correctly update the color of grass in chunks without needing a block to change.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -141,6 +141,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.silverwoodLogCorrectName::isEnabled)
         .addMixinClasses("blocks.MixinBlockMagicalLogItem")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    UPDATE_BIOME_COLOR(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.CLIENT)
+        .setApplyIf(SalisConfig.bugfixes.updateBiomeColorRendering::isEnabled)
+        .addMixinClasses("lib.MixinUtils_UpdateBiomeColor")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinUtils_UpdateBiomeColor.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinUtils_UpdateBiomeColor.java
@@ -1,0 +1,24 @@
+package dev.rndmorris.salisarcana.mixins.late.lib;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.world.World;
+import net.minecraft.world.biome.BiomeGenBase;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import thaumcraft.common.lib.utils.Utils;
+
+@Mixin(Utils.class)
+public class MixinUtils_UpdateBiomeColor {
+
+    @Inject(method = "setBiomeAt", at = @At("TAIL"), remap = false)
+    private static void updateClientColor(World world, int x, int z, BiomeGenBase biome, CallbackInfo ci) {
+        // Important: apply only to client instances. - setSide(Side.CLIENT)
+        if (biome != null && world.isRemote) {
+            Minecraft.getMinecraft().renderGlobal.markBlockRangeForRenderUpdate(x - 1, 0, z - 1, x + 1, 256, z + 1);
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds new bugfix to visually update chunks when biome color is changed.

**What is the current behavior?** (You can also link to an open issue here)
Closes #245 

**What is the new behavior (if this is a feature change)?**
Biome colors are updated on the client.

**Does this PR introduce a breaking change?**
No