### PR TITLE
Catch parsing errors when parsing enum configs, closes #235

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/EnumSetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/EnumSetting.java
@@ -42,6 +42,11 @@ public class EnumSetting<E extends Enum<E>> extends Setting {
             .map(Enum::toString)
             .toArray(String[]::new);
         final var valueString = configuration.getString(name, getCategory(), value.toString(), comment, validValues);
-        value = Enum.valueOf(enumClass, valueString);
+
+        try {
+            value = Enum.valueOf(enumClass, valueString);
+        } catch (IllegalArgumentException e) {
+            // Don't do anything, just use the default value
+        }
     }
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - fixes a crash caused by incorrectly set up configurations

**What is the current behavior?** (You can also link to an open issue here)
Closes #235 

**What is the new behavior (if this is a feature change)?**
Incorrectly configured enum configs are ignored and the default value is used.

**Does this PR introduce a breaking change?**
No