### PR TITLE
Added better filtering & verification to config settings.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/SalisArcana.java
+++ b/src/main/java/dev/rndmorris/salisarcana/SalisArcana.java
@@ -2,7 +2,6 @@ package dev.rndmorris.salisarcana;
 
 import java.util.Map;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import cpw.mods.fml.common.Mod;
@@ -13,6 +12,7 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.network.NetworkCheckHandler;
 import cpw.mods.fml.relauncher.Side;
+import dev.rndmorris.salisarcana.core.SalisArcanaCore;
 
 @Mod(
     modid = SalisArcana.MODID,
@@ -22,8 +22,8 @@ import cpw.mods.fml.relauncher.Side;
     dependencies = "required-after:Thaumcraft;after:tc4tweak@[1.5.32,)")
 public class SalisArcana {
 
-    public static final String MODID = "salisarcana";
-    public static final Logger LOG = LogManager.getLogger(MODID);
+    public static final String MODID = SalisArcanaCore.MODID;
+    public static final Logger LOG = SalisArcanaCore.LOG;
 
     @SidedProxy(
         clientSide = "dev.rndmorris.salisarcana.ClientProxy",

--- a/src/main/java/dev/rndmorris/salisarcana/SalisArcana.java
+++ b/src/main/java/dev/rndmorris/salisarcana/SalisArcana.java
@@ -2,6 +2,7 @@ package dev.rndmorris.salisarcana;
 
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import cpw.mods.fml.common.Mod;
@@ -12,7 +13,6 @@ import cpw.mods.fml.common.event.FMLPreInitializationEvent;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import cpw.mods.fml.common.network.NetworkCheckHandler;
 import cpw.mods.fml.relauncher.Side;
-import dev.rndmorris.salisarcana.core.SalisArcanaCore;
 
 @Mod(
     modid = SalisArcana.MODID,
@@ -22,8 +22,8 @@ import dev.rndmorris.salisarcana.core.SalisArcanaCore;
     dependencies = "required-after:Thaumcraft;after:tc4tweak@[1.5.32,)")
 public class SalisArcana {
 
-    public static final String MODID = SalisArcanaCore.MODID;
-    public static final Logger LOG = SalisArcanaCore.LOG;
+    public static final String MODID = "salisarcana";
+    public static final Logger LOG = LogManager.getLogger(MODID);
 
     @SidedProxy(
         clientSide = "dev.rndmorris.salisarcana.ClientProxy",

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -75,7 +75,8 @@ public class ConfigFeatures extends ConfigGroup {
         // calculated based on TC4's default `specialNodeRarity` value
         new int[] { 972222, 9259, 9259, 9259, },
         0,
-        1000000).setEnabled(false);
+        1000000).setEnabled(false)
+            .setLengthFixed(true);
 
     public final IntArraySetting nodeTypeWeights = new IntArraySetting(
         this,
@@ -84,7 +85,8 @@ public class ConfigFeatures extends ConfigGroup {
         // calculated based on TC4's default `specialNodeRarity` value
         new int[] { 944444, 16666, 16666, 16666, 5555, },
         0,
-        1000000).setEnabled(false);
+        1000000).setEnabled(false)
+            .setLengthFixed(true);
 
     public final ToggleSetting suppressWarpEventsInCreative = new ToggleSetting(
         this,

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/BeaconBlockFixSetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/BeaconBlockFixSetting.java
@@ -13,6 +13,7 @@ public class BeaconBlockFixSetting extends IntArraySetting {
 
     public BeaconBlockFixSetting(IEnabler dependency) {
         super(dependency, configName, comment, new int[] { 4 }, 0, 15);
+        this.setMaxLength(16);
     }
 
     public boolean isBeaconMetadata(int metadata) {

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/EnumSetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/EnumSetting.java
@@ -7,6 +7,7 @@ import javax.annotation.Nonnull;
 import net.minecraftforge.common.config.Configuration;
 
 import dev.rndmorris.salisarcana.config.IEnabler;
+import dev.rndmorris.salisarcana.core.SalisArcanaCore;
 
 public class EnumSetting<E extends Enum<E>> extends Setting {
 
@@ -47,6 +48,11 @@ public class EnumSetting<E extends Enum<E>> extends Setting {
             value = Enum.valueOf(enumClass, valueString);
         } catch (IllegalArgumentException e) {
             // Don't do anything, just use the default value
+            SalisArcanaCore.LOG.error(
+                "Invalid enum value for config \"{}\": {}. Value must be one of: {}",
+                this.name,
+                valueString,
+                String.join(", ", validValues));
         }
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/IntArraySetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/IntArraySetting.java
@@ -52,18 +52,11 @@ public class IntArraySetting extends Setting {
 
     public IntArraySetting setLengthFixed(boolean isFixed) {
         this.fixedLength = isFixed;
-
-        if (isFixed) {
-            this.maxLength = this.defaultValue.length;
-        }
-
         return this;
     }
 
     public IntArraySetting setMaxLength(int maxLength) {
-        if (!this.fixedLength) {
-            this.maxLength = maxLength;
-        }
+        this.maxLength = maxLength;
         return this;
     }
 
@@ -79,7 +72,7 @@ public class IntArraySetting extends Setting {
                 this.minValue,
                 this.maxValue,
                 this.fixedLength,
-                this.maxLength)
+                this.fixedLength ? this.defaultValue.length : this.maxLength)
             .getIntList();
 
         boolean wrong = false;

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/IntArraySetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/IntArraySetting.java
@@ -1,8 +1,11 @@
 package dev.rndmorris.salisarcana.config.settings;
 
+import java.util.Arrays;
+
 import net.minecraftforge.common.config.Configuration;
 
 import dev.rndmorris.salisarcana.config.IEnabler;
+import dev.rndmorris.salisarcana.core.SalisArcanaCore;
 
 public class IntArraySetting extends Setting {
 
@@ -12,6 +15,8 @@ public class IntArraySetting extends Setting {
     protected int[] value;
     protected int minValue;
     protected int maxValue;
+    protected boolean fixedLength = false;
+    protected int maxLength = -1;
 
     Setting pairedSetting;
 
@@ -45,12 +50,60 @@ public class IntArraySetting extends Setting {
         return pairedSetting.isEnabled();
     }
 
+    public IntArraySetting setLengthFixed(boolean isFixed) {
+        this.fixedLength = isFixed;
+
+        if (isFixed) {
+            this.maxLength = this.defaultValue.length;
+        }
+
+        return this;
+    }
+
+    public IntArraySetting setMaxLength(int maxLength) {
+        if (!this.fixedLength) {
+            this.maxLength = maxLength;
+        }
+        return this;
+    }
+
     @Override
     public void loadFromConfiguration(Configuration configuration) {
         pairedSetting.loadFromConfiguration(configuration);
         this.value = configuration
-            .get(getCategory(), this.name, this.defaultValue, this.comment, this.minValue, this.maxValue)
+            .get(
+                getCategory(),
+                this.name,
+                this.defaultValue,
+                this.comment,
+                this.minValue,
+                this.maxValue,
+                this.fixedLength,
+                this.maxLength)
             .getIntList();
+
+        boolean wrong = false;
+        for (int num : this.value) {
+            if (num < this.minValue || num > this.maxValue) {
+                SalisArcanaCore.LOG.error(
+                    "Value {} in setting \"{}\" is out of bounds. (Bounds: {} <= n <= {})",
+                    num,
+                    this.name,
+                    this.minValue,
+                    this.maxValue);
+                wrong = true;
+            }
+        }
+
+        if (wrong) {
+            if (this.fixedLength) {
+                this.value = this.defaultValue;
+            } else {
+                this.value = Arrays.stream(this.value)
+                    .filter(v -> (v >= this.minValue && v <= this.maxValue))
+                    .toArray();
+            }
+        }
     }
 
 }

--- a/src/main/java/dev/rndmorris/salisarcana/core/SalisArcanaCore.java
+++ b/src/main/java/dev/rndmorris/salisarcana/core/SalisArcanaCore.java
@@ -3,6 +3,9 @@ package dev.rndmorris.salisarcana.core;
 import java.util.ArrayList;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.core.asm.IAsmEditor;
@@ -10,6 +13,9 @@ import dev.rndmorris.salisarcana.core.asm.compat.ModCompatEditor;
 
 @IFMLLoadingPlugin.MCVersion("1.7.10")
 public class SalisArcanaCore implements IFMLLoadingPlugin {
+
+    public static final String MODID = "salisarcana";
+    public static final Logger LOG = LogManager.getLogger(MODID);
 
     public SalisArcanaCore() {
         SalisConfig.synchronizeConfiguration();

--- a/src/main/java/dev/rndmorris/salisarcana/core/SalisArcanaCore.java
+++ b/src/main/java/dev/rndmorris/salisarcana/core/SalisArcanaCore.java
@@ -15,7 +15,7 @@ import dev.rndmorris.salisarcana.core.asm.compat.ModCompatEditor;
 public class SalisArcanaCore implements IFMLLoadingPlugin {
 
     public static final String MODID = "salisarcana";
-    public static final Logger LOG = LogManager.getLogger(MODID);
+    public static final Logger LOG = LogManager.getLogger("salisarcana-core");
 
     public SalisArcanaCore() {
         SalisConfig.synchronizeConfiguration();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
General improvement - makes sure that int array settings are filtered for invalid values, reports errors which aren't getting silently suppressed by Forge's config system.

**What is the current behavior?** (You can also link to an open issue here)
`IntArraySetting`s will happily accept out-of-bound numbers (`IntSetting`s & `FloatSetting`s silently clamp the values to the minimum and maximum.)

**What is the new behavior (if this is a feature change)?**
`IntArraySetting`s can now be required to have a maximum or exact amount of items.
`IntArraySetting`s will now reject out-of-bounds entries, log them, and either reset to default or skip the invalid value.
The Salis Arcana Logger has been moved to `SalisArcanaCore` (with it getting copied in `SalisArcana`) in order to allow core-mods and config processing to read the values without loading `SalisArcana` and potentially disrupting others' ASM.
`EnumSetting`s now log whenever they encounter an invalid value.

**Does this PR introduce a breaking change?**
No

**Other information**:
`StringSetting` and `HexColorSetting` are unused and have their own host of problems. I don't want to touch them unless I know how they're supposed to function (can they be disabled? should they parse colors properly? should they accept `#FFFFFF` and `0xFFFFFF`?) They should either be removed or improved to follow some sort of convention.

Many potential config mistakes are being silently corrected or ignored by Forge. There's not much we can do about that.

The Eldritch Altar setting's logic is most likely broken. Testing it to confirm is difficult, though, because of the contrived setup. Can I just prove it via code?