### PR TITLE
Fix obfuscation mapping crashes.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandRod.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/MixinItemWandRod.java
@@ -25,7 +25,7 @@ public abstract class MixinItemWandRod {
     @Shadow
     public IIcon iconPrimalStaff;
 
-    @Inject(method = "getIconFromDamage", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "getIconFromDamage", at = @At("HEAD"), cancellable = true, remap = true)
     private void mixinGetIconFromDamage(int meta, CallbackInfoReturnable<IIcon> cir) {
         if (meta < 50) {
             final var icon = sa$tryGet(iconWand, meta);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/Mixin_ItemIconFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/items/Mixin_ItemIconFix.java
@@ -22,8 +22,7 @@ import thaumcraft.common.items.wands.ItemWandCap;
 
 @Mixin(
     value = { ItemLootBag.class, ItemNugget.class, ItemResource.class, ItemAmuletRunic.class, ItemGirdleRunic.class,
-        ItemRingRunic.class, ItemPrimalArrow.class, ItemWandCap.class },
-    remap = false)
+        ItemRingRunic.class, ItemPrimalArrow.class, ItemWandCap.class })
 public abstract class Mixin_ItemIconFix extends Item {
 
     // explicitly remap = false otherwise we get a runtime InvalidMixinException

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileThaumatorium_HeatSources.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileThaumatorium_HeatSources.java
@@ -28,8 +28,7 @@ public abstract class MixinTileThaumatorium_HeatSources extends TileThaumcraft {
         method = "checkHeat",
         at = @At(
             value = "FIELD",
-            target = "Lnet/minecraft/block/material/Material;lava:Lnet/minecraft/block/material/Material;"),
-        remap = false)
+            target = "Lnet/minecraft/block/material/Material;lava:Lnet/minecraft/block/material/Material;"))
     private Material checkHeatSource(Operation<Material> original, @Local(name = "bi") Block block,
         @Local(name = "md") int md, @Local(name = "mat") Material blockMaterial) {
         return CrucibleHeatLogic.isCrucibleHeatSource(block, md, blockMaterial) ? blockMaterial : original.call();


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - the obfuscated version of the mod would refuse to run

**What is the current behavior?** (You can also link to an open issue here)
Trying to run `runObfClient` crashes because some mixins fail to apply

**What is the new behavior (if this is a feature change)?**
I removed some `remap = false` entries so everything can run properly

**Does this PR introduce a breaking change?**
No

**Other information**:
How was this not noticed until now?