### PR TITLE
Fix research error localization.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.function.Predicate;
 
-import dev.rndmorris.salisarcana.config.SalisConfig;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.event.ClickEvent;
@@ -20,6 +19,7 @@ import net.minecraftforge.common.util.FakePlayer;
 
 import dev.rndmorris.salisarcana.api.IResearchItemExtended;
 import dev.rndmorris.salisarcana.common.commands.PrerequisitesCommand;
+import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchItem;
 import thaumcraft.common.lib.network.PacketHandler;
@@ -90,7 +90,7 @@ public class ResearchHelper {
             final var research = ResearchCategories.getResearch(researchKey);
 
             Object researchName;
-            if(SalisConfig.features.researchItemExtensions.isEnabled()) {
+            if (SalisConfig.features.researchItemExtensions.isEnabled()) {
                 researchName = new ChatComponentTranslation(((IResearchItemExtended) research).getNameTranslationKey());
             } else {
                 researchName = research.getName();

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.function.Predicate;
 
+import dev.rndmorris.salisarcana.config.SalisConfig;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.event.ClickEvent;
@@ -87,10 +88,18 @@ public class ResearchHelper {
     public static void sendResearchError(EntityPlayer player, String researchKey, String translationKey) {
         if (player instanceof EntityPlayerMP playerMP && !(player instanceof FakePlayer)) {
             final var research = ResearchCategories.getResearch(researchKey);
+
+            Object researchName;
+            if(SalisConfig.features.researchItemExtensions.isEnabled()) {
+                researchName = new ChatComponentTranslation(((IResearchItemExtended) research).getNameTranslationKey());
+            } else {
+                researchName = research.getName();
+            }
+
             final var message = new ChatComponentTranslation(
                 translationKey,
-                research.getName(),
-                ResearchCategories.getCategoryName(research.category));
+                researchName,
+                new ChatComponentTranslation("tc.research_category." + research.category));
             message.setChatStyle(new ChatStyle().setColor(EnumChatFormatting.RED));
             playerMP.addChatMessage(message);
         }

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -19,7 +19,6 @@ import net.minecraftforge.common.util.FakePlayer;
 
 import dev.rndmorris.salisarcana.api.IResearchItemExtended;
 import dev.rndmorris.salisarcana.common.commands.PrerequisitesCommand;
-import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.research.ResearchItem;
 import thaumcraft.common.lib.network.PacketHandler;
@@ -89,11 +88,11 @@ public class ResearchHelper {
         if (player instanceof EntityPlayerMP playerMP && !(player instanceof FakePlayer)) {
             final var research = ResearchCategories.getResearch(researchKey);
 
-            Object researchName;
-            if (SalisConfig.features.researchItemExtensions.isEnabled()) {
-                researchName = new ChatComponentTranslation(((IResearchItemExtended) research).getNameTranslationKey());
+            IChatComponent researchName;
+            if (research instanceof IResearchItemExtended extended) {
+                researchName = new ChatComponentTranslation(extended.getNameTranslationKey());
             } else {
-                researchName = research.getName();
+                researchName = new ChatComponentText(research.getName());
             }
 
             final var message = new ChatComponentTranslation(


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix-ish - fixes an issue with the research errors.

**What is the current behavior?** (You can also link to an open issue here)
The research errors for the Crucible and the Runic Matrix were being created on the server, which would cause the names of the categories and the research to be translated on the server (to English, rather than whatever the client's language is.)

**What is the new behavior (if this is a feature change)?**
Properly constructs the chat components to translate the substituted parts on the client

**Does this PR introduce a breaking change?**
No

**Other information**:
This change doesn't do all that much good right now, considering that the error message itself hasn't been translated to any other language yet.