### PR TITLE
Fix Runed Stone shocking players in Creative, closes #252

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -133,3 +133,9 @@ Non-vertical silverwood logs will be correctly named "Silverwood Log" in WAILA.
 **Config option:** `updateBiomeColorRendering`
 
 Biome changes will correctly update the color of grass in chunks without needing a block to change.
+
+## Prevent Runed Stone from Shocking Creative Players
+
+**Config option:** `runedStoneIgnoreCreative`
+
+Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -135,6 +135,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "updateBiomeColorRendering",
         "Biome changes will correctly update the color of grass in chunks without needing a block to change.");
 
+    public final ToggleSetting runedStoneIgnoreCreative = new ToggleSetting(
+        this,
+        "runedStoneIgnoreCreative",
+        "Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -146,6 +146,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.updateBiomeColorRendering::isEnabled)
         .addMixinClasses("lib.MixinUtils_UpdateBiomeColor")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    RUNED_STONE_CREATIVE_IMMUNITY(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.runedStoneIgnoreCreative::isEnabled)
+        .addMixinClasses("tiles.MixinTileEldritchTrap_CreativeImmunity")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileEldritchTrap_CreativeImmunity.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileEldritchTrap_CreativeImmunity.java
@@ -1,0 +1,39 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import thaumcraft.common.tiles.TileEldritchTrap;
+
+@Mixin(TileEldritchTrap.class)
+public class MixinTileEldritchTrap_CreativeImmunity {
+
+    @WrapOperation(
+        method = "updateEntity",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/World;getClosestPlayer(DDDD)Lnet/minecraft/entity/player/EntityPlayer;"))
+    public EntityPlayer getClosestSurvivalPlayer(World world, double x, double y, double z, double maxDistance,
+        Operation<EntityPlayer> original) {
+        EntityPlayer closest = null;
+        double minDistanceSq = maxDistance * maxDistance;
+
+        for (final EntityPlayer player : world.playerEntities) {
+            if (player.capabilities.isCreativeMode || player.capabilities.disableDamage) continue;
+
+            final double distanceSq = player.getDistanceSq(x, y, z);
+            if (distanceSq <= minDistanceSq) {
+                closest = player;
+                minDistanceSq = distanceSq;
+            }
+        }
+
+        return closest;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - prevents players in Creative from being attacked by the outer lands traps

**What is the current behavior?** (You can also link to an open issue here)
Closes #252

**What is the new behavior (if this is a feature change)?**
The `getClosestPlayer` function will now ignore players in Creative. (It also seems to be more efficient than Mojang's implementation of the function in general.)

**Does this PR introduce a breaking change?**
No
