### PR TITLE
Prevent Jars & Banners from dropping in Creative, closes #175

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -140,8 +140,12 @@ Biome changes will correctly update the color of grass in chunks without needing
 
 Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.
 
-## Prevent Jars From Dropping When Broken In Creative
+## Prevent Blocks From Dropping When Broken In Creative
 
 **Config option:** `jarNoCreativeDrops`
 
 Prevent Warded Jars and Node in a Jar from dropping items when broken in Creative.
+
+**Config option:** `bannerNoCreativeDrops`
+
+Prevent Banners from dropping items when broken in Creative.

--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -139,3 +139,9 @@ Biome changes will correctly update the color of grass in chunks without needing
 **Config option:** `runedStoneIgnoreCreative`
 
 Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.
+
+## Prevent Jars From Dropping When Broken In Creative
+
+**Config option:** `jarNoCreativeDrops`
+
+Prevent Warded Jars and Node in a Jar from dropping items when broken in Creative.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -140,6 +140,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "runedStoneIgnoreCreative",
         "Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.");
 
+    public final ToggleSetting jarNoCreativeDrops = new ToggleSetting(
+        this,
+        "jarNoCreativeDrops",
+        "Prevent Warded Jars and Node in a Jar from dropping items when broken in Creative.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -145,6 +145,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "jarNoCreativeDrops",
         "Prevent Warded Jars and Node in a Jar from dropping items when broken in Creative.");
 
+    public final ToggleSetting bannerNoCreativeDrops = new ToggleSetting(
+        this,
+        "bannerNoCreativeDrops",
+        "Prevent Banners from dropping items when broken in Creative.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -156,6 +156,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.jarNoCreativeDrops::isEnabled)
         .addMixinClasses("blocks.MixinBlockJar_NoCreativeDrops")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    BANNER_NO_CREATIVE_DROPS(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.bannerNoCreativeDrops::isEnabled)
+        .addMixinClasses("blocks.MixinBlockWoodenDevice_NoBannerCreativeDrops")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -151,6 +151,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.runedStoneIgnoreCreative::isEnabled)
         .addMixinClasses("tiles.MixinTileEldritchTrap_CreativeImmunity")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    JAR_NO_CREATIVE_DROPS(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.jarNoCreativeDrops::isEnabled)
+        .addMixinClasses("blocks.MixinBlockJar_NoCreativeDrops")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockJar_NoCreativeDrops.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockJar_NoCreativeDrops.java
@@ -1,0 +1,26 @@
+package dev.rndmorris.salisarcana.mixins.late.blocks;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.common.blocks.BlockJar;
+
+@Mixin(BlockJar.class)
+public class MixinBlockJar_NoCreativeDrops {
+
+    @WrapWithCondition(
+        method = "onBlockHarvested",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/blocks/BlockJar;dropBlockAsItem(Lnet/minecraft/world/World;IIIII)V"))
+    public boolean requireSurvival(BlockJar instance, World world, int x, int y, int z, int meta, int fortune,
+        @Local(argsOnly = true) EntityPlayer player) {
+        return !player.capabilities.isCreativeMode;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockWoodenDevice_NoBannerCreativeDrops.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockWoodenDevice_NoBannerCreativeDrops.java
@@ -1,0 +1,26 @@
+package dev.rndmorris.salisarcana.mixins.late.blocks;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.common.blocks.BlockWoodenDevice;
+
+@Mixin(BlockWoodenDevice.class)
+public class MixinBlockWoodenDevice_NoBannerCreativeDrops {
+
+    @WrapWithCondition(
+        method = "onBlockHarvested",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/blocks/BlockWoodenDevice;dropBlockAsItem(Lnet/minecraft/world/World;IIIII)V"))
+    public boolean requireSurvival(BlockWoodenDevice instance, World world, int x, int y, int z, int meta, int fortune,
+        @Local(argsOnly = true) EntityPlayer player) {
+        return !player.capabilities.isCreativeMode;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - prevents blocks from dropping items when broken in Creative Mode

**What is the current behavior?** (You can also link to an open issue here)
Certain blocks (those which need to store data from the tile entity into the item) drop their items separate from the actual harvesting - and they don't check if the player is in Creative Mode.

**What is the new behavior (if this is a feature change)?**
These blocks no longer drop items when broken in Creative Mode

**Does this PR introduce a breaking change?**
No

**Other information**:
Closes #175