### PR TITLE
Implement `getPickBlock` for the Banner, giving the correct item when middle-clicked in Creative Mode

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -139,3 +139,9 @@ Biome changes will correctly update the color of grass in chunks without needing
 **Config option:** `runedStoneIgnoreCreative`
 
 Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.
+
+## Pick-Block Banners Accurately
+
+**Config option:** `bannerPickBlock`
+
+Causes the banner to give the actual banner item when pick-block is used, instead of giving a Crimson Cult Banner. Also fixes the icon of the banner in WAILA.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -140,6 +140,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "runedStoneIgnoreCreative",
         "Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.");
 
+    public final ToggleSetting bannerPickBlock = new ToggleSetting(
+        this,
+        "bannerPickBlock",
+        "Causes the banner to give the actual banner item when pick-block is used, instead of giving a Crimson Cult Banner. Also fixes the icon of the banner in WAILA.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -151,6 +151,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.runedStoneIgnoreCreative::isEnabled)
         .addMixinClasses("tiles.MixinTileEldritchTrap_CreativeImmunity")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    BANNER_PICK_BLOCK(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.bannerPickBlock::isEnabled)
+        .addMixinClasses("blocks.MixinBlockWoodenDevice_BannerPickBlock")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockWoodenDevice_BannerPickBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockWoodenDevice_BannerPickBlock.java
@@ -1,0 +1,42 @@
+package dev.rndmorris.salisarcana.mixins.late.blocks;
+
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import thaumcraft.common.blocks.BlockWoodenDevice;
+import thaumcraft.common.tiles.TileBanner;
+
+@Mixin(BlockWoodenDevice.class)
+public abstract class MixinBlockWoodenDevice_BannerPickBlock extends BlockContainer {
+
+    protected MixinBlockWoodenDevice_BannerPickBlock(Material materialIn) {
+        super(materialIn);
+    }
+
+    @Override
+    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
+        if (world.getBlockMetadata(x, y, z) == 8 && world.getTileEntity(x, y, z) instanceof TileBanner banner) {
+            ItemStack item = new ItemStack(this, 1, 8);
+            if (banner.getColor() >= 0) {
+                NBTTagCompound nbt = new NBTTagCompound();
+                nbt.setByte("color", banner.getColor());
+                if (banner.getAspect() != null) {
+                    nbt.setString(
+                        "aspect",
+                        banner.getAspect()
+                            .getTag());
+                }
+                item.setTagCompound(nbt);
+            }
+            return item;
+        }
+
+        return super.getPickBlock(target, world, x, y, z);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockWoodenDevice_BannerPickBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockWoodenDevice_BannerPickBlock.java
@@ -20,6 +20,7 @@ public abstract class MixinBlockWoodenDevice_BannerPickBlock extends BlockContai
     }
 
     @Override
+    @SuppressWarnings("deprecation")
     public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
         if (world.getBlockMetadata(x, y, z) == 8 && world.getTileEntity(x, y, z) instanceof TileBanner banner) {
             ItemStack item = new ItemStack(this, 1, 8);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - implements `getPickBlock` to return a banner with the right NBT data

**What is the current behavior?** (You can also link to an open issue here)
Closes #176

**What is the new behavior (if this is a feature change)?**
Pick-blocking (or looking in WAILA) onto a banner shows the right color & pattern of banner rather than a Crimson Cult Banner.

**Does this PR introduce a breaking change?**
No