### PR TITLE
Implement `getPickBlock` for the Warded Jars, giving the correct item when middle-clicked in Creative Mode

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -139,3 +139,9 @@ Biome changes will correctly update the color of grass in chunks without needing
 **Config option:** `runedStoneIgnoreCreative`
 
 Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.
+
+## Pick-Block Warded Jars Accurately
+
+**Config option:** `jarPickBlock`
+
+Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used, rather than an empty jar.

--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -144,4 +144,4 @@ Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Cr
 
 **Config option:** `jarPickBlock`
 
-Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used, rather than an empty jar.
+Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used, rather than an empty jar. Also fixes the WAILA tooltip for those blocks.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -143,7 +143,7 @@ public class ConfigBugfixes extends ConfigGroup {
     public final ToggleSetting jarPickBlock = new ToggleSetting(
         this,
         "jarPickBlock",
-        "Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used."); // TODO add comment & mixin entry.
+        "Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used.");
 
     @Nonnull
     @Override

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -143,7 +143,7 @@ public class ConfigBugfixes extends ConfigGroup {
     public final ToggleSetting jarPickBlock = new ToggleSetting(
         this,
         "jarPickBlock",
-        "Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used.");
+        "Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used. Also fixes the WAILA tooltip for those blocks.");
 
     @Nonnull
     @Override

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -140,6 +140,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "runedStoneIgnoreCreative",
         "Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.");
 
+    public final ToggleSetting jarPickBlock = new ToggleSetting(
+        this,
+        "jarPickBlock",
+        "Causes Warded Jars and Node in a Jar to create an item with the current contents of the jar when pick-block is used."); // TODO add comment & mixin entry.
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -151,6 +151,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.runedStoneIgnoreCreative::isEnabled)
         .addMixinClasses("tiles.MixinTileEldritchTrap_CreativeImmunity")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    JAR_PICK_BLOCK(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.jarPickBlock::isEnabled)
+        .addMixinClasses("blocks.MixinBlockJar_PickBlock")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockJar_PickBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockJar_PickBlock.java
@@ -1,0 +1,33 @@
+package dev.rndmorris.salisarcana.mixins.late.blocks;
+
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.material.Material;
+import net.minecraft.item.ItemStack;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import thaumcraft.common.blocks.BlockJar;
+
+import java.util.ArrayList;
+
+@Mixin(BlockJar.class)
+public abstract class MixinBlockJar_PickBlock extends BlockContainer {
+    @Shadow(remap = false)
+    public abstract ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune);
+
+    protected MixinBlockJar_PickBlock(Material p_i45386_1_) {
+        super(p_i45386_1_);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
+        final var drop = this.getDrops(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+        if(drop.size() == 1) {
+            return drop.get(0);
+        } else {
+            return super.getPickBlock(target, world, x, y, z);
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockJar_PickBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockJar_PickBlock.java
@@ -1,18 +1,21 @@
 package dev.rndmorris.salisarcana.mixins.late.blocks;
 
+import java.util.ArrayList;
+
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.World;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import thaumcraft.common.blocks.BlockJar;
 
-import java.util.ArrayList;
+import thaumcraft.common.blocks.BlockJar;
 
 @Mixin(BlockJar.class)
 public abstract class MixinBlockJar_PickBlock extends BlockContainer {
+
     @Shadow(remap = false)
     public abstract ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune);
 
@@ -24,7 +27,7 @@ public abstract class MixinBlockJar_PickBlock extends BlockContainer {
     @SuppressWarnings("deprecation")
     public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z) {
         final var drop = this.getDrops(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
-        if(drop.size() == 1) {
+        if (drop.size() == 1) {
             return drop.get(0);
         } else {
             return super.getPickBlock(target, world, x, y, z);


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - improves jar pick-block behavior

**What is the current behavior?** (You can also link to an open issue here)
Pick-blocking a jar returns just the base block - an empty jar, a Brain in a Jar, or a zero-aspect Node in a Jar.

**What is the new behavior (if this is a feature change)?**
Pick-block now returns the actual block (as defined by the block dropped when you break the jar.)

**Does this PR introduce a breaking change?**
No