### PR TITLE
Make upgraded foci with a different casting vis cost than the base focus spend the correct cost.

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -139,3 +139,9 @@ Biome changes will correctly update the color of grass in chunks without needing
 **Config option:** `runedStoneIgnoreCreative`
 
 Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.
+
+## Spend the Correct Vis Cost of Upgraded Foci
+
+**Config option:** `upgradedFocusVisCost`
+
+Makes certain upgraded foci (ex. Wand Focus: Fire with Fireball upgrade) spend the upgraded vis cost rather than the default.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -140,6 +140,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "runedStoneIgnoreCreative",
         "Runed Stone (shock traps in Outer Lands) will not attempt to shock players in Creative Mode.");
 
+    public final ToggleSetting upgradedFocusVisCost = new ToggleSetting(
+        this,
+        "upgradedFocusVisCost",
+        "Makes certain upgraded foci (ex. Wand Focus: Fire with Fireball upgrade) spend the upgraded vis cost rather than the default.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -151,6 +151,11 @@ public enum Mixins {
         .setApplyIf(SalisConfig.bugfixes.runedStoneIgnoreCreative::isEnabled)
         .addMixinClasses("tiles.MixinTileEldritchTrap_CreativeImmunity")
         .addTargetedMod(TargetedMod.THAUMCRAFT)),
+    WAND_FOCUS_LEVEL_PATCH(new Builder().setPhase(Phase.LATE)
+        .setSide(Side.BOTH)
+        .setApplyIf(SalisConfig.bugfixes.upgradedFocusVisCost::isEnabled)
+        .addMixinClasses("api.MixinItemFocusBasic_WandUpgradeLevel")
+        .addTargetedMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new Builder().setPhase(Phase.LATE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/api/MixinItemFocusBasic_WandUpgradeLevel.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/api/MixinItemFocusBasic_WandUpgradeLevel.java
@@ -1,0 +1,24 @@
+package dev.rndmorris.salisarcana.mixins.late.api;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import thaumcraft.api.wands.ItemFocusBasic;
+import thaumcraft.common.items.wands.ItemWandCasting;
+
+@Mixin(ItemFocusBasic.class)
+public class MixinItemFocusBasic_WandUpgradeLevel {
+
+    @WrapMethod(method = "getAppliedUpgrades", remap = false)
+    public short[] unwrapWandItem(ItemStack focusStack, Operation<short[]> original) {
+        if (focusStack.getItem() instanceof ItemWandCasting wand) {
+            focusStack = wand.getFocusItem(focusStack);
+        }
+
+        return original.call(focusStack);
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - causes upgraded foci to spend the correct vis cost.

**What is the current behavior?** (You can also link to an open issue here)
Closes #269

**What is the new behavior (if this is a feature change)?**
Foci will check the focus item in order to determine present upgrades instead of checking the wand item (which cannot have focus upgrade NBT tags.)

**Does this PR introduce a breaking change?**
No