### PR TITLE
Allow "Single Wand Replacement" to work when the "missing research error in Arcane Workbench" feature is enabled.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/KnowItAll.java
@@ -1,5 +1,7 @@
 package dev.rndmorris.salisarcana.lib;
 
+import javax.annotation.Nullable;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.util.ChunkCoordinates;
 import net.minecraft.util.DamageSource;
@@ -16,7 +18,7 @@ import thaumcraft.common.lib.research.ResearchManager;
 
 public class KnowItAll extends EntityPlayer {
 
-    private static KnowItAll knowItAll = null;
+    private static @Nullable KnowItAll knowItAll = null;
     private static final String USERNAME = SalisArcana.MODID + ":KnowItAll";
     public static final EventCollector EVENT_COLLECTOR = new EventCollector();
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
@@ -9,7 +9,6 @@ import net.minecraft.util.StatCollector;
 
 import org.lwjgl.opengl.GL11;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
@@ -23,13 +22,9 @@ import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.client.gui.GuiArcaneWorkbench;
 import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.lib.research.ResearchManager;
-import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(GuiArcaneWorkbench.class)
 public abstract class MixinGuiArcaneWorkbench_MissingResearch extends GuiContainer {
-
-    @Shadow(remap = false)
-    private TileArcaneWorkbench tileEntity;
 
     public MixinGuiArcaneWorkbench_MissingResearch(Container p_i1072_1_) {
         super(p_i1072_1_);
@@ -42,9 +37,9 @@ public abstract class MixinGuiArcaneWorkbench_MissingResearch extends GuiContain
             target = "Lthaumcraft/common/lib/crafting/ThaumcraftCraftingManager;findMatchingArcaneRecipe(Lnet/minecraft/inventory/IInventory;Lnet/minecraft/entity/player/EntityPlayer;)Lnet/minecraft/item/ItemStack;",
             remap = false))
     public ItemStack captureRecipe(IInventory awb, EntityPlayer player, Operation<ItemStack> original,
-        @Local(name = "var5") int centerX, @Local(name = "var6") int topY) {
-        final var wand = this.tileEntity.getStackInSlot(10);
-        if (wand == null || wand.getItem() == null && !(wand.getItem() instanceof ItemWandCasting)) return null;
+        @Local(name = "var5") int centerX, @Local(name = "var6") int topY, @Local ItemWandCasting wand) {
+
+        if (wand == null) return null;
 
         final var recipe = CraftingHelper.INSTANCE.findArcaneRecipe(awb, KnowItAll.getInstance());
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - the "missing research error" feature was preventing the "single wand replacement" GUI changes from activating.

**What is the current behavior?** (You can also link to an open issue here)
See above - when `notifyMissingResearchWorkbench` was set to true, the Arcane Workbench GUI wouldn't show the vis cost & the research requirements of the recipe unless there was a wand in the wand slot.

**What is the new behavior (if this is a feature change)?**
The mix-ins now target more logical injection points and use less restrictive logic in order to work together.

**Does this PR introduce a breaking change?**
No

**Other information**:
Tested functional in dev & obfuscated environments.

New functionality:
- Trying to swap wand parts without the required research will show the error text in the workbench when there's no wand in the wand slot.
- Trying to swap wand parts without a wand in the wand slot will show the vis price of the swap. (even when `notifyMissingResearchWorkbench` is turned on.)