### PR TITLE
Prevent ctrl-clicking research in Creative Mode from giving Research Notes when holding Scribing Tools & Paper

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiResearchBrowser_Creative_Scroll.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiResearchBrowser_Creative_Scroll.java
@@ -183,16 +183,11 @@ public abstract class MixinGuiResearchBrowser_Creative_Scroll extends GuiScreen 
         }
     }
 
-    @Inject(
-        method = "updateResearch",
-        at = @At(
-            value = "INVOKE",
-            target = "Lthaumcraft/api/research/ResearchCategories;getResearchList(Ljava/lang/String;)Lthaumcraft/api/research/ResearchCategoryList;",
-            ordinal = 0),
-        remap = false)
+    @Inject(method = "updateResearch", at = @At("TAIL"), remap = false)
     private void creativePaperCheck(CallbackInfo ci) {
-        this.hasScribestuff = this.mc.thePlayer.capabilities.isCreativeMode && sa$opEnabled
-            && !Keyboard.isKeyDown(Keyboard.KEY_LCONTROL);
+        if (this.mc.thePlayer.capabilities.isCreativeMode && sa$opEnabled) {
+            this.hasScribestuff = !Keyboard.isKeyDown(Keyboard.KEY_LCONTROL);
+        }
     }
 
 }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - fixes unintended behavior of the OP Thaumonomicon feature

**What is the current behavior?** (You can also link to an open issue here)
Ctrl-clicking research in the Thaumonomicon while in Creative Mode and holding Scribing Tools & Paper will give you a research note in addition to completing the research.

**What is the new behavior (if this is a feature change)?**
Ctrl-clicking research in Creative will never give you a research note, not even if you have the supplies.

**Does this PR introduce a breaking change?**
No

**Other information**:
PR #243 fixed this issue most of the way - before that PR, ctrl-clicking research would always give you a research note. The problem lies in the fact that the standard check for scribing tools and paper would override the `false` value set by the mixin when ctrl is held. Changing the mixin target to `TAIL` (so the mixin overrides the standard check) and making it only override the value if the Creative Mode conditions are met fixed this issue.