### PR TITLE
GTNH TC Wands Compat

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -45,9 +45,21 @@ dependencies {
     compileOnly("maven.modrinth:bugtorch:1.2.13")
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))
     compileOnly(rfg.deobf("curse.maven:undergroundbiomesconstructs-72744:2304497"))
+    compileOnly("com.github.GTNewHorizons:GTNH-TC-Wands:1.4.5:dev")
 
     /* Patched TC4 addons */
     compileOnly("com.github.GTNewHorizons:ThaumicTinkerer:2.6.2:dev")
     compileOnly(rfg.deobf("curse.maven:automagy-222153:2285272"))
 
+    project.getConfigurations()
+
+    // Required for testing GTNH-TC-Wands
+    //  .configureEach(c -> {
+    //      final DependencySubstitutions ds = c.getResolutionStrategy()
+    //          .getDependencySubstitution()
+    //      ds.substitute(ds.module("com.github.GTNewHorizons:Baubles"))
+    //          .using(ds.module("com.github.GTNewHorizons:Baubles-Expanded:2.1.8-GTNH"))
+    //          .withClassifier("dev")
+    //          .because("Baubles-Expanded replaces Baubles")
+    //  })
 }

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,7 +40,7 @@ dependencies {
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
     // devOnlyNonPublishable(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
-    runtimeOnlyNonPublishable(rfg.deobf"curse.maven:tcneiplugin-225095:2241913")
+    runtimeOnlyNonPublishable(rfg.deobf("curse.maven:thaumcraft-nei-plugin-225095:2241913"))
     compileOnly("curse.maven:hodgepodge-688899:6039713")
     compileOnly("maven.modrinth:bugtorch:1.2.13")
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))

--- a/src/main/java/dev/rndmorris/salisarcana/SalisArcana.java
+++ b/src/main/java/dev/rndmorris/salisarcana/SalisArcana.java
@@ -19,7 +19,7 @@ import cpw.mods.fml.relauncher.Side;
     version = Tags.VERSION,
     name = "Salis Arcana",
     acceptedMinecraftVersions = "[1.7.10]",
-    dependencies = "required-after:Thaumcraft;after:tc4tweak@[1.5.32,)")
+    dependencies = "required-after:Thaumcraft;after:tc4tweak@[1.5.32,);after:gtnhtcwands")
 public class SalisArcana {
 
     public static final String MODID = "salisarcana";

--- a/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
@@ -10,6 +10,11 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagByte;
 import net.minecraftforge.oredict.OreDictionary;
 
+import com.gtnewhorizons.tcwands.api.TCWandAPI;
+import com.gtnewhorizons.tcwands.api.wandinfo.WandDetails;
+import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
+
+import dev.rndmorris.salisarcana.common.compat.GTNHTCWandsCompat;
 import dev.rndmorris.salisarcana.common.item.PlaceholderItem;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.config.settings.CustomResearchSetting;
@@ -162,6 +167,9 @@ public class CustomResearch {
         final var scepterList = new ArrayList<IArcaneRecipe>();
         final var staffList = new ArrayList<IArcaneRecipe>();
 
+        final ItemStack[] screw = { null }; // Needs to be like this to work in the lambda
+        final ItemStack[] conductor = { null };
+
         WandHelper.allVanillaRods()
             .stream()
             .filter(
@@ -179,13 +187,39 @@ public class CustomResearch {
                     wand.setRod(outputStaff, wandRod);
 
                     final var staffCost = WandType.STAFF.getCraftingVisCost(baseCap, wandRod);
-                    staffList.add(
-                        new ShapelessArcaneRecipe(
-                            null,
-                            outputStaff,
-                            AspectHelper.primalList(staffCost),
-                            staffItem,
-                            rodItem));
+
+                    if (SalisConfig.modCompat.gtnhWands.coreSwapMaterials.isEnabled()) {
+                        AbstractWandWrapper wrapper = GTNHTCWandsCompat
+                            .getWandWrapper(wandRod, WandType.getWandType(wandItem));
+                        if (wrapper == null) wrapper = TCWandAPI.getWandWrappers()
+                            .get(0);
+                        WandDetails props = wrapper.getDetails();
+                        screw[0] = OreDictionary.getOres(props.getScrew())
+                            .get(0);
+                        conductor[0] = props.getConductor();
+
+                        staffList.add(
+                            new ShapelessArcaneRecipe(
+                                null,
+                                outputStaff,
+                                AspectHelper.primalList(staffCost),
+                                staffItem,
+                                rodItem,
+                                screw[0],
+                                screw[0],
+                                screw[0],
+                                screw[0],
+                                conductor[0],
+                                conductor[0]));
+                    } else {
+                        staffList.add(
+                            new ShapelessArcaneRecipe(
+                                null,
+                                outputStaff,
+                                AspectHelper.primalList(staffCost),
+                                staffItem,
+                                rodItem));
+                    }
                 } else {
                     if (wandRod == baseWandRod) {
                         return;
@@ -194,24 +228,61 @@ public class CustomResearch {
                     final var outputScepter = scepterItem.copy();
                     wand.setRod(outputWand, wandRod);
                     wand.setRod(outputScepter, wandRod);
-
                     final var wandCost = WandType.WAND.getCraftingVisCost(baseCap, wandRod);
-                    wandList.add(
-                        new ShapelessArcaneRecipe(
-                            null,
-                            outputWand,
-                            AspectHelper.primalList(wandCost),
-                            wandItem,
-                            rodItem));
-
                     final var scepterCost = WandType.SCEPTER.getCraftingVisCost(baseCap, wandRod);
-                    scepterList.add(
-                        new ShapelessArcaneRecipe(
-                            null,
-                            outputScepter,
-                            AspectHelper.primalList(scepterCost),
-                            scepterItem,
-                            rodItem));
+
+                    if (SalisConfig.modCompat.gtnhWands.coreSwapMaterials.isEnabled()) {
+                        AbstractWandWrapper wrapper = GTNHTCWandsCompat
+                            .getWandWrapper(wandRod, WandType.getWandType(wandItem));
+                        if (wrapper == null) wrapper = TCWandAPI.getWandWrappers()
+                            .get(0);
+                        WandDetails props = wrapper.getDetails();
+                        screw[0] = OreDictionary.getOres(props.getScrew())
+                            .get(0);
+                        conductor[0] = props.getConductor();
+
+                        wandList.add(
+                            new ShapelessArcaneRecipe(
+                                null,
+                                outputWand,
+                                AspectHelper.primalList(wandCost),
+                                wandItem,
+                                rodItem,
+                                screw[0],
+                                screw[0],
+                                screw[0],
+                                screw[0],
+                                conductor[0],
+                                conductor[0]));
+
+                        scepterList.add(
+                            new ShapelessArcaneRecipe(
+                                null,
+                                outputScepter,
+                                AspectHelper.primalList(scepterCost),
+                                scepterItem,
+                                rodItem,
+                                screw[0],
+                                screw[0],
+                                conductor[0],
+                                conductor[0]));
+                    } else {
+                        wandList.add(
+                            new ShapelessArcaneRecipe(
+                                null,
+                                outputWand,
+                                AspectHelper.primalList(wandCost),
+                                wandItem,
+                                rodItem));
+
+                        scepterList.add(
+                            new ShapelessArcaneRecipe(
+                                null,
+                                outputScepter,
+                                AspectHelper.primalList(scepterCost),
+                                scepterItem,
+                                rodItem));
+                    }
                 }
             });
 

--- a/src/main/java/dev/rndmorris/salisarcana/common/compat/GTNHTCWandsCompat.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/compat/GTNHTCWandsCompat.java
@@ -1,0 +1,47 @@
+package dev.rndmorris.salisarcana.common.compat;
+
+import com.gtnewhorizons.tcwands.api.TCWandAPI;
+import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.SceptreWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.StaffSceptreWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.StaffWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.WandWrapper;
+
+import dev.rndmorris.salisarcana.lib.WandType;
+import thaumcraft.api.wands.WandCap;
+import thaumcraft.api.wands.WandRod;
+
+public class GTNHTCWandsCompat {
+
+    public static AbstractWandWrapper getWandWrapper(WandRod rod, WandType type) {
+        for (AbstractWandWrapper wrapper : TCWandAPI.getWandWrappers()) {
+            if (!wrapper.getRodName()
+                .equals(rod.getTag())) continue;
+
+            switch (type) {
+                case WAND -> {
+                    if (wrapper instanceof WandWrapper) return wrapper;
+                }
+                case SCEPTER -> {
+                    if (wrapper instanceof SceptreWrapper) return wrapper;
+                }
+                case STAFF -> {
+                    if (wrapper instanceof StaffWrapper) return wrapper;
+                }
+                case STAFFTER -> {
+                    if (wrapper instanceof StaffSceptreWrapper) return wrapper;
+                }
+            }
+        }
+        return null;
+    }
+
+    public static CapWrapper getCapWrapper(WandCap cap) {
+        for (CapWrapper wrapper : TCWandAPI.getCaps()) {
+            if (wrapper.getName()
+                .equals(cap.getTag())) return wrapper;
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigModCompat.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigModCompat.java
@@ -5,11 +5,13 @@ import javax.annotation.Nonnull;
 import dev.rndmorris.salisarcana.config.ConfigGroup;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.config.settings.ToggleSetting;
+import dev.rndmorris.salisarcana.config.settings.compat.GTNHTCWandsCompatSettings;
 import dev.rndmorris.salisarcana.config.settings.compat.UBCCompatSettings;
 
 public class ConfigModCompat extends ConfigGroup {
 
     public final UBCCompatSettings undergroundBiomes = new UBCCompatSettings(this);
+    public final GTNHTCWandsCompatSettings gtnhWands = new GTNHTCWandsCompatSettings(this);
 
     public final ToggleSetting tc4tweakScrollPages = new ToggleSetting(
         SalisConfig.features.nomiconScrollwheelEnabled,

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/compat/GTNHTCWandsCompatSettings.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/compat/GTNHTCWandsCompatSettings.java
@@ -1,0 +1,18 @@
+package dev.rndmorris.salisarcana.config.settings.compat;
+
+import dev.rndmorris.salisarcana.config.IEnabler;
+import dev.rndmorris.salisarcana.config.settings.ToggleSetting;
+
+public class GTNHTCWandsCompatSettings extends BaseCompatSetting {
+
+    public final ToggleSetting coreSwapMaterials = new ToggleSetting(
+        this,
+        "coreSwapMaterials",
+        "Require screws and conductors to swap wand/staff cores.");
+
+    public final ToggleSetting cost = new ToggleSetting(this, "cost", "Use the increased vis costs from GTNHTCWands.");
+
+    public GTNHTCWandsCompatSettings(IEnabler dependency) {
+        super(dependency, "gtnhtcwands");
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/WandType.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/WandType.java
@@ -5,6 +5,11 @@ import javax.annotation.Nullable;
 
 import net.minecraft.item.ItemStack;
 
+import com.gtnewhorizons.tcwands.api.wrappers.AbstractWandWrapper;
+import com.gtnewhorizons.tcwands.api.wrappers.CapWrapper;
+
+import dev.rndmorris.salisarcana.common.compat.GTNHTCWandsCompat;
+import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.api.wands.StaffRod;
 import thaumcraft.api.wands.WandCap;
 import thaumcraft.api.wands.WandRod;
@@ -15,12 +20,16 @@ public enum WandType {
     UNKNOWN,
     WAND,
     SCEPTER,
-    STAFF;
+    STAFF,
+    STAFFTER;
 
     public static @Nonnull WandType getWandType(@Nullable ItemStack itemStack) {
         final var wandInstance = WandHelper.getWandItem(itemStack);
         if (wandInstance == null) {
             return UNKNOWN;
+        }
+        if (wandInstance.isSceptre(itemStack) && wandInstance.isStaff(itemStack)) {
+            return STAFFTER;
         }
         if (wandInstance.isSceptre(itemStack)) {
             return SCEPTER;
@@ -36,21 +45,30 @@ public enum WandType {
             return -1;
         }
 
+        if (SalisConfig.modCompat.gtnhWands.cost.isEnabled()) {
+            AbstractWandWrapper wandWrapper = GTNHTCWandsCompat.getWandWrapper(forRod, this);
+            CapWrapper capWrapper = GTNHTCWandsCompat.getCapWrapper(forCap);
+            if (wandWrapper == null || capWrapper == null) return -1;
+
+            return wandWrapper.getRecipeCost(capWrapper);
+        }
+
         if (forCap == ConfigItems.WAND_CAP_IRON && forRod == ConfigItems.WAND_ROD_WOOD) {
             return 0;
         }
 
         return switch (this) {
             case WAND, STAFF -> forCap.getCraftCost() * forRod.getCraftCost();
-            case SCEPTER -> (int) ((float) (forCap.getCraftCost() * forRod.getCraftCost()) * 1.5F);
+            case SCEPTER, STAFFTER -> (int) ((float) (forCap.getCraftCost() * forRod.getCraftCost()) * 1.5F);
             default -> -1;
         };
+
     }
 
     public int getRequiredCaps() {
         return switch (this) {
             case WAND, STAFF -> 2;
-            case SCEPTER -> 3;
+            case SCEPTER, STAFFTER -> 3;
             default -> -1;
         };
     }
@@ -58,7 +76,7 @@ public enum WandType {
     public <R extends WandRod> boolean isCoreSuitable(@Nullable R coreType) {
         return switch (this) {
             case WAND, SCEPTER -> coreType instanceof WandRod && !(coreType instanceof StaffRod);
-            case STAFF -> coreType instanceof StaffRod;
+            case STAFF, STAFFTER -> coreType instanceof StaffRod;
             default -> false;
         };
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
GTNH TC Wands Compat

**What is the current behavior?** (You can also link to an open issue here)
https://github.com/rndmorris/Salis-Arcana/issues/265

**What is the new behavior (if this is a feature change)?**
Screws and conductors are required to upgrade wand cores.
The method from GTNH TC Wands is used to calculate the vis cost instead of base Thaum's.
The Thaumonomicon entries show extra required items and updated vis costs.
Extra items and updated vis costs have relevant configs.
A preexisting bug where staffters could only be upgraded with wand cores and not staff cores has been fixed by adding a STAFFTER enum to WandType.
The thaumcraft-nei-plugin dep is renamed to not cause problems with GTNH TC Wands because it drags in everything on and off the planet transitively.
Functionality without GTW should be unchanged.

**Does this PR introduce a breaking change?**
I don't think so.

**Other information**:
The logic for the changes to the research inside the lambda is a bit rough and could probably be improved, but I'm not sure how it would be.
Tested as thoroughly as I and @Nikolay-Sitnikov could think to. See conversation in GT:NH Discord: https://discord.com/channels/181078474394566657/603348502637969419/1392856587047014512.

One example:
<img width="903" height="696" alt="image" src="https://github.com/user-attachments/assets/e0245208-16a9-4888-af8f-b15a0151752c" />

Updated 'nomicon (carrots are filler used by GTW when NH's coremod isn't loaded):
<img width="1511" height="1114" alt="image" src="https://github.com/user-attachments/assets/cf863503-7ee7-4517-8634-52a9282b539c" />
