### PR TITLE
add recipes to empty phials/jars

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -309,6 +309,9 @@ Add a recipe to convert flesh blocks back into rotten flesh.
 ## Config option: `crystalClusterUncrafting`
 Add crafting recipes to convert crystal cluster blocks back into primal shards. Does not work for mixed crystal clusters.
 
+## Config Option: `addEmptyPhialJarRecipes`
+Adds crafting recipes to convert jars and phials of essentia into their empty variants.
+
 # Enhancements - Wand Component Replacement
 
 ## Config option: `enableReplaceWandCapsRecipe`

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -21,6 +21,7 @@ import cpw.mods.fml.common.registry.GameRegistry;
 import dev.rndmorris.salisarcana.api.OreDict;
 import dev.rndmorris.salisarcana.common.blocks.CustomBlocks;
 import dev.rndmorris.salisarcana.config.SalisConfig;
+import dev.rndmorris.salisarcana.lib.recipe.EmptyJarRecipe;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.api.crafting.ShapedArcaneRecipe;
@@ -85,9 +86,8 @@ public class CustomRecipes {
             GameRegistry.addShapelessRecipe(
                 new ItemStack(ConfigItems.itemEssence, 1),
                 new ItemStack(ConfigItems.itemEssence, 1, OreDictionary.WILDCARD_VALUE));
-            GameRegistry.addShapelessRecipe(
-                new ItemStack(ConfigBlocks.blockJar, 1),
-                new ItemStack(ConfigItems.itemJarFilled, 1, OreDictionary.WILDCARD_VALUE));
+
+            GameRegistry.addRecipe(new EmptyJarRecipe());
         }
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -80,6 +80,11 @@ public class CustomRecipes {
                     new ItemStack(ConfigBlocks.blockCrystal, 1, metadata));
             }
         }
+
+        if (features.addEmptyPhialJarRecipes.isEnabled()) {
+            GameRegistry.addShapelessRecipe( new ItemStack(ConfigItems.itemEssence, 1), new ItemStack(ConfigItems.itemEssence, 1, OreDictionary.WILDCARD_VALUE));
+            GameRegistry.addShapelessRecipe(new ItemStack(ConfigBlocks.blockJar, 1), new ItemStack(ConfigItems.itemJarFilled, 1, OreDictionary.WILDCARD_VALUE));
+        }
     }
 
     public static void registerRecipesPostInit() {

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -82,8 +82,12 @@ public class CustomRecipes {
         }
 
         if (features.addEmptyPhialJarRecipes.isEnabled()) {
-            GameRegistry.addShapelessRecipe( new ItemStack(ConfigItems.itemEssence, 1), new ItemStack(ConfigItems.itemEssence, 1, OreDictionary.WILDCARD_VALUE));
-            GameRegistry.addShapelessRecipe(new ItemStack(ConfigBlocks.blockJar, 1), new ItemStack(ConfigItems.itemJarFilled, 1, OreDictionary.WILDCARD_VALUE));
+            GameRegistry.addShapelessRecipe(
+                new ItemStack(ConfigItems.itemEssence, 1),
+                new ItemStack(ConfigItems.itemEssence, 1, OreDictionary.WILDCARD_VALUE));
+            GameRegistry.addShapelessRecipe(
+                new ItemStack(ConfigBlocks.blockJar, 1),
+                new ItemStack(ConfigItems.itemJarFilled, 1, OreDictionary.WILDCARD_VALUE));
         }
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -85,7 +85,7 @@ public class CustomRecipes {
         if (features.addEmptyPhialJarRecipes.isEnabled()) {
             GameRegistry.addShapelessRecipe(
                 new ItemStack(ConfigItems.itemEssence, 1),
-                new ItemStack(ConfigItems.itemEssence, 1, OreDictionary.WILDCARD_VALUE));
+                new ItemStack(ConfigItems.itemEssence, 1, 1));
 
             GameRegistry.addRecipe(new EmptyJarRecipe());
         }

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -444,6 +444,12 @@ public class ConfigFeatures extends ConfigGroup {
         "deadlyGazeMobCheck",
         "If enabled, the Deadly Gaze effect will only affect mobs that are not invulnerable or immune to wither");
 
+
+    public final ToggleSetting addEmptyPhialJarRecipes = new ToggleSetting(
+        this, "addEmptyPhialJarRecipes",
+        "Adds crafting recipes to empty a phial or jar of essentia."
+    );
+
     public boolean singleWandReplacementEnabled() {
         return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())
             && SalisConfig.bugfixes.arcaneWorkbenchGhostItemFix.isEnabled()

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -444,11 +444,10 @@ public class ConfigFeatures extends ConfigGroup {
         "deadlyGazeMobCheck",
         "If enabled, the Deadly Gaze effect will only affect mobs that are not invulnerable or immune to wither");
 
-
     public final ToggleSetting addEmptyPhialJarRecipes = new ToggleSetting(
-        this, "addEmptyPhialJarRecipes",
-        "Adds crafting recipes to empty a phial or jar of essentia."
-    );
+        this,
+        "addEmptyPhialJarRecipes",
+        "Adds crafting recipes to empty a phial or jar of essentia.");
 
     public boolean singleWandReplacementEnabled() {
         return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())

--- a/src/main/java/dev/rndmorris/salisarcana/lib/recipe/EmptyJarRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/recipe/EmptyJarRecipe.java
@@ -1,0 +1,70 @@
+package dev.rndmorris.salisarcana.lib.recipe;
+
+import java.util.ArrayList;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.world.World;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.common.blocks.ItemJarFilled;
+import thaumcraft.common.config.ConfigBlocks;
+
+public class EmptyJarRecipe implements IRecipe {
+
+    @Override
+    public boolean matches(InventoryCrafting inventory, World world) {
+        ArrayList<ItemStack> stacks = getStacks(inventory);
+        if (stacks.size() != 1) {
+            return false; // We only allow one item in the crafting grid
+        }
+
+        ItemStack itemStack = stacks.get(0);
+        return itemStack.getItem() instanceof ItemJarFilled;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting inventory) {
+        ArrayList<ItemStack> stacks = getStacks(inventory);
+        ItemStack stack = stacks.get(0);
+        if (stack.getItem() instanceof ItemJarFilled jar) {
+            Aspect filter = jar.getFilter(stack);
+            ItemStack emptyJar;
+            if (filter != null) {
+                emptyJar = new ItemStack(jar, 1, stack.getItemDamage());
+                // If the jar has a filter, we return an empty jar with the filter intact
+                emptyJar.setTagCompound(new NBTTagCompound());
+                emptyJar.getTagCompound()
+                    .setString("AspectFilter", filter.getTag());
+            } else {
+                // If the jar doesn't have a filter, we return a warded jar instead of jar of essentia
+                emptyJar = new ItemStack(ConfigBlocks.blockJar, 1, stack.getItemDamage());
+            }
+            return emptyJar;
+        }
+        return null;
+    }
+
+    @Override
+    public int getRecipeSize() {
+        return 1;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput() {
+        return null;
+    }
+
+    private ArrayList<ItemStack> getStacks(InventoryCrafting inventory) {
+        ArrayList<ItemStack> stacks = new ArrayList<>();
+        for (int i = 0; i < inventory.getSizeInventory(); i++) {
+            ItemStack stack = inventory.getStackInSlot(i);
+            if (stack != null && stack.getItem() != null) {
+                stacks.add(stack);
+            }
+        }
+        return stacks;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

**What is the current behavior?** (You can also link to an open issue here)
#292 

**What is the new behavior (if this is a feature change)?**
adds shapeless recipes to empty essentia phials/jars

**Does this PR introduce a breaking change?**
no

**Other information**:
closes #292