### PR TITLE
Fix `MultiContainer`s retaining old `ContainerArcaneWorkbench` instances on the client

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_MultiContainer.java
@@ -9,6 +9,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
@@ -43,6 +44,13 @@ public abstract class MixinContainerArcaneWorkbench_MultiContainer extends Conta
             remap = false))
     public void removeEventHandler(TileArcaneWorkbench instance, Container value, Operation<Void> original) {
         original.call(instance, MultiContainer.removeContainer(instance.eventHandler, this));
+    }
+
+    @ModifyExpressionValue(
+        method = "onContainerClosed",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/world/World;isRemote:Z"))
+    public boolean removeEventHanderOnClientToo(boolean original) {
+        return false;
     }
 
     @WrapOperation(


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - fixes lag caused by a buildup of old `Container`s checking for recipes. (Specifically, the client-side `MultiContainer` wouldn't ever get any `Container`s removed from it.)

**What is the current behavior?** (You can also link to an open issue here)
Closes #293 

**What is the new behavior (if this is a feature change)?**
The bug is fixed, and the container-removing code gets called on both sides of Minecraft.

**Does this PR introduce a breaking change?**
No

**Other information**:
This PR was surprisingly easy - I don't know how I missed that issue when I was writing the code.