### PR TITLE
Prevent the block bounds of Abandoned Crates & Old Urns from changing

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -179,3 +179,9 @@ Causes Warded Jars and Node in a Jar to create an item with the current contents
 **Config option:** `correctItemInsertion`
 
 Thaumcraft will correctly insect items into inventories - prevents double-counting slots when testing for space and allows insertion of items into an empty slot of the other side of a double chest.
+
+## Ancient Crate & Old Urn Hitboxes
+
+**Config option:** `lootBlockHitbox`
+
+Correctly sets the hitboxes of the Old Urn & Abandoned Crate, preventing a bug where you can phase through the blocks while mining them.

--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -180,7 +180,7 @@ Causes Warded Jars and Node in a Jar to create an item with the current contents
 
 Thaumcraft will correctly insect items into inventories - prevents double-counting slots when testing for space and allows insertion of items into an empty slot of the other side of a double chest.
 
-## Ancient Crate & Old Urn Hitboxes
+## Abandoned Crates & Old Urn Hitboxes
 
 **Config option:** `lootBlockHitbox`
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -175,6 +175,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "correctItemInsertion",
         "Thaumcraft will correctly insect items into inventories - prevents double-counting slots when testing for space and allows insertion of items into an empty slot of the other side of a double chest.");
 
+    public final ToggleSetting lootBlockHitbox = new ToggleSetting(
+        this,
+        "lootBlockHitbox",
+        "Correctly sets the hitboxes of the Old Urn & Abandoned Crate, preventing a bug where you can phase through the blocks while mining them.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -142,6 +142,11 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.correctItemInsertion)
         .addCommonMixins("lib.MixinInventoryUtils_AmountCounting")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    LOOT_BLOCK_HITBOX(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.lootBlockHitbox)
+        .addCommonMixins("blocks.MixinBlockLoot_SetHitbox")
+        .addClientMixins("client.renderers.block.MixinBlockLootRenderer_ConserveBlockBounds")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockLoot_SetHitbox.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockLoot_SetHitbox.java
@@ -1,0 +1,51 @@
+package dev.rndmorris.salisarcana.mixins.late.blocks;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.client.renderers.block.BlockRenderer;
+import thaumcraft.common.blocks.BlockLoot;
+
+@Mixin(BlockLoot.class)
+public class MixinBlockLoot_SetHitbox {
+
+    @WrapOperation(
+        method = "<init>",
+        at = @At(value = "INVOKE", target = "Lthaumcraft/common/blocks/BlockLoot;setBlockBounds(FFFFFF)V"))
+    public void setBlockBounds(BlockLoot instance, float minX, float minY, float minZ, float maxX, float maxY,
+        float maxZ, Operation<Void> original, @Local(argsOnly = true) int renderType) {
+        if (renderType == 1) {
+            original.call(
+                instance,
+                BlockRenderer.W2,
+                BlockRenderer.W1,
+                BlockRenderer.W2,
+                BlockRenderer.W14,
+                BlockRenderer.W13,
+                BlockRenderer.W14);
+        } else {
+            original.call(
+                instance,
+                BlockRenderer.W1,
+                0.0F,
+                BlockRenderer.W1,
+                BlockRenderer.W15,
+                BlockRenderer.W14,
+                BlockRenderer.W15);
+        }
+    }
+
+    @WrapOperation(
+        method = "getSelectedBoundingBoxFromPool",
+        at = @At(value = "INVOKE", target = "Lthaumcraft/common/blocks/BlockLoot;setBlockBounds(FFFFFF)V"))
+    public void ignoreFurtherChanges(BlockLoot instance, float minX, float minY, float minZ, float maxX, float maxY,
+        float maxZ, Operation<Void> original) {
+        // The block bounds are being set in the constructor, and they should never need to change again.
+        // This injection technically isn't necessary, but it does remove extra useless operations & makes any related
+        // issues a lot more obvious.
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/client/renderers/block/MixinBlockLootRenderer_ConserveBlockBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/client/renderers/block/MixinBlockLootRenderer_ConserveBlockBounds.java
@@ -1,0 +1,35 @@
+package dev.rndmorris.salisarcana.mixins.late.client.renderers.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.client.renderers.block.BlockLootCrateRenderer;
+import thaumcraft.client.renderers.block.BlockLootUrnRenderer;
+
+@Mixin({ BlockLootUrnRenderer.class, BlockLootCrateRenderer.class })
+public class MixinBlockLootRenderer_ConserveBlockBounds {
+
+    @WrapOperation(
+        method = "renderWorldBlock",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;setBlockBounds(FFFFFF)V"))
+    public void setRenderBounds(Block instance, float minX, float minY, float minZ, float maxX, float maxY, float maxZ,
+        Operation<Void> original, @Local(argsOnly = true) RenderBlocks renderer) {
+        renderer.setRenderBounds(minX, minY, minZ, maxX, maxY, maxZ);
+    }
+
+    @WrapOperation(
+        method = "renderWorldBlock",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/client/renderer/RenderBlocks;setRenderBoundsFromBlock(Lnet/minecraft/block/Block;)V"))
+    public void ignoreBoundsFromBlock(RenderBlocks instance, Block p_147775_1_, Operation<Void> original) {
+        // The previous method sets the render bounds. This method intentionally does nothing.
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - prevents entities from phasing through Abandoned Crates & Old Urns when the blocks are being broken.

**What is the current behavior?** (You can also link to an open issue here)
Closes #306 

**What is the new behavior (if this is a feature change)?**
The hitboxes don't change when the blocks are being broken, and no falling through blocks or jittering is noticeable.

**Does this PR introduce a breaking change?**
No