### PR TITLE
drop correct meta of custom planks

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/common/blocks/BlockPlank.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/blocks/BlockPlank.java
@@ -40,6 +40,11 @@ public class BlockPlank extends Block {
         par3List.add(new ItemStack(par1, 1, 1));
     }
 
+    @Override
+    public int damageDropped(int meta) {
+        return meta;
+    }
+
     public IIcon getIcon(int par1, int par2) {
         return par2 == 0 ? this.iconGreatwood : this.iconSilverwood;
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bugfix

**What is the current behavior?** (You can also link to an open issue here)
custom planks always drop meta 0

**What is the new behavior (if this is a feature change)?**
they drop correct meta

**Does this PR introduce a breaking change?**
no

**Other information**:
