### PR TITLE
Add translations for Portal To Nowhere.

### DIFF
--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -168,3 +168,5 @@ tc.research_page.salisarcana:FOCUS_DISENCHANTING.1=(Since each level stores more
 salisarcana:error_missing_research.infusion=You lack the research to start this infusion! You must research "%s" in %s before you can craft this item!
 salisarcana:error_missing_research.crucible=You lack the research to craft this recipe in the Crucible! You must research "%s" in %s before you can craft this item!
 salisarcana:error_missing_research.gui=Missing Research
+
+tile.blockPortalNothing.name=Portal to Nothing

--- a/src/main/resources/assets/salisarcana/lang/ru_RU.lang
+++ b/src/main/resources/assets/salisarcana/lang/ru_RU.lang
@@ -3,3 +3,5 @@ salisarcana:tcinventoryscan.thaumometerTooltip=Доступно сканиров
 salisarcana:tcinventoryscan.thaumometerTooltipMore=Наведите таумометр на предмет,\nчтобы изучить его.
 
 item.Wand.staffter.obj=посохипетр
+
+tile.blockPortalNothing.name=Портал в никуда


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
`tile.blockPortalNothing.name` (the portal-like blocks outside the Outer Lands dungeon that deal void damage on contact) don't have translations.

**What is the new behavior (if this is a feature change)?**
I added Russian & English translations for the language key.

**Does this PR introduce a breaking change?**
No