### PR TITLE
Fix formatting for "Focus Pouch" text in Baubles Expanded

### DIFF
--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -176,7 +176,7 @@ salisarcana:duplicate_research.success=Duplicated research paper added to invent
 
 tile.blockPortalNothing.name=Portal to Nothing
 
-slot.focus_pouch=Focus Pouch
+slot.focus_pouch=§aFocus Pouch§7
 
 salisarcana:misc.golem.reject_player=You are not my Master!
 salisarcana:misc.warded.destroy_ender_pearl=The magic of a nearby warded object destroys the ender pearl.


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
<img width="972" height="265" alt="image" src="https://github.com/user-attachments/assets/b9acec4e-11ef-4aab-bce9-ab21b89d98ff" />
https://github.com/GTNewHorizons/ThaumicTinkerer/pull/62

**What is the new behavior (if this is a feature change)?**
That text is now green

**Does this PR introduce a breaking change?**
No

**Other information**:
