### PR TITLE
Remove the ability to upgrade a staff using its own vis.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -62,6 +62,9 @@ public abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extend
                 }
             }
 
+            // Staves & Staffters cannot be used to supply vis for crafting
+            if (itemWand.isStaff(originalWand)) return;
+
             // Vis is spent using the original wand, which is why that loop above is necessary.
             if (itemWand.consumeAllVisCrafting(originalWand, this.ip.player, visPrice, true)) {
                 if (SalisConfig.features.preserveWandVis.isEnabled()) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
@@ -38,6 +38,10 @@ public class MixinGuiArcaneWorkbench_SingleWandReplacement {
                 final ItemStack slot = this.tileEntity.getStackInSlot(i);
                 if (slot != null && slot.getItem() instanceof ItemWandCasting itemWand) {
                     // Found a wand in table
+
+                    // Staves & Staffters cannot be used to supply vis for crafting
+                    if (itemWand.isStaff(slot)) return null;
+
                     if ((CustomRecipes.replaceWandCapsRecipe != null && CustomRecipes.replaceWandCapsRecipe
                         .matches(this.tileEntity, this.ip.player.worldObj, KnowItAll.getInstance()))
                         || (CustomRecipes.replaceWandCoreRecipe != null && CustomRecipes.replaceWandCoreRecipe


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
Staves can be used to upgrade themselves, thus allowing impossible staves to be created.

**What is the new behavior (if this is a feature change)?**
Single Wand Replacement doesn't work on Staves & Staffters anymore.

**Does this PR introduce a breaking change?**
No

**Other information**:
This feels a lot more unintuitive to me. I might look into expanding that "research error" message to show other messages, like "staves cannot supply vis for crafting" & "conductors & screws required to swap wand cores".