### PR TITLE
NEI paste now updates the output slot of the Arcane Worktable.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -40,7 +40,7 @@ dependencies {
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
     // devOnlyNonPublishable(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
-    runtimeOnlyNonPublishable(rfg.deobf("curse.maven:thaumcraft-nei-plugin-225095:2241913"))
+    devOnlyNonPublishable(rfg.deobf("curse.maven:thaumcraft-nei-plugin-225095:2241913")) { transitive = false }
     compileOnly("curse.maven:hodgepodge-688899:6039713")
     compileOnly("maven.modrinth:bugtorch:1.2.13")
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -80,6 +80,11 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.arcaneWorkbenchMultiContainer)
         .addCommonMixins("container.MixinContainerArcaneWorkbench_MultiContainer")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    MULTI_CONTAINER_NEI_FIX(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.arcaneWorkbenchMultiContainer)
+        .addClientMixins("addons.ThaumcraftNEIPlugin.MixinArcaneWorkbenchOverlayHandler")
+        .addRequiredMod(TargetedMod.THAUMCRAFT_NEI_PLUGIN)
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     THAUMATORIUM_MULTI_CONTAINER(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.thaumatoriumMultiContainer)
         .addCommonMixins("container.MixinContainerThaumatorium_MultiContainer")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
@@ -13,6 +13,7 @@ public enum TargetedMod implements ITargetMod {
     GTNH_THAUMCRAFT_WANDS("gtnhtcwands"),
     THAUMCRAFT("Thaumcraft"),
     THAUMIC_TINKERER("ThaumicTinkerer"),
+    THAUMCRAFT_NEI_PLUGIN("thaumcraftneiplugin"),
     TC4_TWEAKS("tc4tweak"),
     BAUBLES_EXPANDED("Baubles|Expanded"),
     UNDERGROUND_BIOMES("UndergroundBiomes");

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/ThaumcraftNEIPlugin/MixinArcaneWorkbenchOverlayHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/addons/ThaumcraftNEIPlugin/MixinArcaneWorkbenchOverlayHandler.java
@@ -1,0 +1,27 @@
+package dev.rndmorris.salisarcana.mixins.late.addons.ThaumcraftNEIPlugin;
+
+import java.util.List;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.djgiannuzz.thaumcraftneiplugin.nei.overlay.ArcaneWorkbenchOverlayHandler;
+
+import codechicken.nei.recipe.DefaultOverlayHandler;
+import thaumcraft.common.container.ContainerArcaneWorkbench;
+
+@Mixin(value = ArcaneWorkbenchOverlayHandler.class, remap = false)
+public class MixinArcaneWorkbenchOverlayHandler {
+
+    @Inject(method = "moveIngredients", at = @At("TAIL"))
+    public void triggerRecipeSearch(GuiContainer gui,
+        List<DefaultOverlayHandler.IngredientDistribution> assignedIngredients, int quantity, CallbackInfo ci) {
+        if (gui.inventorySlots instanceof ContainerArcaneWorkbench workbench) {
+            workbench.onCraftMatrixChanged(null);
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
Closes #337

**What is the new behavior (if this is a feature change)?**
Pasting in a recipe from NEI visually updates the output slot to show the new recipe.

**Does this PR introduce a breaking change?**
No

**Other information**:
I have no idea how NEI manages to modify the inventory of the Arcane Worktable without causing a single recipe update, and I really don't know how to keep chasing the issue. As far as I can tell, `slotClick` gets called on the client, but the slots it modifies never update the inventory, even though `setInventorySlotContents` is the only way to change the items in the slots, which should trigger the update function.