### PR TITLE
Earth Shock blocks (from Wand Focus: Shock) no longer float midair & while on top of non-solid blocks.

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -234,3 +234,9 @@ Applying patterns to banners will only consume the essentia, and not the phial i
 **Config option:** `extraSecureArcaneKeys`
 
 Arcane Keys will now save the dimension and the creator of the key when linked to a warded object, and will check those values before granting permission.
+
+## Earth Shock Blocks Require Solid Ground
+
+**Config option:** `earthShockRequireSolidGround`
+
+Requires the spark blocks left behind by Wand Focus: Shock with the Earth Shock upgrade to have a solid block beneath them to exist.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -220,6 +220,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "extraSecureArcaneKeys",
         "Arcane Keys will now save the dimension and the creator of the key when linked to a warded object, and will check those values before granting permission.");
 
+    public final ToggleSetting earthShockRequireSolidGround = new ToggleSetting(
+        this,
+        "earthShockRequireSolidGround",
+        "Requires the spark blocks left behind by Wand Focus: Shock with the Earth Shock upgrade to have a solid block beneath them to exist.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -196,6 +196,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.extraSecureArcaneKeys)
         .addCommonMixins("items.MixinItemKey_ExtraSecurityChecks")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    EARTH_SHOCK_REQUIRE_SOLID_GROUND(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.earthShockRequireSolidGround)
+        .addCommonMixins("entities.MixinEntityShockOrb_CheckSolidGround", "blocks.MixinBlockAiry_EarthShockCheckSolidGround")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockAiry_EarthShockCheckSolidGround.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/blocks/MixinBlockAiry_EarthShockCheckSolidGround.java
@@ -1,0 +1,26 @@
+package dev.rndmorris.salisarcana.mixins.late.blocks;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import thaumcraft.common.blocks.BlockAiry;
+
+@Mixin(BlockAiry.class)
+public class MixinBlockAiry_EarthShockCheckSolidGround {
+
+    @ModifyExpressionValue(
+        method = "onNeighborBlockChange",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;getBlockMetadata(III)I"))
+    public int checkSolidGround(int meta, World world, int x, int y, int z) {
+        // Spark block from Earth Shock
+        if (meta == 10 && !world.isRemote && !World.doesBlockHaveSolidTopSurface(world, x, y - 1, z)) {
+            world.setBlockToAir(x, y, z);
+        }
+
+        return meta;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/entities/MixinEntityShockOrb_CheckSolidGround.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/entities/MixinEntityShockOrb_CheckSolidGround.java
@@ -1,0 +1,22 @@
+package dev.rndmorris.salisarcana.mixins.late.entities;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import thaumcraft.common.entities.projectile.EntityShockOrb;
+
+@Mixin(EntityShockOrb.class)
+public class MixinEntityShockOrb_CheckSolidGround {
+
+    @WrapOperation(
+        method = "onImpact",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;isAirBlock(III)Z", ordinal = 2))
+    public boolean isSolidBlock(World world, int x, int y, int z, Operation<Boolean> original) {
+        return !World.doesBlockHaveSolidTopSurface(world, x, y, z);
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
Earth Shock blocks can exist midair, even though they're rendered as if they're energized ground.

**What is the new behavior (if this is a feature change)?**
They instantly disappear if the ground below them is no longer solid, and they don't spawn on top of non-solid blocks.

**Does this PR introduce a breaking change?**
No

**Other information**:
I think `World.doesBlockHaveSolidTopSurface` requires the block to be solid - i.e. no glass. (same as mob spawning logic) I might want to use something more akin to the torch logic so glass blocks can have Earth Shock blocks placed on top.