### PR TITLE
Add property tooltips to wand cores & wand caps.

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -238,6 +238,12 @@ Override how eldritch altars pick where to try spawning crimson knights and eldr
 
 Applying patterns to banners not consume the phial or the essentia. Overrides `bannerReturnPhials` in the bugfixes module.
 
+## Wand Cap & Wand Core Properties in Tooltip
+
+**Config option:** `wandPartStatsTooltip`
+
+Wand caps & wand rods will show information about their vis capacity & discount in their tooltips.
+
 # Enhancements - Infusion
 
 ## Config option: `useStabilizerRewrite`

--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -11,6 +11,7 @@ import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import dev.rndmorris.salisarcana.client.ThaumicInventoryScanner;
 import dev.rndmorris.salisarcana.client.handlers.GuiHandler;
 import dev.rndmorris.salisarcana.config.SalisConfig;
+import dev.rndmorris.salisarcana.lib.WandPartTooltipEventHandler;
 
 public class ClientProxy extends CommonProxy {
 
@@ -27,6 +28,9 @@ public class ClientProxy extends CommonProxy {
                 .register(scanner);
 
             scanner.init(event);
+        }
+        if (SalisConfig.features.wandPartStatsTooltip.isEnabled()) {
+            MinecraftForge.EVENT_BUS.register(new WandPartTooltipEventHandler());
         }
         new GuiHandler();
     }

--- a/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/CommonProxy.java
@@ -35,11 +35,7 @@ import dev.rndmorris.salisarcana.common.item.PlaceholderItem;
 import dev.rndmorris.salisarcana.common.recipes.CustomRecipes;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.config.settings.CommandSettings;
-import dev.rndmorris.salisarcana.lib.BlockAiryBucketInterceptor;
-import dev.rndmorris.salisarcana.lib.CrucibleHeatLogic;
-import dev.rndmorris.salisarcana.lib.KnowItAll;
-import dev.rndmorris.salisarcana.lib.ObfuscationInfo;
-import dev.rndmorris.salisarcana.lib.R;
+import dev.rndmorris.salisarcana.lib.*;
 import dev.rndmorris.salisarcana.network.NetworkHandler;
 import dev.rndmorris.salisarcana.notifications.StartupNotifications;
 import dev.rndmorris.salisarcana.notifications.Updater;
@@ -125,6 +121,7 @@ public class CommonProxy {
     public void postInit(FMLPostInitializationEvent event) {
         CustomRecipes.registerRecipesPostInit();
         CustomResearch.init();
+        WandHelper.loadWandParts();
     }
 
     // register server commands in this event handler (Remove if not needed)

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -466,6 +466,11 @@ public class ConfigFeatures extends ConfigGroup {
         "Applying patterns to banners not consume the phial or the essentia. Overrides bannerReturnPhials in the bugfixes module.")
             .setEnabled(false);
 
+    public final ToggleSetting wandPartStatsTooltip = new ToggleSetting(
+        this,
+        "wandPartStatsTooltip",
+        "Wand caps & wand rods will show information about their vis capacity & discount in their tooltips.");
+
     public boolean singleWandReplacementEnabled() {
         return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())
             && SalisConfig.bugfixes.arcaneWorkbenchGhostItemFix.isEnabled()

--- a/src/main/java/dev/rndmorris/salisarcana/lib/WandHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/WandHelper.java
@@ -1,10 +1,12 @@
 package dev.rndmorris.salisarcana.lib;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 
 import thaumcraft.api.wands.WandCap;
@@ -14,6 +16,33 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class WandHelper {
 
+    private static final HashMap<Item, HashMap<Integer, WandCap>> WAND_CAPS = new HashMap<>();
+    private static final HashMap<Item, HashMap<Integer, WandRod>> WAND_RODS = new HashMap<>();
+
+    public static void loadWandParts() {
+        for (final var cap : WandCap.caps.values()) {
+            final var itemStack = cap.getItem();
+            if (itemStack == null) continue;
+
+            final var item = itemStack.getItem();
+            if (item == null) continue;
+
+            WAND_CAPS.computeIfAbsent(item, ignore -> new HashMap<>())
+                .put(itemStack.getItemDamage(), cap);
+        }
+
+        for (final var rod : WandRod.rods.values()) {
+            final var itemStack = rod.getItem();
+            if (itemStack == null) continue;
+
+            final var item = itemStack.getItem();
+            if (item == null) continue;
+
+            WAND_RODS.computeIfAbsent(item, ignore -> new HashMap<>())
+                .put(itemStack.getItemDamage(), rod);
+        }
+    }
+
     /**
      * Try to find the registered {@link WandCap} by its item form.
      *
@@ -21,24 +50,13 @@ public class WandHelper {
      * @return The registered {@link WandCap} if one was found, or {@code null} otherwise.
      */
     public static @Nullable WandCap getWandCapFromItem(@Nullable ItemStack itemStack) {
-        if (itemStack == null) {
-            return null;
-        }
-        final var item = itemStack.getItem();
-        if (item == null) {
-            return null;
-        }
-        for (var cap : WandCap.caps.values()) {
-            final var capItemStack = cap.getItem();
-            if (capItemStack == null) {
-                continue;
-            }
-            if (itemStack.isItemEqual(capItemStack)) {
-                return cap;
-            }
-        }
+        if (itemStack == null) return null;
 
-        return null;
+        final var item = itemStack.getItem();
+        if (item == null) return null;
+
+        final var subMap = WAND_CAPS.get(item);
+        return subMap != null ? subMap.get(itemStack.getItemDamage()) : null;
     }
 
     /**
@@ -63,24 +81,13 @@ public class WandHelper {
      * @return The registered {@link WandRod} if one was found, or {@code null} otherwise.
      */
     public static @Nullable WandRod getWandRodFromItem(@Nullable ItemStack itemStack) {
-        if (itemStack == null) {
-            return null;
-        }
-        final var item = itemStack.getItem();
-        if (item == null) {
-            return null;
-        }
-        for (var rod : WandRod.rods.values()) {
-            final var rodItemStack = rod.getItem();
-            if (rodItemStack == null) {
-                continue;
-            }
-            if (itemStack.isItemEqual(rodItemStack)) {
-                return rod;
-            }
-        }
+        if (itemStack == null) return null;
 
-        return null;
+        final var item = itemStack.getItem();
+        if (item == null) return null;
+
+        final var subMap = WAND_RODS.get(item);
+        return subMap != null ? subMap.get(itemStack.getItemDamage()) : null;
     }
 
     /**

--- a/src/main/java/dev/rndmorris/salisarcana/lib/WandPartTooltipEventHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/WandPartTooltipEventHandler.java
@@ -1,0 +1,60 @@
+package dev.rndmorris.salisarcana.lib;
+
+import java.text.NumberFormat;
+
+import net.minecraft.util.StatCollector;
+import net.minecraftforge.event.entity.player.ItemTooltipEvent;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.wands.StaffRod;
+
+public class WandPartTooltipEventHandler {
+
+    private static final NumberFormat PERCENT_FORMAT = NumberFormat.getPercentInstance();
+
+    private static final Aspect[] PRIMALS = new Aspect[] { Aspect.AIR, Aspect.EARTH, Aspect.FIRE, Aspect.WATER,
+        Aspect.ORDER, Aspect.ENTROPY };
+
+    @SubscribeEvent
+    public void renderTooltip(ItemTooltipEvent event) {
+        final var wandCap = WandHelper.getWandCapFromItem(event.itemStack);
+        if (wandCap != null) {
+            final float baseCost = wandCap.getBaseCostModifier();
+            final float specialCost = wandCap.getSpecialCostModifier();
+            final var specialAspects = wandCap.getSpecialCostModifierAspects();
+
+            final String baseCostString = (baseCost > 1f ? "§4" : "§2") + PERCENT_FORMAT.format(1f - baseCost);
+            if (specialCost == 0 || specialAspects == null || specialAspects.isEmpty()) {
+                // The vis price is the same for all aspects
+                event.toolTip.add(
+                    StatCollector
+                        .translateToLocalFormatted("salisarcana:wand_cap.vis_discount.generic", baseCostString));
+            } else {
+                final String specialCostString = (specialCost > 1f ? "§4" : "§2")
+                    + PERCENT_FORMAT.format(1f - specialCost);
+
+                for (final Aspect primal : PRIMALS) {
+                    final String primalName = "§" + primal.getChatcolor() + primal.getName() + "§5";
+
+                    event.toolTip.add(
+                        StatCollector.translateToLocalFormatted(
+                            "salisarcana:wand_cap.vis_discount.aspect",
+                            primalName,
+                            specialAspects.contains(primal) ? specialCostString : baseCostString));
+                }
+            }
+            return;
+        }
+
+        final var wandRod = WandHelper.getWandRodFromItem(event.itemStack);
+        if (wandRod != null) {
+            event.toolTip.add(
+                StatCollector.translateToLocalFormatted("salisarcana:wand_rod.vis_capacity", wandRod.getCapacity()));
+
+            if (wandRod instanceof StaffRod staff && staff.hasRunes()) {
+                event.toolTip.add(StatCollector.translateToLocal("salisarcana:wand_rod.runes"));
+            }
+        }
+    }
+}

--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -187,3 +187,8 @@ salisarcana:misc.mirror.already_linked=That mirror is already linked to a valid 
 
 salisarcana:misc.arcane_key.creator=§5§oCreated by: %s
 salisarcana:misc.arcane_key.dimension= (dimension %s)
+
+salisarcana:wand_cap.vis_discount.generic=§5Discount: %s
+salisarcana:wand_cap.vis_discount.aspect=%s Discount: %s
+salisarcana:wand_rod.vis_capacity=§5Capacity: %s vis
+salisarcana:wand_rod.runes=§5+1 Potency§2 for any equipped focus


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature - new informative tooltips

**What is the current behavior?** (You can also link to an open issue here)
You only figure out the relative strengths of the wand caps & cores by either reading the Thaumonomicon entries or looking at a wiki.

**What is the new behavior (if this is a feature change)?**
Every wand part item now has extra lines in their tooltip stating their basic stats (discount & capacity.) Unfortunately, there's no good way to implement a tooltip for showing vis regeneration per second, since that information isn't organized anywhere.

<img width="681" height="190" alt="2025-08-10_20 45 25" src="https://github.com/user-attachments/assets/ae16dcda-eeda-4413-bb2e-d9ea848aac18" />
<img width="790" height="438" alt="2025-08-10_20 45 28" src="https://github.com/user-attachments/assets/b8fa9426-0613-4095-9825-4587043080af" />
<img width="1004" height="191" alt="2025-08-10_20 45 32" src="https://github.com/user-attachments/assets/29fb350a-0804-467b-b698-6e26a7ca0701" />
<img width="1229" height="237" alt="2025-08-10_20 45 37" src="https://github.com/user-attachments/assets/9b64f985-056a-4f50-b77b-2d92830fccb6" />

**Does this PR introduce a breaking change?**
No

**Other information:**
Original GTNH issues:
- https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17925
- https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/17926