### PR TITLE
Fix lang key error in `/list-research` command

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/common/commands/ListResearchCommand.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/commands/ListResearchCommand.java
@@ -57,7 +57,7 @@ public class ListResearchCommand extends ArcanaCommandBase<ListResearchCommand.A
 
         var results = ResearchHelper.printResearchToChat(predicate);
         if (results.isEmpty()) {
-            throw new CommandException("salisarcana:command.player-research.no_results");
+            throw new CommandException("salisarcana:command.list-research.no_results");
         }
         results.forEach(sender::addChatMessage);
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
When no research is found, a raw lang key is displayed to the user.

**What is the new behavior (if this is a feature change)?**
The right lang key is shown & translated.

**Does this PR introduce a breaking change?**
No