### PR TITLE
Arcane Worktable Recipe Caching & Forge Event Bridge

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -123,6 +123,18 @@ Allows players to craft after the wand in the GUI runs out of vis and is recharg
 
 Prevents bugs related to multiple players opening an Arcane Workbench's GUI at the same time, including a duplication bug, research verification bug, and some others.
 
+### Cache Last Recipe in Arcane Workbench
+
+**Config option:** `arcaneWorkbenchCache`
+
+Causes each Arcane Workbench to keep a cache of the last valid recipe, massively improving the performance of bulk crafts & the GUI.
+
+### Arcane Workbench Pretends to be a Crafting Table during Forge Events
+
+**Config option:** `arcaneWorkbenchForgeEventBridge`
+
+When performing a mundane crafting recipe in an Arcane Workbench, it will pretend to be a normal crafting table when sending the Forge event. Prevents the Spellbinding Cloth item duplication glitch.
+
 ## Use Forge fishing lists for fishing golem loot
 
 **Config option:** `useForgeFishingLists`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -100,6 +100,16 @@ public class ConfigBugfixes extends ConfigGroup {
         "arcaneWorkbenchMultiContainer",
         "Prevents bugs related to multiple players opening an Arcane Workbench's GUI at the same time.");
 
+    public final ToggleSetting arcaneWorkbenchCache = new ToggleSetting(
+        this,
+        "arcaneWorkbenchCache",
+        "Causes each Arcane Workbench to keep a cache of the last valid recipe, massively improving the performance of bulk crafts & the GUI.");
+
+    public final ToggleSetting arcaneWorkbenchForgeEventBridge = new ToggleSetting(
+        this,
+        "arcaneWorkbenchForgeEventBridge",
+        "When performing a mundane crafting recipe in an Arcane Workbench, it will pretend to be a normal crafting table when sending the Forge event. Prevents the Spellbinding Cloth item duplication glitch.");
+
     public final ToggleSetting negativeBossSpawnCount = new ToggleSetting(
         this,
         "negativeBossSpawnCount",

--- a/src/main/java/dev/rndmorris/salisarcana/lib/CraftingHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/CraftingHelper.java
@@ -9,6 +9,7 @@ import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 
 import cpw.mods.fml.common.Loader;
+import dev.rndmorris.salisarcana.lib.recipe.MundaneRepairRecipe;
 import thaumcraft.api.ThaumcraftApi;
 import thaumcraft.api.crafting.IArcaneRecipe;
 
@@ -27,9 +28,13 @@ public class CraftingHelper {
     private CraftingHelper() {}
 
     public IRecipe findMundaneRecipe(final InventoryCrafting awb, final World world) {
-        // TODO Add support for repair-combination recipe.
         final var recipes = CraftingManager.getInstance()
             .getRecipeList();
+
+        // Minecraft checks for the "combine two tools' durability" recipe without using a IRecipe.
+        if (MundaneRepairRecipe.INSTANCE.matches(awb, world)) {
+            return MundaneRepairRecipe.INSTANCE;
+        }
 
         for (final var recipe : recipes) {
             if (recipe.matches(awb, world)) {

--- a/src/main/java/dev/rndmorris/salisarcana/lib/CraftingHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/CraftingHelper.java
@@ -3,6 +3,8 @@ package dev.rndmorris.salisarcana.lib;
 import net.glease.tc4tweak.modules.findRecipes.FindRecipes;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.world.World;
 
 import cpw.mods.fml.common.Loader;
 import thaumcraft.api.ThaumcraftApi;
@@ -22,7 +24,11 @@ public class CraftingHelper {
 
     private CraftingHelper() {}
 
-    public IArcaneRecipe findArcaneRecipe(final IInventory awb, final EntityPlayer player) {
+    public IRecipe findMundaneRecipe(final IInventory awb, final World world) {
+        // TODO Figure out this bit.
+    }
+
+    public IArcaneRecipe findArcaneRecipe(final IInventory awb, final World world, final EntityPlayer player) {
         final var recipes = ThaumcraftApi.getCraftingRecipes();
 
         for (final var recipe : recipes) {

--- a/src/main/java/dev/rndmorris/salisarcana/lib/CraftingHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/CraftingHelper.java
@@ -3,6 +3,8 @@ package dev.rndmorris.salisarcana.lib;
 import net.glease.tc4tweak.modules.findRecipes.FindRecipes;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.item.crafting.IRecipe;
 import net.minecraft.world.World;
 
@@ -24,11 +26,21 @@ public class CraftingHelper {
 
     private CraftingHelper() {}
 
-    public IRecipe findMundaneRecipe(final IInventory awb, final World world) {
-        // TODO Figure out this bit.
+    public IRecipe findMundaneRecipe(final InventoryCrafting awb, final World world) {
+        // TODO Add support for repair-combination recipe.
+        final var recipes = CraftingManager.getInstance()
+            .getRecipeList();
+
+        for (final var recipe : recipes) {
+            if (recipe.matches(awb, world)) {
+                return recipe;
+            }
+        }
+
+        return null;
     }
 
-    public IArcaneRecipe findArcaneRecipe(final IInventory awb, final World world, final EntityPlayer player) {
+    public IArcaneRecipe findArcaneRecipe(final IInventory awb, final EntityPlayer player) {
         final var recipes = ThaumcraftApi.getCraftingRecipes();
 
         for (final var recipe : recipes) {

--- a/src/main/java/dev/rndmorris/salisarcana/lib/MundaneCraftingBridge.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/MundaneCraftingBridge.java
@@ -5,7 +5,7 @@ import net.minecraft.item.ItemStack;
 
 import thaumcraft.common.tiles.TileMagicWorkbench;
 
-public class MundaneCraftingBridge extends InventoryCrafting {
+public final class MundaneCraftingBridge extends InventoryCrafting {
 
     private final TileMagicWorkbench workbench;
 

--- a/src/main/java/dev/rndmorris/salisarcana/lib/MundaneCraftingBridge.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/MundaneCraftingBridge.java
@@ -1,0 +1,48 @@
+package dev.rndmorris.salisarcana.lib;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+
+import thaumcraft.common.tiles.TileMagicWorkbench;
+
+public class MundaneCraftingBridge extends InventoryCrafting {
+
+    private final TileMagicWorkbench workbench;
+
+    public MundaneCraftingBridge(TileMagicWorkbench workbench) {
+        super(workbench.eventHandler, 3, 3);
+        this.workbench = workbench;
+    }
+
+    @Override
+    public ItemStack getStackInSlot(int index) {
+        return index < 9 ? this.workbench.getStackInSlot(index) : null;
+    }
+
+    @Override
+    public ItemStack decrStackSize(int index, int count) {
+        return index < 9 ? this.workbench.decrStackSize(index, count) : null;
+    }
+
+    @Override
+    public ItemStack getStackInSlotOnClosing(int index) {
+        return index < 9 ? this.workbench.getStackInSlotOnClosing(index) : null;
+    }
+
+    @Override
+    public void setInventorySlotContents(int index, ItemStack stack) {
+        if (index < 9) {
+            this.workbench.setInventorySlotContents(index, stack);
+        }
+    }
+
+    @Override
+    public boolean isItemValidForSlot(int index, ItemStack stack) {
+        return index < 9;
+    }
+
+    @Override
+    public ItemStack getStackInRowAndColumn(int row, int column) {
+        return this.workbench.getStackInRowAndColumn(row, column);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/NullAspectList.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/NullAspectList.java
@@ -1,0 +1,99 @@
+package dev.rndmorris.salisarcana.lib;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+
+public final class NullAspectList extends AspectList {
+
+    public static final NullAspectList INSTANCE = new NullAspectList();
+    private static final Aspect[] NO_ASPECTS = new Aspect[0];
+
+    private NullAspectList() {}
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public int visSize() {
+        return 0;
+    }
+
+    @Override
+    public Aspect[] getAspects() {
+        return NO_ASPECTS;
+    }
+
+    @Override
+    public Aspect[] getPrimalAspects() {
+        return NO_ASPECTS;
+    }
+
+    @Override
+    public Aspect[] getAspectsSorted() {
+        return NO_ASPECTS;
+    }
+
+    @Override
+    public Aspect[] getAspectsSortedAmount() {
+        return NO_ASPECTS;
+    }
+
+    @Override
+    public int getAmount(Aspect key) {
+        return 0;
+    }
+
+    @Override
+    public boolean reduce(Aspect key, int amount) {
+        return false;
+    }
+
+    @Override
+    public AspectList remove(Aspect key, int amount) {
+        return this;
+    }
+
+    @Override
+    public AspectList remove(Aspect key) {
+        return this;
+    }
+
+    @Override
+    public AspectList add(Aspect aspect, int amount) {
+        throw new UnsupportedOperationException("Cannot add aspects to a constant NullAspectList.");
+    }
+
+    @Override
+    public AspectList merge(Aspect aspect, int amount) {
+        throw new UnsupportedOperationException("Cannot add aspects to a constant NullAspectList.");
+    }
+
+    @Override
+    public AspectList add(AspectList in) {
+        throw new UnsupportedOperationException("Cannot add aspects to a constant NullAspectList.");
+    }
+
+    @Override
+    public AspectList merge(AspectList in) {
+        throw new UnsupportedOperationException("Cannot add aspects to a constant NullAspectList.");
+    }
+
+    @Override
+    public AspectList copy() {
+        return this;
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbttagcompound) {
+        throw new UnsupportedOperationException("Cannot load aspects from NBT to a constant NullAspectList.");
+    }
+
+    @Override
+    public void readFromNBT(NBTTagCompound nbttagcompound, String label) {
+        throw new UnsupportedOperationException("Cannot load aspects from NBT to a constant NullAspectList.");
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/ifaces/ICachedMagicWorkbench.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ifaces/ICachedMagicWorkbench.java
@@ -1,0 +1,13 @@
+package dev.rndmorris.salisarcana.lib.ifaces;
+
+import net.minecraft.item.crafting.IRecipe;
+
+import thaumcraft.api.crafting.IArcaneRecipe;
+
+public interface ICachedMagicWorkbench {
+
+    IRecipe salisArcana$getMundaneRecipe();
+
+    IArcaneRecipe salisArcana$getArcaneRecipe();
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/recipe/MundaneRepairRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/recipe/MundaneRepairRecipe.java
@@ -1,0 +1,78 @@
+package dev.rndmorris.salisarcana.lib.recipe;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.world.World;
+
+public final class MundaneRepairRecipe implements IRecipe {
+
+    public static final MundaneRepairRecipe INSTANCE = new MundaneRepairRecipe();
+
+    @Override
+    public boolean matches(InventoryCrafting inv, World world) {
+        return this.getCraftingResult(inv) != null;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(InventoryCrafting inv) {
+        Item toolItem = null;
+        ItemStack toolOne = null;
+        ItemStack toolTwo = null;
+
+        for (int i = 0; i < inv.getSizeInventory(); i++) {
+            final ItemStack stack = inv.getStackInSlot(i);
+
+            if (stack == null) continue;
+
+            if (stack.stackSize != 1) {
+                // Tools must have a stack-size of 1 (according to the Minecraft implementation)
+                return null;
+            }
+
+            if (toolOne == null) {
+                toolOne = stack;
+                toolItem = stack.getItem();
+
+                //noinspection DataFlowIssue
+                if (!toolItem.isRepairable()) {
+                    // Tool cannot be repaired in workbench
+                    return null;
+                }
+            } else if (toolTwo == null) {
+                toolTwo = stack;
+
+                if (toolOne.getItem() != toolTwo.getItem()) {
+                    // Mismatched items
+                    return null;
+                }
+            } else {
+                // More than two items found
+                return null;
+            }
+        }
+
+        if (toolTwo != null) {
+            // Two matching items found
+            int durability = toolItem.getMaxDamage() - toolOne.getItemDamageForDisplay();
+            durability += toolItem.getMaxDamage() - toolTwo.getItemDamageForDisplay();
+            durability += toolItem.getMaxDamage() / 20; // 5% bonus
+
+            return new ItemStack(toolItem, 1, Math.max(0, toolItem.getMaxDamage() - durability));
+        } else {
+            // One or zero matching items found
+            return null;
+        }
+    }
+
+    @Override
+    public int getRecipeSize() {
+        return 2;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput() {
+        return null;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/lib/recipe/MundaneRepairRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/recipe/MundaneRepairRecipe.java
@@ -17,7 +17,6 @@ public final class MundaneRepairRecipe implements IRecipe {
 
     @Override
     public ItemStack getCraftingResult(InventoryCrafting inv) {
-        Item toolItem = null;
         ItemStack toolOne = null;
         ItemStack toolTwo = null;
 
@@ -33,10 +32,10 @@ public final class MundaneRepairRecipe implements IRecipe {
 
             if (toolOne == null) {
                 toolOne = stack;
-                toolItem = stack.getItem();
 
-                //noinspection DataFlowIssue
-                if (!toolItem.isRepairable()) {
+                // noinspection DataFlowIssue
+                if (!stack.getItem()
+                    .isRepairable()) {
                     // Tool cannot be repaired in workbench
                     return null;
                 }
@@ -55,11 +54,14 @@ public final class MundaneRepairRecipe implements IRecipe {
 
         if (toolTwo != null) {
             // Two matching items found
-            int durability = toolItem.getMaxDamage() - toolOne.getItemDamageForDisplay();
-            durability += toolItem.getMaxDamage() - toolTwo.getItemDamageForDisplay();
-            durability += toolItem.getMaxDamage() / 20; // 5% bonus
+            final Item item = toolOne.getItem();
+            final int maxDamage = item.getMaxDamage();
 
-            return new ItemStack(toolItem, 1, Math.max(0, toolItem.getMaxDamage() - durability));
+            int durability = maxDamage - toolOne.getItemDamageForDisplay();
+            durability += maxDamage - toolTwo.getItemDamageForDisplay();
+            durability += maxDamage / 20; // 5% bonus
+
+            return new ItemStack(item, 1, Math.max(0, maxDamage - durability));
         } else {
             // One or zero matching items found
             return null;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -200,6 +200,15 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.earthShockRequireSolidGround)
         .addCommonMixins("entities.MixinEntityShockOrb_CheckSolidGround", "blocks.MixinBlockAiry_EarthShockCheckSolidGround")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    CACHE_ARCANE_WORKBENCH_RECIPE(new SalisBuilder()
+        .addCommonMixins(
+            "container.MixinContainerArcaneWorkbench_UseCache",
+            "lib.MixinThaumcraftCraftingManager_UseCache",
+            "tiles.MixinTileMagicWorkbench_CacheRecipe")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    MUNDANE_CRAFT_FORGE_EVENT_BRIDGE(new SalisBuilder()
+        .addCommonMixins("container.MixinSlotCraftingArcaneWorkbench_ForgeEventBridge")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -201,12 +201,14 @@ public enum Mixins implements IMixins {
         .addCommonMixins("entities.MixinEntityShockOrb_CheckSolidGround", "blocks.MixinBlockAiry_EarthShockCheckSolidGround")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     CACHE_ARCANE_WORKBENCH_RECIPE(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.arcaneWorkbenchCache)
         .addCommonMixins(
             "container.MixinContainerArcaneWorkbench_UseCache",
             "lib.MixinThaumcraftCraftingManager_UseCache",
             "tiles.MixinTileMagicWorkbench_CacheRecipe")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     MUNDANE_CRAFT_FORGE_EVENT_BRIDGE(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.arcaneWorkbenchForgeEventBridge)
         .addCommonMixins("container.MixinSlotCraftingArcaneWorkbench_ForgeEventBridge")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_UseCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_UseCache.java
@@ -19,7 +19,7 @@ import thaumcraft.common.tiles.TileArcaneWorkbench;
 @Mixin(ContainerArcaneWorkbench.class)
 public class MixinContainerArcaneWorkbench_UseCache {
 
-    @Shadow
+    @Shadow(remap = false)
     private TileArcaneWorkbench tileEntity;
 
     @WrapOperation(

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_UseCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_UseCache.java
@@ -1,0 +1,39 @@
+package dev.rndmorris.salisarcana.mixins.late.container;
+
+import net.minecraft.inventory.InventoryCrafting;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.CraftingManager;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.lib.ifaces.ICachedMagicWorkbench;
+import thaumcraft.common.container.ContainerArcaneWorkbench;
+import thaumcraft.common.tiles.TileArcaneWorkbench;
+
+@Mixin(ContainerArcaneWorkbench.class)
+public class MixinContainerArcaneWorkbench_UseCache {
+
+    @Shadow
+    private TileArcaneWorkbench tileEntity;
+
+    @WrapOperation(
+        method = "onCraftMatrixChanged",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/item/crafting/CraftingManager;findMatchingRecipe(Lnet/minecraft/inventory/InventoryCrafting;Lnet/minecraft/world/World;)Lnet/minecraft/item/ItemStack;"))
+    private ItemStack useCachedRecipe(CraftingManager instance, InventoryCrafting inventoryCrafting, World world,
+        Operation<ItemStack> original) {
+        if (this.tileEntity instanceof ICachedMagicWorkbench cache) {
+            return cache.salisArcana$getMundaneRecipe()
+                .getCraftingResult(inventoryCrafting);
+        }
+
+        return original.call(instance, inventoryCrafting, world);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_UseCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinContainerArcaneWorkbench_UseCache.java
@@ -30,8 +30,8 @@ public class MixinContainerArcaneWorkbench_UseCache {
     private ItemStack useCachedRecipe(CraftingManager instance, InventoryCrafting inventoryCrafting, World world,
         Operation<ItemStack> original) {
         if (this.tileEntity instanceof ICachedMagicWorkbench cache) {
-            return cache.salisArcana$getMundaneRecipe()
-                .getCraftingResult(inventoryCrafting);
+            final var recipe = cache.salisArcana$getMundaneRecipe();
+            return recipe != null ? recipe.getCraftingResult(inventoryCrafting) : null;
         }
 
         return original.call(instance, inventoryCrafting, world);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_ForgeEventBridge.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_ForgeEventBridge.java
@@ -17,14 +17,15 @@ import thaumcraft.common.tiles.TileMagicWorkbench;
 @Mixin(SlotCraftingArcaneWorkbench.class)
 public class MixinSlotCraftingArcaneWorkbench_ForgeEventBridge {
 
-    @Shadow
+    @Shadow(remap = false)
     private EntityPlayer thePlayer;
 
     @ModifyArg(
         method = "onPickupFromSlot",
         at = @At(
             value = "INVOKE",
-            target = "Lcpw/mods/fml/common/FMLCommonHandler;firePlayerCraftingEvent(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/item/ItemStack;Lnet/minecraft/inventory/IInventory;)V"),
+            target = "Lcpw/mods/fml/common/FMLCommonHandler;firePlayerCraftingEvent(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/item/ItemStack;Lnet/minecraft/inventory/IInventory;)V",
+            remap = false),
         index = 2)
     public IInventory wrapEventInventory(IInventory craftMatrix) {
         if (craftMatrix instanceof ICachedMagicWorkbench cache && cache.salisArcana$getMundaneRecipe() != null) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_ForgeEventBridge.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/container/MixinSlotCraftingArcaneWorkbench_ForgeEventBridge.java
@@ -1,0 +1,40 @@
+package dev.rndmorris.salisarcana.mixins.late.container;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import dev.rndmorris.salisarcana.lib.MundaneCraftingBridge;
+import dev.rndmorris.salisarcana.lib.ifaces.ICachedMagicWorkbench;
+import thaumcraft.common.container.SlotCraftingArcaneWorkbench;
+import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
+import thaumcraft.common.tiles.TileMagicWorkbench;
+
+@Mixin(SlotCraftingArcaneWorkbench.class)
+public class MixinSlotCraftingArcaneWorkbench_ForgeEventBridge {
+
+    @Shadow
+    private EntityPlayer thePlayer;
+
+    @ModifyArg(
+        method = "onPickupFromSlot",
+        at = @At(
+            value = "INVOKE",
+            target = "Lcpw/mods/fml/common/FMLCommonHandler;firePlayerCraftingEvent(Lnet/minecraft/entity/player/EntityPlayer;Lnet/minecraft/item/ItemStack;Lnet/minecraft/inventory/IInventory;)V"),
+        index = 2)
+    public IInventory wrapEventInventory(IInventory craftMatrix) {
+        if (craftMatrix instanceof ICachedMagicWorkbench cache && cache.salisArcana$getMundaneRecipe() != null) {
+            return new MundaneCraftingBridge((TileMagicWorkbench) craftMatrix);
+        } else if (craftMatrix.getStackInSlot(10) == null
+            || ThaumcraftCraftingManager.findMatchingArcaneRecipeAspects(craftMatrix, this.thePlayer)
+                .size() == 0) {
+                    return new MundaneCraftingBridge((TileMagicWorkbench) craftMatrix);
+                }
+
+        return craftMatrix;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
@@ -41,7 +41,7 @@ public abstract class MixinGuiArcaneWorkbench_MissingResearch extends GuiContain
 
         if (wand == null) return null;
 
-        final var recipe = CraftingHelper.INSTANCE.findArcaneRecipe(awb, KnowItAll.getInstance());
+        final var recipe = CraftingHelper.INSTANCE.findArcaneRecipe(awb, player.worldObj, KnowItAll.getInstance());
 
         if (recipe != null && !recipe.matches(awb, player.worldObj, player)) {
             final var researchArray = (recipe instanceof IMultipleResearchArcaneRecipe multi)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiArcaneWorkbench_MissingResearch.java
@@ -41,7 +41,7 @@ public abstract class MixinGuiArcaneWorkbench_MissingResearch extends GuiContain
 
         if (wand == null) return null;
 
-        final var recipe = CraftingHelper.INSTANCE.findArcaneRecipe(awb, player.worldObj, KnowItAll.getInstance());
+        final var recipe = CraftingHelper.INSTANCE.findArcaneRecipe(awb, KnowItAll.getInstance());
 
         if (recipe != null && !recipe.matches(awb, player.worldObj, player)) {
             final var researchArray = (recipe instanceof IMultipleResearchArcaneRecipe multi)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinThaumcraftCraftingManager_UseCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinThaumcraftCraftingManager_UseCache.java
@@ -18,7 +18,7 @@ import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 @Mixin(ThaumcraftCraftingManager.class)
 public class MixinThaumcraftCraftingManager_UseCache {
 
-    @WrapMethod(method = "findMatchingArcaneRecipe")
+    @WrapMethod(method = "findMatchingArcaneRecipe", remap = false)
     private static ItemStack checkArcaneRecipeCache(IInventory awb, EntityPlayer player,
         Operation<ItemStack> original) {
         if (awb instanceof ICachedMagicWorkbench cache) {
@@ -33,7 +33,7 @@ public class MixinThaumcraftCraftingManager_UseCache {
         return original.call(awb, player);
     }
 
-    @WrapMethod(method = "findMatchingArcaneRecipeAspects")
+    @WrapMethod(method = "findMatchingArcaneRecipeAspects", remap = false)
     private static AspectList checkArcaneRecipeCacheAspects(IInventory awb, EntityPlayer player,
         Operation<AspectList> original) {
         if (awb instanceof ICachedMagicWorkbench cache) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinThaumcraftCraftingManager_UseCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinThaumcraftCraftingManager_UseCache.java
@@ -1,0 +1,52 @@
+package dev.rndmorris.salisarcana.mixins.late.lib;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import dev.rndmorris.salisarcana.lib.NullAspectList;
+import dev.rndmorris.salisarcana.lib.ifaces.ICachedMagicWorkbench;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
+
+@Mixin(ThaumcraftCraftingManager.class)
+public class MixinThaumcraftCraftingManager_UseCache {
+
+    @WrapMethod(method = "findMatchingArcaneRecipe")
+    private static ItemStack checkArcaneRecipeCache(IInventory awb, EntityPlayer player,
+        Operation<ItemStack> original) {
+        if (awb instanceof ICachedMagicWorkbench cache) {
+            final IArcaneRecipe recipe = cache.salisArcana$getArcaneRecipe();
+
+            if (recipe == null) return null;
+            if (!recipe.matches(awb, player.worldObj, player)) return null;
+
+            return recipe.getCraftingResult(awb);
+        }
+
+        return original.call(awb, player);
+    }
+
+    @WrapMethod(method = "findMatchingArcaneRecipeAspects")
+    private static AspectList checkArcaneRecipeCacheAspects(IInventory awb, EntityPlayer player,
+        Operation<AspectList> original) {
+        if (awb instanceof ICachedMagicWorkbench cache) {
+            final IArcaneRecipe recipe = cache.salisArcana$getArcaneRecipe();
+
+            if (recipe == null) return NullAspectList.INSTANCE;
+            if (!recipe.matches(awb, player.worldObj, player)) return NullAspectList.INSTANCE;
+
+            // This is stupid, but this is how the base method works.
+            final AspectList aspectsSimple = recipe.getAspects();
+            return aspectsSimple != null ? aspectsSimple : recipe.getAspects(awb);
+        }
+
+        return original.call(awb, player);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -38,7 +38,7 @@ public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
     private boolean salisArcana$recipeCacheReady = false;
 
     @Override
-    public IRecipe salisArcana$getMundaneRecipe() {
+    public final IRecipe salisArcana$getMundaneRecipe() {
         if (!this.salisArcana$recipeCacheReady) {
             this.salisArcana$calculateRecipeCache();
         }
@@ -47,7 +47,7 @@ public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
     }
 
     @Override
-    public IArcaneRecipe salisArcana$getArcaneRecipe() {
+    public final IArcaneRecipe salisArcana$getArcaneRecipe() {
         if (!this.salisArcana$recipeCacheReady) {
             this.salisArcana$calculateRecipeCache();
         }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -98,8 +98,7 @@ public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
             }
         }
 
-        this.salisArcana$mundaneRecipe = CraftingHelper.INSTANCE
-            .findMundaneRecipe(bridge, this.worldObj);
+        this.salisArcana$mundaneRecipe = CraftingHelper.INSTANCE.findMundaneRecipe(bridge, this.worldObj);
 
         if (this.salisArcana$mundaneRecipe == null) {
             this.salisArcana$arcaneRecipe = CraftingHelper.INSTANCE.findArcaneRecipe(this, knowItAll);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -85,8 +85,7 @@ public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
             .findMundaneRecipe(new MundaneCraftingBridge((TileMagicWorkbench) (Object) this), this.worldObj);
 
         if (this.salisArcana$mundaneRecipe == null) {
-            this.salisArcana$arcaneRecipe = CraftingHelper.INSTANCE
-                .findArcaneRecipe(this, this.worldObj, KnowItAll.getInstance());
+            this.salisArcana$arcaneRecipe = CraftingHelper.INSTANCE.findArcaneRecipe(this, KnowItAll.getInstance());
         } else {
             this.salisArcana$arcaneRecipe = null;
         }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -81,11 +81,28 @@ public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
 
     @Unique
     private void salisArcana$calculateRecipeCache() {
+        final var bridge = new MundaneCraftingBridge((TileMagicWorkbench) (Object) this);
+        final var knowItAll = KnowItAll.getInstance();
+
+        if (this.salisArcana$mundaneRecipe != null) {
+            if (this.salisArcana$mundaneRecipe.matches(bridge, this.worldObj)) {
+                // The new mundane recipe is the same as the previous recipe
+                this.salisArcana$recipeCacheReady = true;
+                return;
+            }
+        } else if (this.salisArcana$arcaneRecipe != null) {
+            if (this.salisArcana$arcaneRecipe.matches(this, knowItAll.worldObj, knowItAll)) {
+                // The new arcane recipe is the same as the previous recipe
+                this.salisArcana$recipeCacheReady = true;
+                return;
+            }
+        }
+
         this.salisArcana$mundaneRecipe = CraftingHelper.INSTANCE
-            .findMundaneRecipe(new MundaneCraftingBridge((TileMagicWorkbench) (Object) this), this.worldObj);
+            .findMundaneRecipe(bridge, this.worldObj);
 
         if (this.salisArcana$mundaneRecipe == null) {
-            this.salisArcana$arcaneRecipe = CraftingHelper.INSTANCE.findArcaneRecipe(this, KnowItAll.getInstance());
+            this.salisArcana$arcaneRecipe = CraftingHelper.INSTANCE.findArcaneRecipe(this, knowItAll);
         } else {
             this.salisArcana$arcaneRecipe = null;
         }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -1,0 +1,96 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.crafting.IRecipe;
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import dev.rndmorris.salisarcana.lib.CraftingHelper;
+import dev.rndmorris.salisarcana.lib.KnowItAll;
+import dev.rndmorris.salisarcana.lib.MundaneCraftingBridge;
+import dev.rndmorris.salisarcana.lib.ifaces.ICachedMagicWorkbench;
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.common.tiles.TileMagicWorkbench;
+
+@Mixin(TileMagicWorkbench.class)
+public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
+    implements IInventory, ICachedMagicWorkbench {
+
+    @Shadow
+    public ItemStack[] stackList;
+
+    @Unique
+    private IArcaneRecipe salisArcana$arcaneRecipe;
+
+    @Unique
+    private IRecipe salisArcana$mundaneRecipe;
+
+    @Unique
+    private boolean salisArcana$recipeCacheReady = false;
+
+    @Override
+    public IRecipe salisArcana$getMundaneRecipe() {
+        if (!this.salisArcana$recipeCacheReady) {
+            this.salisArcana$calculateRecipeCache();
+        }
+
+        return this.salisArcana$mundaneRecipe;
+    }
+
+    @Override
+    public IArcaneRecipe salisArcana$getArcaneRecipe() {
+        if (!this.salisArcana$recipeCacheReady) {
+            this.salisArcana$calculateRecipeCache();
+        }
+
+        return this.salisArcana$arcaneRecipe;
+    }
+
+    @Inject(method = "setInventorySlotContents", at = @At("HEAD"))
+    private void resetCache1(int par1, ItemStack par2ItemStack, CallbackInfo ci) {
+        this.salisArcana$recipeCacheReady = false;
+    }
+
+    @Inject(method = "getStackInSlotOnClosing", at = @At("HEAD"))
+    private void resetCache2(int par1, CallbackInfoReturnable<ItemStack> cir) {
+        if (this.stackList[par1] != null) {
+            this.salisArcana$recipeCacheReady = false;
+        }
+    }
+
+    @Inject(method = "decrStackSize", at = @At("HEAD"))
+    private void resetCache3(int par1, int par2, CallbackInfoReturnable<ItemStack> cir) {
+        if (this.stackList[par1] != null) {
+            this.salisArcana$recipeCacheReady = false;
+        }
+    }
+
+    @Inject(method = "readCustomNBT", at = @At("HEAD"))
+    private void resetCache4(NBTTagCompound par1NBTTagCompound, CallbackInfo ci) {
+        this.salisArcana$recipeCacheReady = false;
+    }
+
+    @Unique
+    private void salisArcana$calculateRecipeCache() {
+        this.salisArcana$mundaneRecipe = CraftingHelper.INSTANCE
+            .findMundaneRecipe(new MundaneCraftingBridge((TileMagicWorkbench) (Object) this), this.worldObj);
+
+        if (this.salisArcana$mundaneRecipe == null) {
+            this.salisArcana$arcaneRecipe = CraftingHelper.INSTANCE
+                .findArcaneRecipe(this, this.worldObj, KnowItAll.getInstance());
+        } else {
+            this.salisArcana$arcaneRecipe = null;
+        }
+
+        this.salisArcana$recipeCacheReady = true;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -25,7 +25,7 @@ import thaumcraft.common.tiles.TileMagicWorkbench;
 public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
     implements IInventory, ICachedMagicWorkbench {
 
-    @Shadow
+    @Shadow(remap = false)
     public ItemStack[] stackList;
 
     @Unique
@@ -74,7 +74,7 @@ public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
         }
     }
 
-    @Inject(method = "readCustomNBT", at = @At("HEAD"))
+    @Inject(method = "readCustomNBT", at = @At("HEAD"), remap = false)
     private void resetCache4(NBTTagCompound par1NBTTagCompound, CallbackInfo ci) {
         this.salisArcana$recipeCacheReady = false;
     }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- Bug fix - closes #278
- Improvement - bulk crafting is now near-instant instead of taking half a second.

**What is the current behavior?** (You can also link to an open issue here)
See issue #278 
Shift-clicking a craft out of the arcane workbench window can take a while to calculate.

**What is the new behavior (if this is a feature change)?**
- Arcane Workbenches now cache the last valid recipe (or if no valid recipe was found), allowing the GUI to render much faster (not profiled, but it's got to save a good 50% of the runtime.)
- Arcane Workbenches are now visibly faster (shift-clicking a stack of arcane crafting recipes took a good half-second on my dev environment, is now as fast as a Crafting Table.)
- Forge events now have a bit more compatibility with standard crafting-table triggers.

**Does this PR introduce a breaking change?**
No