### PR TITLE
Alchemical sealant

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -9,7 +9,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import dev.rndmorris.salisarcana.client.ThaumicInventoryScanner;
-import dev.rndmorris.salisarcana.client.events.WandPartTooltipEventHandler;
+import dev.rndmorris.salisarcana.client.events.TooltipHandler;
 import dev.rndmorris.salisarcana.client.handlers.GuiHandler;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 
@@ -30,7 +30,7 @@ public class ClientProxy extends CommonProxy {
             scanner.init(event);
         }
         if (SalisConfig.features.wandPartStatsTooltip.isEnabled()) {
-            MinecraftForge.EVENT_BUS.register(new WandPartTooltipEventHandler());
+            MinecraftForge.EVENT_BUS.register(new TooltipHandler());
         }
         new GuiHandler();
     }

--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -9,9 +9,9 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
 import dev.rndmorris.salisarcana.client.ThaumicInventoryScanner;
+import dev.rndmorris.salisarcana.client.events.WandPartTooltipEventHandler;
 import dev.rndmorris.salisarcana.client.handlers.GuiHandler;
 import dev.rndmorris.salisarcana.config.SalisConfig;
-import dev.rndmorris.salisarcana.lib.WandPartTooltipEventHandler;
 
 public class ClientProxy extends CommonProxy {
 

--- a/src/main/java/dev/rndmorris/salisarcana/api/NbtUtilities.java
+++ b/src/main/java/dev/rndmorris/salisarcana/api/NbtUtilities.java
@@ -1,0 +1,135 @@
+package dev.rndmorris.salisarcana.api;
+
+import java.util.Objects;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraftforge.common.util.Constants;
+
+public final class NbtUtilities {
+
+    private NbtUtilities() {}
+
+    public static final String TAG_SALIS_ARCANA = "salisarcana";
+    public static final String TAG_SUPPRESS_ASPECTS = "suppressAspects";
+
+    /**
+     * Add the NBT tag that suppresses the item's aspects, if it does not already have it.
+     * 
+     * @param stack The stack whose aspects should be suppressed.
+     * @return The input {@link ItemStack}.
+     */
+    public static @Nonnull ItemStack setSuppressAspectsTag(@Nonnull ItemStack stack) {
+        final var salisTag = getOrCreateSalisArcanaTag(stack);
+        salisTag.setBoolean(TAG_SUPPRESS_ASPECTS, true);
+        return stack;
+    }
+
+    /**
+     * Remove the NBT tag that supresses the item's aspects, if it has it.
+     * 
+     * @param stack The stack whose aspects should no longer be suppressed.
+     * @return The input {@link ItemStack}.
+     */
+    public static @Nullable ItemStack removeSupressAspectsTag(@Nullable ItemStack stack) {
+        final var salisTag = getSalisArcanaTag(stack);
+        if (salisTag == null) {
+            return stack;
+        }
+        salisTag.removeTag(TAG_SUPPRESS_ASPECTS);
+        removeEmptyTags(stack);
+        return stack;
+    }
+
+    /**
+     * Check if the given {@link ItemStack} has the tag to suppresses its aspects.
+     * 
+     * @param stack The stack whose tags should be queried.
+     * @return <c>true</c> if <c>stack</c> both is not null and has the tag to suppress the item's aspects, <c>false</c>
+     *         otherwise.
+     */
+    public static boolean hasSuppressAspectsTag(@Nullable ItemStack stack) {
+        final var salisTag = getSalisArcanaTag(stack);
+        if (salisTag == null) {
+            return false;
+        }
+        return salisTag.hasKey(TAG_SUPPRESS_ASPECTS, Constants.NBT.TAG_BYTE);
+    }
+
+    /**
+     * Try to get the Salis Arcana tag from the given {@link ItemStack}.
+     *
+     * @param itemStack The {@link ItemStack} for which the Salis Arcana tag should be retrieved.
+     * @return The Salis Arcana {@link NBTTagCompound} if <c>itemStack</c> is not null and the tag was found, or
+     *         <c>null</c> otherwise.
+     */
+    public static @Nullable NBTTagCompound getSalisArcanaTag(@Nullable ItemStack itemStack) {
+        if (itemStack == null) {
+            return null;
+        }
+        if (!itemStack.hasTagCompound()) {
+            return null;
+        }
+        final var itemTag = itemStack.getTagCompound();
+        if (!itemTag.hasKey(TAG_SALIS_ARCANA, Constants.NBT.TAG_COMPOUND)) {
+            return null;
+        }
+        return itemTag.getCompoundTag(TAG_SALIS_ARCANA);
+    }
+
+    /**
+     * Get the Salis Arcana tag for the given {@link ItemStack}, or create and attach it to the item if one is not
+     * found.
+     *
+     * @param itemStack The {@link ItemStack} for which the Salis Arcana tag should be retrieved or created.
+     * @return <c>null</c> if <c>itemStack</c> is null, or the existing or newly-created <c>salisarcana</c> tag from the
+     *         item.
+     */
+    public static @Nonnull NBTTagCompound getOrCreateSalisArcanaTag(@Nonnull ItemStack itemStack) {
+        Objects.requireNonNull(itemStack);
+
+        final NBTTagCompound itemTag;
+        if (itemStack.hasTagCompound()) {
+            itemTag = itemStack.getTagCompound();
+        } else {
+            itemStack.setTagCompound(itemTag = new NBTTagCompound());
+        }
+
+        final NBTTagCompound salisTag;
+        if (itemTag.hasKey(TAG_SALIS_ARCANA, Constants.NBT.TAG_COMPOUND)) {
+            salisTag = itemTag.getCompoundTag(TAG_SALIS_ARCANA);
+        } else {
+            itemTag.setTag(TAG_SALIS_ARCANA, salisTag = new NBTTagCompound());
+        }
+        return salisTag;
+    }
+
+    /**
+     * Remove the Salis Arcana tag if it exists but is empty, then remove the item's root tag if it exists but is empty.
+     * 
+     * @param itemStack The stack whose tags should be cleaned.
+     * @return The input {@link ItemStack}.
+     */
+    public static @Nullable ItemStack removeEmptyTags(@Nullable ItemStack itemStack) {
+        if (itemStack == null) {
+            return null;
+        }
+        if (!itemStack.hasTagCompound()) {
+            return itemStack;
+        }
+        final var itemTag = itemStack.getTagCompound();
+        if (itemTag.hasKey(TAG_SALIS_ARCANA, Constants.NBT.TAG_COMPOUND)) {
+            final var salisTag = itemTag.getCompoundTag(TAG_SALIS_ARCANA);
+            if (salisTag.hasNoTags()) {
+                itemTag.removeTag(TAG_SALIS_ARCANA);
+            }
+        }
+        if (itemTag.hasNoTags()) {
+            itemStack.setTagCompound(null);
+        }
+        return itemStack;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/client/events/TooltipHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/events/TooltipHandler.java
@@ -4,19 +4,21 @@ import java.text.NumberFormat;
 import java.util.List;
 import java.util.StringJoiner;
 
+import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.StatCollector;
 import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 
 import org.lwjgl.input.Keyboard;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import dev.rndmorris.salisarcana.api.NbtUtilities;
 import dev.rndmorris.salisarcana.lib.WandHelper;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.wands.StaffRod;
 import thaumcraft.common.config.ConfigItems;
 
-public class WandPartTooltipEventHandler {
+public class TooltipHandler {
 
     private static final NumberFormat PERCENT_FORMAT = NumberFormat.getPercentInstance();
 
@@ -25,6 +27,23 @@ public class WandPartTooltipEventHandler {
 
     @SubscribeEvent
     public void renderTooltip(ItemTooltipEvent event) {
+        renderAlchSealTooltip(event);
+        renderWandComponentTooltip(event);
+    }
+
+    private static void renderAlchSealTooltip(ItemTooltipEvent event) {
+        if (NbtUtilities.hasSuppressAspectsTag(event.itemStack)) {
+            event.toolTip.add(
+                String.format(
+                    "%s%s%s%s",
+                    EnumChatFormatting.DARK_PURPLE,
+                    EnumChatFormatting.ITALIC,
+                    StatCollector.translateToLocal("salisarcana:tagged.alchemically_sealed"),
+                    EnumChatFormatting.RESET));
+        }
+    }
+
+    private static void renderWandComponentTooltip(ItemTooltipEvent event) {
         final boolean expandText = Keyboard.isKeyDown(Keyboard.KEY_LCONTROL);
 
         final var wandCap = WandHelper.getWandCapFromItem(event.itemStack);

--- a/src/main/java/dev/rndmorris/salisarcana/client/events/WandPartTooltipEventHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/events/WandPartTooltipEventHandler.java
@@ -1,4 +1,4 @@
-package dev.rndmorris.salisarcana.lib;
+package dev.rndmorris.salisarcana.client.events;
 
 import java.text.NumberFormat;
 import java.util.List;
@@ -10,6 +10,7 @@ import net.minecraftforge.event.entity.player.ItemTooltipEvent;
 import org.lwjgl.input.Keyboard;
 
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import dev.rndmorris.salisarcana.lib.WandHelper;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.research.ResearchCategories;
 import thaumcraft.api.wands.StaffRod;

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/CustomRecipes.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nullable;
@@ -39,14 +40,19 @@ public class CustomRecipes {
 
         final var features = SalisConfig.features;
 
+        // noinspection unchecked
+        final var thaumcraftRecipes = (List<Object>) ThaumcraftApi.getCraftingRecipes();
+
+        if (features.alchemicalSealant.isEnabled()) {
+            thaumcraftRecipes.add(new ToggleSuppressAspectsRecipe());
+        }
+
         if (features.lookalikePlanks.isEnabled()) {
             registerPlankRecipes();
         }
 
         if (features.lessPickyPrimalCharmRecipe.isEnabled()) {
-            // noinspection unchecked
-            ThaumcraftApi.getCraftingRecipes()
-                .add(new RecipeForgivingPrimalCharm());
+            thaumcraftRecipes.add(new RecipeForgivingPrimalCharm());
         }
 
         if (features.rotatedThaumometerRecipe.isEnabled()) {
@@ -58,15 +64,11 @@ public class CustomRecipes {
         }
 
         if (features.replaceWandCapsSettings.isEnabled()) {
-            // noinspection unchecked
-            ThaumcraftApi.getCraftingRecipes()
-                .add(replaceWandCapsRecipe = new ReplaceWandCapsRecipe());
+            thaumcraftRecipes.add(replaceWandCapsRecipe = new ReplaceWandCapsRecipe());
         }
 
         if (features.replaceWandCoreSettings.isEnabled()) {
-            // noinspection unchecked
-            ThaumcraftApi.getCraftingRecipes()
-                .add(replaceWandCoreRecipe = new ReplaceWandCoreRecipe());
+            thaumcraftRecipes.add(replaceWandCoreRecipe = new ReplaceWandCoreRecipe());
         }
 
         if (features.rottenFleshRecipe.isEnabled()) {

--- a/src/main/java/dev/rndmorris/salisarcana/common/recipes/ToggleSuppressAspectsRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/recipes/ToggleSuppressAspectsRecipe.java
@@ -1,0 +1,105 @@
+package dev.rndmorris.salisarcana.common.recipes;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+import net.minecraft.world.World;
+
+import dev.rndmorris.salisarcana.api.NbtUtilities;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.crafting.IArcaneRecipe;
+import thaumcraft.common.items.ItemCrystalEssence;
+
+public class ToggleSuppressAspectsRecipe implements IArcaneRecipe {
+
+    private final static int[] SLOT_CRYSTALS = new int[] { 1, 3, 5, 7 };
+    private final static int[] SLOT_EMPTY = new int[] { 0, 2, 6, 8 };
+    private final static int SLOT_ITEM = 4;
+
+    private static boolean isCorrectCrystal(ItemStack stack, Aspect aspect) {
+        if (stack == null) {
+            return false;
+        }
+        if (!(stack.getItem() instanceof ItemCrystalEssence crystal)) {
+            return false;
+        }
+        return crystal.getAspects(stack)
+            .getAmount(aspect) > 0;
+    }
+
+    @Override
+    public boolean matches(IInventory inventory, World world, EntityPlayer player) {
+        for (var slot : SLOT_EMPTY) {
+            if (inventory.getStackInSlot(slot) != null) {
+                return false;
+            }
+        }
+
+        final var centerItem = inventory.getStackInSlot(SLOT_ITEM);
+        if (centerItem == null) {
+            return false;
+        }
+
+        final var action = NbtUtilities.hasSuppressAspectsTag(centerItem) ? Action.REMOVE_TAG : Action.ADD_TAG;
+        for (var slot : SLOT_CRYSTALS) {
+            if (!isCorrectCrystal(inventory.getStackInSlot(slot), action.aspect)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public ItemStack getCraftingResult(IInventory inventory) {
+        final var source = inventory.getStackInSlot(SLOT_ITEM);
+        final var output = source.splitStack(1);
+        if (NbtUtilities.hasSuppressAspectsTag(source)) {
+            return NbtUtilities.removeSupressAspectsTag(output);
+        }
+        return NbtUtilities.setSuppressAspectsTag(output);
+    }
+
+    @Override
+    public int getRecipeSize() {
+        return 9;
+    }
+
+    @Override
+    public ItemStack getRecipeOutput() {
+        return null;
+    }
+
+    @Override
+    public AspectList getAspects() {
+        return null;
+    }
+
+    @Override
+    public AspectList getAspects(IInventory inventory) {
+        if (NbtUtilities.hasSuppressAspectsTag(inventory.getStackInSlot(SLOT_ITEM))) {
+            return new AspectList().add(Aspect.ENTROPY, 1)
+                .add(Aspect.FIRE, 1);
+        }
+        return new AspectList().add(Aspect.ORDER, 30)
+            .add(Aspect.EARTH, 30);
+    }
+
+    @Override
+    public String getResearch() {
+        return "PHIAL"; // todo: replace this
+    }
+
+    private enum Action {
+
+        ADD_TAG(Aspect.ARMOR),
+        REMOVE_TAG(Aspect.WEAPON);
+
+        public final Aspect aspect;
+
+        Action(Aspect aspect) {
+            this.aspect = aspect;
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -471,6 +471,11 @@ public class ConfigFeatures extends ConfigGroup {
         "wandPartStatsTooltip",
         "Wand caps & wand rods will show information about their vis capacity & discount in their tooltips.");
 
+    public final ToggleSetting alchemicalSealant = new ToggleSetting(
+        this,
+        "alchemicalSealant",
+        "Enables crafting recipes that prevent hungry nodes, crucibles, and alchemical furnaces from being able to destroy items.");
+
     public boolean singleWandReplacementEnabled() {
         return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())
             && SalisConfig.bugfixes.arcaneWorkbenchGhostItemFix.isEnabled()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -467,6 +467,13 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)
         .addRequiredMod(TargetedMod.BAUBLES_EXPANDED)),
 
+    SUPPRESS_ASPECTS_TAG(new SalisBuilder()
+        .setApplyIf(() -> true)
+        .addCommonMixins(
+            "lib.MixinThaumicCraftingManager_SuppressAspectsTag",
+            "tiles.MixinTileNode_SuppressAspectsTag")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
+
     // Required
     ADD_VISCONTAINER_INTERFACE(new SalisBuilder()
         .setRequired()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -468,7 +468,7 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.BAUBLES_EXPANDED)),
 
     SUPPRESS_ASPECTS_TAG(new SalisBuilder()
-        .setApplyIf(() -> true)
+        .applyIf(SalisConfig.features.alchemicalSealant)
         .addCommonMixins(
             "lib.MixinThaumicCraftingManager_SuppressAspectsTag",
             "tiles.MixinTileNode_SuppressAspectsTag")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinThaumicCraftingManager_SuppressAspectsTag.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/lib/MixinThaumicCraftingManager_SuppressAspectsTag.java
@@ -1,0 +1,33 @@
+package dev.rndmorris.salisarcana.mixins.late.lib;
+
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import dev.rndmorris.salisarcana.api.NbtUtilities;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
+
+@Mixin(value = ThaumcraftCraftingManager.class, remap = false)
+public abstract class MixinThaumicCraftingManager_SuppressAspectsTag {
+
+    @WrapMethod(method = "getObjectTags")
+    private static AspectList onGetObjectTags(ItemStack itemStack, Operation<AspectList> original) {
+        if (NbtUtilities.hasSuppressAspectsTag(itemStack)) {
+            return new AspectList();
+        }
+        return original.call(itemStack);
+    }
+
+    @WrapMethod(method = "getBonusTags")
+    private static AspectList onGetBonusTags(ItemStack itemStack, AspectList sourceTags,
+        Operation<AspectList> original) {
+        if (NbtUtilities.hasSuppressAspectsTag(itemStack)) {
+            return new AspectList();
+        }
+        return original.call(itemStack, sourceTags);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_SuppressAspectsTag.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileNode_SuppressAspectsTag.java
@@ -1,0 +1,28 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityItem;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import dev.rndmorris.salisarcana.api.NbtUtilities;
+import thaumcraft.common.tiles.TileNode;
+
+@Mixin(value = TileNode.class, remap = false)
+public abstract class MixinTileNode_SuppressAspectsTag {
+
+    @ModifyExpressionValue(
+        method = "handleHungryNodeFirst",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/Entity;isEntityInvulnerable()Z"))
+    private boolean protectItems(boolean original, @Local(name = "eo") Entity entity) {
+        if (!(entity instanceof EntityItem item)) {
+            return original;
+        }
+        // if the entity is already invulnerable or has the tag, it should be immune to the hungry node's damage
+        return original || NbtUtilities.hasSuppressAspectsTag(item.getEntityItem());
+    }
+}

--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -129,6 +129,8 @@ salisarcana:error.unexpected_value=Unexpected input "%s".
 salisarcana:error.unknown_value=Unknown value "%s".
 salisarcana:error.unknown_research=%s is not a known research key.
 
+salisarcana:tagged.alchemically_sealed=Alchemically Sealed
+
 salisarcana:update_available=A new version of Salis Arcana is available (%s). 
 salisarcana:update_link= §9Click here to open the download page.§r
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

**What is the current behavior?** (You can also link to an open issue here)
There is no way to protect items from accidentally being tossed into crucibles or eaten by hungry nodes. #221 

**What is the new behavior (if this is a feature change)?**
A pair of crafting recipes add NBT tags to items that will suppress the item's aspects and protect it from alchemical machines and hungry nodes.

**Does this PR introduce a breaking change?**
NO

**Other information**:
