### PR TITLE
Remove the extra comma present at the end of `/list-research`

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/ResearchHelper.java
@@ -49,22 +49,18 @@ public class ResearchHelper {
 
             IChatComponent researchMessage = new ChatComponentText("");
 
-            final var research$ = category.research.values()
-                .iterator();
-            var anyInCategory = false;
-
-            while (research$.hasNext()) {
-                final var research = research$.next();
+            boolean anyInCategory = false;
+            for (final var research : category.research.values()) {
                 if (!filter.test(research)) {
                     continue;
                 }
-                anyInCategory = true;
-                final var item = formatResearch(research);
 
-                researchMessage.appendSibling(item);
-                if (research$.hasNext()) {
+                if (anyInCategory) {
                     researchMessage.appendText(", ");
                 }
+
+                anyInCategory = true;
+                researchMessage.appendSibling(formatResearch(research));
             }
 
             if (anyInCategory) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
`/list-research` will add an extra comma to the end of the research list when the last research is filtered out with `--search`.

**What is the new behavior (if this is a feature change)?**
It no longer does that, and the code is much simpler.

**Does this PR introduce a breaking change?**
No

Before:
<img width="854" height="480" alt="2025-08-31_00 56 34" src="https://github.com/user-attachments/assets/a21225dd-1c10-476e-83b4-a894fe98aedc" />

After:
<img width="854" height="480" alt="2025-08-31_00 50 00" src="https://github.com/user-attachments/assets/95e60b29-f9bd-459e-a223-a13df6ef2585" />
