### PR TITLE
Add validation to the aspect list settings of custom research

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/CustomResearch.java
@@ -329,7 +329,13 @@ public class CustomResearch {
                 }
                 sibling.siblings = ArrayHelper.appendToArray(sibling.siblings, fullKey);
             }
+        } else if (research.tags.size() == 0) {
+            // The research isn't free, so we need some aspect cost for it to be researchable
+            LOG.error(
+                "Research {} does not have any aspects set but is not auto-unlockable, making it impossible to research.",
+                fullKey);
         }
+
         if (settings.warp > 0) {
             ThaumcraftApi.addWarpToResearch(fullKey, settings.warp);
         }

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/CustomResearchSetting.java
@@ -127,7 +127,32 @@ public class CustomResearchSetting extends Setting {
                         this.configName);
                     continue;
                 }
-                researchAspects.add(Aspect.getAspect(aspectParts[0]), Integer.parseInt(aspectParts[1]));
+
+                int amount;
+                try {
+                    amount = Integer.parseInt(aspectParts[1]);
+                } catch (NumberFormatException e) {
+                    LOG.error(
+                        "Cannot parse amount of aspects in value \"{}\" in config setting \"{}Aspects\".",
+                        aspect,
+                        this.configName);
+                    continue;
+                }
+
+                if (amount > 0) {
+                    researchAspects.add(Aspect.getAspect(aspectParts[0]), amount);
+                } else {
+                    LOG.error(
+                        "Invalid amount of aspect {} in value \"{}\" in config setting \"{}Aspects\".",
+                        aspectParts[0],
+                        aspect,
+                        this.configName);
+                }
+            } else {
+                LOG.error(
+                    "Invalid aspect string \"{}\" in config setting \"{}Aspects\". Each value must be formatted as \"aspect:amount\".",
+                    aspect,
+                    this.configName);
             }
         }
         return researchAspects;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix / convenience feature

**What is the current behavior?** (You can also link to an open issue here)
Setting an empty aspect list on a non-auto-unlock research will make the research impossible to unlock. (https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20802)
Invalid values in the research list can cause the entire game to crash.

**What is the new behavior (if this is a feature change)?**
Added extra value verification to prevent crashes, skip invalid values, and report all errors to the console.

**Does this PR introduce a breaking change?**
No