### PR TITLE
add Super-TiC Thaumic Augmentation compatibility and generally compat for TiCon tool infusions

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileInfusionMatrix_InputEnforcement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileInfusionMatrix_InputEnforcement.java
@@ -35,6 +35,9 @@ public class MixinTileInfusionMatrix_InputEnforcement {
         final var inputTag = recipeInput.stackTagCompound;
         final var pedestalTag = fromPedestal.stackTagCompound;
 
+        // be more lenient with TiCon tools specifically
+        if (pedestalTag.hasKey("InfiTool")) return true;
+
         if ((inputTag != null && pedestalTag == null) || (inputTag == null && pedestalTag != null)) {
             return false;
         }


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Compat/Bug fix.

**What is the current behavior?** (You can also link to an open issue here)
infusions with ticon tools as center items fail instantly.

**What is the new behavior (if this is a feature change)?**
ticon tools as center items bypass the nbt check while running. 

**Does this PR introduce a breaking change?**
no.

**Other information**:
Specifically this is part of me trying to fix a Super-TiC feature in GTNH here: https://github.com/GTNewHorizons/Super-TiC/pull/10
Thaumic Augmentation in Super-TiC is a infusion recipe that adds a modifier to a TiCon tool once.

However this change will also allow any other mod to add infusion recipes affecting TiCon tools, all further details can be implemented by extending the Thaumcraft InfusionRecipe.