### PR TITLE
Display hints when hovering over question marks in research table.

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -244,6 +244,12 @@ Applying patterns to banners not consume the phial or the essentia. Overrides `b
 
 Wand caps & wand rods will show information about their vis capacity & discount in their tooltips.
 
+## Show Hints for Unknown Aspects in Research Table
+
+**Config option:** `researchTableAspectHints`
+
+Hovering over an unknown aspect inside the Research Table will show a tooltip with a hint about where you can find it.
+
 # Enhancements - Infusion
 
 ## Config option: `useStabilizerRewrite`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -471,6 +471,11 @@ public class ConfigFeatures extends ConfigGroup {
         "wandPartStatsTooltip",
         "Wand caps & wand rods will show information about their vis capacity & discount in their tooltips.");
 
+    public final ToggleSetting researchTableAspectHints = new ToggleSetting(
+        this,
+        "researchTableAspectHints",
+        "Hovering over an unknown aspect inside the Research Table will show a tooltip with a hint about where you can find it.");
+
     public boolean singleWandReplacementEnabled() {
         return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())
             && SalisConfig.bugfixes.arcaneWorkbenchGhostItemFix.isEnabled()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -464,6 +464,10 @@ public enum Mixins implements IMixins {
         .addCommonMixins("tiles.MixinTileResearchTable_FreeDuplicates")
         .addClientMixins("gui.MixinGuiResearchTable_FreeDuplicates")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    RESEARCH_UNKNOWN_ASPECT_HINT(new SalisBuilder()
+        .applyIf(SalisConfig.features.researchTableAspectHints)
+        .addClientMixins("gui.MixinGuiResearchTable_UnknownAspectTooltip")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     FOCUS_POUCH_SLOT(new SalisBuilder()
         .applyIf(SalisConfig.modCompat.baublesExpanded.focusPouchSlot)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiResearchTable_UnknownAspectTooltip.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/gui/MixinGuiResearchTable_UnknownAspectTooltip.java
@@ -1,0 +1,76 @@
+package dev.rndmorris.salisarcana.mixins.late.gui;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Container;
+import net.minecraft.util.StatCollector;
+
+import org.lwjgl.opengl.GL11;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.client.gui.GuiResearchTable;
+import thaumcraft.client.lib.UtilsFX;
+import thaumcraft.common.Thaumcraft;
+import thaumcraft.common.lib.research.ResearchNoteData;
+import thaumcraft.common.lib.utils.HexUtils;
+
+@Mixin(value = GuiResearchTable.class, remap = false)
+public abstract class MixinGuiResearchTable_UnknownAspectTooltip extends GuiContainer {
+
+    @Shadow
+    public ResearchNoteData note;
+
+    @Shadow
+    private String username;
+
+    private MixinGuiResearchTable_UnknownAspectTooltip(Container p_i1072_1_) {
+        super(p_i1072_1_);
+    }
+
+    @Inject(
+        method = "drawSheet",
+        at = @At(value = "INVOKE", target = "Lorg/lwjgl/opengl/GL11;glPopMatrix()V", ordinal = 1))
+    private void drawUnknownAspectTooltip(int x, int y, int mx, int my, CallbackInfo ci, @Local HexUtils.Hex mouseHex) {
+        final var hexData = this.note.hexEntries.get(mouseHex.toString());
+
+        if (hexData != null && hexData.aspect != null
+            && !Thaumcraft.proxy.getPlayerKnowledge()
+                .hasDiscoveredAspect(this.username, hexData.aspect)) {
+            final String aspect = hexData.aspect.getTag();
+            final String aspectHintKey = "tc.aspect.help." + aspect;
+            String hint = StatCollector.translateToLocal(aspectHintKey);
+
+            // If there's no hint translation present, fall back to aspect description
+            if (hint == aspectHintKey) {
+                hint = StatCollector.translateToLocal("tc.aspect." + aspect);
+            }
+
+            // Calculate position of textbox
+            final HexUtils.Pixel pixel = mouseHex.toPixel(9);
+            int xPos = (int) pixel.x + x + 161 + 8;
+            int yPos = (int) pixel.y + y + 75 + 20;
+
+            // Prevent textbox from overflowing out of the right edge of the GUI
+            // because it gets covered up by the NEI menu
+            xPos = Math.min(xPos, x + 94 + 85);
+
+            // -12 & +12 correct for the inherent shift in UtilsFX.drawCustomTooltip
+            GL11.glDisable(GL11.GL_LIGHTING);
+            UtilsFX.drawCustomTooltip(
+                this,
+                itemRender,
+                this.fontRendererObj,
+                this.fontRendererObj.listFormattedStringToWidth(
+                    StatCollector.translateToLocalFormatted("tc.discoveryerror", hint),
+                    150),
+                xPos - 75 - 12,
+                yPos + 12,
+                7);
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature

**What is the current behavior?** (You can also link to an open issue here)
You have no idea what aspects you need to discover in order to be able to complete a research.

**What is the new behavior (if this is a feature change)?**
Hovering over a question mark displays a textbox that gives you a hint about the unknown aspect.

**Does this PR introduce a breaking change?**
No