### PR TITLE
Prevent crucibles from melting stacks after they run out of water

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -270,3 +270,9 @@ Prevents the "Vis in Wand" GUI when the wand is held from showing impossible bar
 **Config option:** `extendUpgradeFocusPacket`
 
 Use a larger packet for sending the ID of the focus upgrade being selected, allowing the use of focus upgrade IDs > 127 on multiplayer servers.
+
+## Terminate Crucible Item-Stack Melting Early
+
+**Config option:** `earlyTerminateCrucibleCraft`
+
+Prevent large item stacks from partially dissolving into aspects if the Crucible runs out of water while crafting.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -250,6 +250,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "extendUpgradeFocusPacket",
         "Use a larger packet for sending the ID of the focus upgrade being selected, allowing the use of focus upgrade IDs > 127 on multiplayer servers.");
 
+    public final ToggleSetting earlyTerminateCrucibleCraft = new ToggleSetting(
+        this,
+        "earlyTerminateCrucibleCraft",
+        "Prevent large item stacks from partially dissolving into aspects if the Crucible runs out of water while crafting.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -218,6 +218,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.extendUpgradeFocusPacket)
         .addClientMixins("gui.MixinGuiFocalManipulator_UseExtendedEnchantmentPacket")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    EARLY_TERMINATE_CRUCIBLE_CRAFT(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.earlyTerminateCrucibleCraft)
+        .addCommonMixins("tiles.MixinTileCrucible_EarlyTerminateCraft")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_EarlyTerminateCraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/tiles/MixinTileCrucible_EarlyTerminateCraft.java
@@ -1,0 +1,29 @@
+package dev.rndmorris.salisarcana.mixins.late.tiles;
+
+import net.minecraftforge.fluids.FluidTank;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import thaumcraft.common.tiles.TileCrucible;
+
+@Mixin(value = TileCrucible.class, remap = false)
+public class MixinTileCrucible_EarlyTerminateCraft {
+
+    @Shadow
+    public FluidTank tank;
+
+    @ModifyVariable(
+        method = "attemptSmelt",
+        name = "a",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraftforge/fluids/FluidTank;drain(IZ)Lnet/minecraftforge/fluids/FluidStack;",
+            shift = At.Shift.AFTER))
+    private int terminateLoop(int original) {
+        // It will get incremented, so we don't want it to roll over.
+        return this.tank.getFluidAmount() > 0 ? original : (Integer.MAX_VALUE - 1);
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
Closes #397

**What is the new behavior (if this is a feature change)?**
Crucibles will immediately stop trying to process a stack after the water is gone.

**Does this PR introduce a breaking change?**
No

**Other information**:
A bug fix speedrun? 15 minutes from troubleshooting to PR!