### PR TITLE
Prevent items from being consumed by multiple Crucibles in the same tick.

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -322,3 +322,9 @@ When right-clicking a Research Note made from Knowledge Fragments, will use a ra
 **Config option:** `hiddenResearchCheckInventory`
 
 When right-clicking a Research Note made from Knowledge Fragments, will not generate a research note you already have in your inventory.
+
+## Prevent Crucible Dead-Item Duplication Glitch
+
+**Config option:** `crucibleDeadItemDupe`
+
+Prevent multiple Crucibles from melting/crafting the same item entity in the same tick.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -293,6 +293,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "hiddenResearchCheckInventory",
         "When right-clicking a Research Note made from Knowledge Fragments, will not generate a research note you already have in your inventory.");
 
+    public final ToggleSetting crucibleDeadItemDupe = new ToggleSetting(
+        this,
+        "crucibleDeadItemDupe",
+        "Prevent multiple Crucibles from melting/crafting the same item entity in the same tick.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -238,6 +238,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.hiddenResearchCheckInventory)
         .addCommonMixins("thaumcraft.common.lib.research.MixinResearchManager_SkipResearchInInventory")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    PREVENT_DEAD_ITEM_CRUCIBLE_DUPE(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.crucibleDeadItemDupe)
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileCrucible_NoDupeDeadItems")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     ELEMENTAL_PICK_SCAN_ZERO_ASPECTS(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.detectZeroAspectBlocks)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_NoDupeDeadItems.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_NoDupeDeadItems.java
@@ -1,0 +1,21 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
+
+import net.minecraft.entity.item.EntityItem;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import thaumcraft.common.tiles.TileCrucible;
+
+@Mixin(TileCrucible.class)
+public abstract class MixinTileCrucible_NoDupeDeadItems {
+
+    @WrapMethod(method = "attemptSmelt", remap = false)
+    private void ignoreDeadItems(EntityItem entity, Operation<Void> original) {
+        if (!entity.isDead) {
+            original.call(entity);
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - fixes a duplication glitch.

**What is the current behavior?** (You can also link to an open issue here)
Closes #434

**What is the new behavior (if this is a feature change)?**
Only one Crucible will consume any one item entity.

**Does this PR introduce a breaking change?**
No