### PR TITLE
Prevent Crucibles from consuming Water Buckets in Creative Mode.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -314,6 +314,7 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.features.stopCreativeModeItemConsumption)
         .addCommonMixins(
             "thaumcraft.common.blocks.MixinBlockEldritch_CreativeMode",
+            "thaumcraft.common.blocks.MixinBlockMetalDevice_CreativePreserveWater",
             "thaumcraft.common.items.MixinItemEssence_CreativeItemConsumption")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMetalDevice_CreativePreserveWater.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMetalDevice_CreativePreserveWater.java
@@ -1,0 +1,33 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.blocks;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.InventoryPlayer;
+import net.minecraft.item.ItemStack;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.common.blocks.BlockMetalDevice;
+
+@Mixin(BlockMetalDevice.class)
+public class MixinBlockMetalDevice_CreativePreserveWater {
+
+    @WrapWithCondition(
+        method = "onBlockActivated",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/entity/player/InventoryPlayer;decrStackSize(II)Lnet/minecraft/item/ItemStack;"))
+    private boolean preventWaterConsumption(InventoryPlayer instance, int itemstack, int i,
+        @Local(argsOnly = true) EntityPlayer player) {
+        return !player.capabilities.isCreativeMode;
+    }
+
+    @ModifyVariable(method = "onBlockActivated", at = @At("STORE"), name = "emptyContainer")
+    private ItemStack noEmptyContainers(ItemStack value, @Local(argsOnly = true) EntityPlayer player) {
+        return player.capabilities.isCreativeMode ? null : value;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature improvement.

**What is the current behavior?** (You can also link to an open issue here)
Right-clicking a water bucket on a Crucible to fill it up always consumes the water inside the bucket.

**What is the new behavior (if this is a feature change)?**
The water no longer gets consumed in Creative Mode, and you don't get empty buckets back.

**Does this PR introduce a breaking change?**
No