### PR TITLE
Update Baubles dependency

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,7 +36,7 @@
 dependencies {
     api("com.github.GTNewHorizons:NotEnoughItems:2.8.40-GTNH:dev")
     runtimeOnly("com.github.GTNewHorizons:waila:1.9.15:dev@jar")
-    runtimeOnly("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev")
+    api("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev")
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
     // devOnlyNonPublishable(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
@@ -46,7 +46,6 @@ dependencies {
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))
     compileOnly(rfg.deobf("curse.maven:undergroundbiomesconstructs-72744:2304497"))
     compileOnly("com.github.GTNewHorizons:GTNH-TC-Wands:1.4.6:dev")
-    compileOnly('com.github.GTNewHorizons:Baubles-Expanded:2.2.2-GTNH:dev')
 
     /* Patched TC4 addons */
     compileOnly("com.github.GTNewHorizons:ThaumicTinkerer:2.12.2:dev")


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
The Baubles-1.0.4 dep is updated to Baubles-Expanded-2.2.6. A `compileOnly` statement is removed since it's now redundant.

**What is the current behavior?** (You can also link to an open issue here)
The mod does not build!

**What is the new behavior (if this is a feature change)?**
The mod builds!

**Does this PR introduce a breaking change?**
No; Baubles-Expanded should be backwards compatible.

**Other information**:
The same change was made in e.g. https://github.com/GTNewHorizons/ThaumicEnergistics/pull/108 or https://github.com/GTNewHorizons/Gadomancy/pull/47/changes/5c2d4af539261d7a0f86aaf35cf07d6ec41634f0