### PR TITLE
Add deepslate to list of blocks able to be crushed by Primal Crusher.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/equipment/PrimalCrusher_StoneOredictCompat.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/equipment/PrimalCrusher_StoneOredictCompat.java
@@ -12,6 +12,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import com.llamalad7.mixinextras.sugar.Local;
 
+import cpw.mods.fml.common.Loader;
 import ganymedes01.etfuturum.blocks.BlockDeepslate;
 import thaumcraft.common.items.equipment.ItemPrimalCrusher;
 
@@ -42,7 +43,7 @@ public abstract class PrimalCrusher_StoneOredictCompat {
             sa$cobblestoneOreId = OreDictionary.getOreID("cobblestone");
             sa$stoneBrickOreId = OreDictionary.getOreID("stoneBricks");
         }
-        if (block instanceof BlockDeepslate) return true;
+        if (Loader.isModLoaded("etfuturum") && block instanceof BlockDeepslate) return true;
         final int[] oreIds = OreDictionary.getOreIDs(new ItemStack(block, 1, metadata));
         for (final var oreId : oreIds) {
             if (oreId == sa$stoneOreId || oreId == sa$cobblestoneOreId || oreId == sa$stoneBrickOreId) {


### PR DESCRIPTION
**What kind of change does this PR introduce?** Change to feature


**What is the current behavior?** (You can also link to an open issue here) Primal crusher can crush stone, dirt or other stone-type blocks, but it cannot crush deepslate and instead mines normally (Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23140).


**What is the new behavior (if this is a feature change)?** The primal crusher can now crush deepslate and mine it in a 3x3 area. 


**Does this PR introduce a breaking change?** No


**Other information**: I haven't tested this yet because the baubles dependency is out-of-date, tried using baubles expanded but it would freeze on world load. I also couldn't use oredict because EtFuturum deepslate appears to not have any oredict.
