### PR TITLE
[Memory-opti:runtime allocations] prevent the TileNode from constantly loading chunks while ticking

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -318,7 +318,7 @@ public class ConfigBugfixes extends ConfigGroup {
     public final ToggleSetting fixNodeTriggeringChunkLoading = new ToggleSetting(
         this,
         "fixNodeTriggeringChunkLoading",
-        "Fix Node code constantly triggering chunk loading");
+        "Prevent Node ticking code from triggering constant chunk loading on the server.");
 
     @Nonnull
     @Override

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -315,6 +315,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "stableRunicMatrixAnimation",
         "Runic Matrices which are too stable will not fly far out from the center of the multiblock.");
 
+    public final ToggleSetting fixNodeTriggeringChunkLoading = new ToggleSetting(
+        this,
+        "fixNodeTriggeringChunkLoading",
+        "Fix Node code constantly triggering chunk loading");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -571,6 +571,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.taintedModifierSpeed)
         .addCommonMixins("thaumcraft.common.tiles.MixinTileNode_ModifierSpeed_Tainted")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    NODE_FIX_GET_BLOCK(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.fixNodeTriggeringChunkLoading)
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileNode_ProtectGetBlock")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     FAKE_PLAYERS_DROP_LOOTBAGS(new SalisBuilder()
         .applyIf(SalisConfig.features.fakePlayersDropLootbags)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
@@ -1,12 +1,10 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.world.World;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.Redirect;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.sugar.Local;
@@ -16,18 +14,19 @@ import thaumcraft.common.tiles.TileNode;
 @Mixin(TileNode.class)
 public class MixinTileNode_ProtectGetBlock extends TileEntity {
 
-    @Redirect(
+    @Inject(
         method = "handleDischarge",
         remap = false,
+        cancellable = true,
         at = @At(
             value = "INVOKE",
             target = "Lnet/minecraft/world/World;getTileEntity(III)Lnet/minecraft/tileentity/TileEntity;",
             remap = true))
-    private TileEntity protectGetTE(World instance, int x, int y, int z) {
-        if (this.worldObj.blockExists(x, y, z)) {
-            return this.worldObj.getTileEntity(x, y, z);
+    private void protectGetTE(boolean change, CallbackInfoReturnable<Boolean> cir, @Local(name = "x") int x,
+        @Local(name = "y") int y, @Local(name = "z") int z) {
+        if (!this.worldObj.blockExists(this.xCoord + x, this.yCoord + y, this.zCoord + z)) {
+            cir.setReturnValue(change);
         }
-        return null;
     }
 
     @Inject(

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
@@ -11,8 +11,16 @@ import com.llamalad7.mixinextras.sugar.Local;
 
 import thaumcraft.common.tiles.TileNode;
 
+/**
+ * The tick code of TileNode has multiple calls to world.getBlock, world.getTileEntity...
+ * with coordinates that's around the Node, thing is if those coordinates happen to be in
+ * unloaded chunks, the call to getBlock will trigger chunk loading on the server which
+ * is bad for performance.
+ * This mixin prevents this behavior by adding worldObj.blockExists checks before
+ * running the code that would trigger chunk loading.
+ */
 @Mixin(TileNode.class)
-public class MixinTileNode_ProtectGetBlock extends TileEntity {
+public abstract class MixinTileNode_ProtectGetBlock extends TileEntity {
 
     @Inject(
         method = "handleDischarge",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
@@ -1,0 +1,63 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.common.tiles.TileNode;
+
+@Mixin(TileNode.class)
+public class MixinTileNode_ProtectGetBlock extends TileEntity {
+
+    @Redirect(
+        method = "handleDischarge",
+        remap = false,
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/World;getTileEntity(III)Lnet/minecraft/tileentity/TileEntity;",
+            remap = true))
+    private TileEntity protectGetTE(World instance, int x, int y, int z) {
+        if (this.worldObj.blockExists(x, y, z)) {
+            return this.worldObj.getTileEntity(x, y, z);
+        }
+        return null;
+    }
+
+    @Inject(
+        method = "handlePureNode",
+        remap = false,
+        cancellable = true,
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/World;getBiomeGenForCoords(II)Lnet/minecraft/world/biome/BiomeGenBase;",
+            remap = true))
+    private void protectGetBiome(boolean change, CallbackInfoReturnable<Boolean> cir, @Local(name = "x") int x,
+        @Local(name = "z") int z) {
+        if (!this.worldObj.blockExists(x, 0, z)) {
+            cir.setReturnValue(change);
+        }
+    }
+
+    @Inject(
+        method = "handleHungryNodeSecond",
+        remap = false,
+        cancellable = true,
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/util/Vec3;createVectorHelper(DDD)Lnet/minecraft/util/Vec3;",
+            ordinal = 0,
+            remap = true))
+    private void protectGetBlock(boolean change, CallbackInfoReturnable<Boolean> cir, @Local(name = "tx") int tx,
+        @Local(name = "ty") int ty, @Local(name = "tz") int tz) {
+        if (!this.worldObj.blockExists(tx, ty, tz)) {
+            cir.setReturnValue(change);
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

prevent the TileNode from constantly loading chunks while ticking

In my profile this cause 20% of the allocations on the server thread

<img width="333" height="576" alt="image" src="https://github.com/user-attachments/assets/58725319-b204-415b-90e3-08559bdaaafd" />

