### PR TITLE
Replace Thaumonomicon font renderer with Angelica's

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -46,6 +46,7 @@ dependencies {
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))
     compileOnly(rfg.deobf("curse.maven:undergroundbiomesconstructs-72744:2304497"))
     compileOnly("com.github.GTNewHorizons:GTNH-TC-Wands:1.4.6:dev")
+    compileOnly("com.github.GTNewHorizons:Angelica:2.1.3:dev")
 
     /* Patched TC4 addons */
     compileOnly("com.github.GTNewHorizons:ThaumicTinkerer:2.12.2:dev")

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigModCompat.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigModCompat.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import dev.rndmorris.salisarcana.config.ConfigGroup;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.config.settings.ToggleSetting;
+import dev.rndmorris.salisarcana.config.settings.compat.AngelicaSettings;
 import dev.rndmorris.salisarcana.config.settings.compat.BaublesExpandedSettings;
 import dev.rndmorris.salisarcana.config.settings.compat.GTNHTCWandsCompatSettings;
 import dev.rndmorris.salisarcana.config.settings.compat.UBCCompatSettings;
@@ -14,6 +15,7 @@ public class ConfigModCompat extends ConfigGroup {
     public final UBCCompatSettings undergroundBiomes = new UBCCompatSettings(this);
     public final GTNHTCWandsCompatSettings gtnhWands = new GTNHTCWandsCompatSettings(this);
     public final BaublesExpandedSettings baublesExpanded = new BaublesExpandedSettings(this);
+    public final AngelicaSettings angelica = new AngelicaSettings(this);
 
     public final ToggleSetting tc4tweakScrollPages = new ToggleSetting(
         SalisConfig.features.nomiconScrollwheelEnabled,

--- a/src/main/java/dev/rndmorris/salisarcana/config/settings/compat/AngelicaSettings.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/settings/compat/AngelicaSettings.java
@@ -1,0 +1,17 @@
+package dev.rndmorris.salisarcana.config.settings.compat;
+
+import dev.rndmorris.salisarcana.config.IEnabler;
+import dev.rndmorris.salisarcana.config.settings.ToggleSetting;
+import dev.rndmorris.salisarcana.mixins.TargetedMod;
+
+public class AngelicaSettings extends BaseCompatSetting {
+
+    public final ToggleSetting replaceTCFontRenderer = new ToggleSetting(
+        this,
+        "replaceTCFontRenderer",
+        "Replace the Thaumonomicon's font rendering with Angelica's, using settings that should improve the appearance of text.");
+
+    public AngelicaSettings(IEnabler dependency) {
+        super(dependency, TargetedMod.ANGELICA);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -587,10 +587,10 @@ public enum Mixins implements IMixins {
         .addClientMixins("thaumcraft.client.lib.MixinUtilsFX_DisableAspectTint")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
-    MIXIN_TCFONTRENDERER(new SalisBuilder()
+    MIXIN_ANGELICA_FONTRENDERER(new SalisBuilder()
         .setApplyIf(() -> SalisConfig.modCompat.angelica.replaceTCFontRenderer.isEnabled()
             && TargetedMod.ANGELICA.isLoaded() && AngelicaConfig.enableFontRenderer)
-        .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer")
+        .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer_AngelicaFontRenderer")
         .addRequiredMod(TargetedMod.THAUMCRAFT)
         .addRequiredMod(TargetedMod.ANGELICA)),
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -4,8 +4,8 @@ import javax.annotation.Nonnull;
 
 import com.gtnewhorizon.gtnhmixins.builders.IMixins;
 import com.gtnewhorizon.gtnhmixins.builders.MixinBuilder;
-
 import com.gtnewhorizons.angelica.config.AngelicaConfig;
+
 import dev.rndmorris.salisarcana.common.compat.MixinModCompat;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.config.settings.Setting;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -589,12 +589,7 @@ public enum Mixins implements IMixins {
 
     MIXIN_TCFONTRENDERER(new SalisBuilder()
         .setApplyIf(() -> {
-            try {
-                Class.forName("com.gtnewhorizons.angelica.config.AngelicaConfig");
-            } catch (ClassNotFoundException e) {
-                return false;
-            }
-            return AngelicaConfig.enableFontRenderer;
+            return TargetedMod.ANGELICA.isLoaded() && AngelicaConfig.enableFontRenderer;
         })
         .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer")
         .addRequiredMod(TargetedMod.THAUMCRAFT)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -588,9 +588,7 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     MIXIN_TCFONTRENDERER(new SalisBuilder()
-        .setApplyIf(() -> {
-            return TargetedMod.ANGELICA.isLoaded() && AngelicaConfig.enableFontRenderer;
-        })
+        .setApplyIf(() -> TargetedMod.ANGELICA.isLoaded() && AngelicaConfig.enableFontRenderer)
         .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer")
         .addRequiredMod(TargetedMod.THAUMCRAFT)
         .addRequiredMod(TargetedMod.ANGELICA)),

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -588,8 +588,8 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     MIXIN_TCFONTRENDERER(new SalisBuilder()
-        .applyIf(SalisConfig.modCompat.angelica.replaceTCFontRenderer)
-        .setApplyIf(() -> TargetedMod.ANGELICA.isLoaded() && AngelicaConfig.enableFontRenderer)
+        .setApplyIf(() -> SalisConfig.modCompat.angelica.replaceTCFontRenderer.isEnabled()
+            && TargetedMod.ANGELICA.isLoaded() && AngelicaConfig.enableFontRenderer)
         .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer")
         .addRequiredMod(TargetedMod.THAUMCRAFT)
         .addRequiredMod(TargetedMod.ANGELICA)),

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -5,6 +5,7 @@ import javax.annotation.Nonnull;
 import com.gtnewhorizon.gtnhmixins.builders.IMixins;
 import com.gtnewhorizon.gtnhmixins.builders.MixinBuilder;
 
+import com.gtnewhorizons.angelica.config.AngelicaConfig;
 import dev.rndmorris.salisarcana.common.compat.MixinModCompat;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.config.settings.Setting;
@@ -585,6 +586,20 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.disableAspectTint)
         .addClientMixins("thaumcraft.client.lib.MixinUtilsFX_DisableAspectTint")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+
+    MIXIN_TCFONTRENDERER(new SalisBuilder()
+        .setApplyIf(() -> {
+            try {
+                Class.forName("com.gtnewhorizons.angelica.config.AngelicaConfig");
+            } catch (ClassNotFoundException e) {
+                return false;
+            }
+            return AngelicaConfig.enableFontRenderer;
+        })
+        //.setApplyIf(() -> false)
+        .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)
+        .addRequiredMod(TargetedMod.ANGELICA)),
 
     // Required
     ADD_VISCONTAINER_INTERFACE(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -596,7 +596,6 @@ public enum Mixins implements IMixins {
             }
             return AngelicaConfig.enableFontRenderer;
         })
-        //.setApplyIf(() -> false)
         .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer")
         .addRequiredMod(TargetedMod.THAUMCRAFT)
         .addRequiredMod(TargetedMod.ANGELICA)),

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -588,6 +588,7 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     MIXIN_TCFONTRENDERER(new SalisBuilder()
+        .applyIf(SalisConfig.modCompat.angelica.replaceTCFontRenderer)
         .setApplyIf(() -> TargetedMod.ANGELICA.isLoaded() && AngelicaConfig.enableFontRenderer)
         .addClientMixins("thaumcraft.client.lib.MixinTCFontRenderer")
         .addRequiredMod(TargetedMod.THAUMCRAFT)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
@@ -15,7 +15,8 @@ public enum TargetedMod implements ITargetMod {
     THAUMIC_TINKERER("ThaumicTinkerer"),
     TC4_TWEAKS("tc4tweak"),
     BAUBLES_EXPANDED("Baubles|Expanded"),
-    UNDERGROUND_BIOMES("UndergroundBiomes");
+    UNDERGROUND_BIOMES("UndergroundBiomes"),
+    ANGELICA("angelica");
 
     private final TargetModBuilder builder;
     public final String modId;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
@@ -14,10 +14,10 @@ import thaumcraft.client.lib.TCFontRenderer;
 public class MixinTCFontRenderer {
 
     @Unique
-    private static FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
+    private static FontRenderer sa$fr = Minecraft.getMinecraft().fontRenderer;
 
     @Unique
-    private static BatchingFontRenderer bfr = ((FontRendererAccessor) fr).angelica$getBatcher();
+    private static BatchingFontRenderer sa$bfr = ((FontRendererAccessor) sa$fr).angelica$getBatcher();
 
     /**
      * @author DeathFuel
@@ -25,9 +25,9 @@ public class MixinTCFontRenderer {
      */
     @Overwrite
     private int renderString(String text, int x, int y, int argb, boolean dropShadow) {
-        bfr.setBookMode(true);
-        int i = ((FontRendererAccessor) fr).angelica$drawStringBatched(text, x, y, argb, dropShadow);
-        bfr.setBookMode(false);
+        sa$bfr.setBookMode(true);
+        int i = ((FontRendererAccessor) sa$fr).angelica$drawStringBatched(text, x, y, argb, dropShadow);
+        sa$bfr.setBookMode(false);
         return i;
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
@@ -1,13 +1,15 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.client.lib;
 
-import com.gtnewhorizons.angelica.client.font.BatchingFontRenderer;
-import com.gtnewhorizons.angelica.mixins.interfaces.FontRendererAccessor;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
-import org.spongepowered.asm.mixin.Mixin;
 
+import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Unique;
+
+import com.gtnewhorizons.angelica.client.font.BatchingFontRenderer;
+import com.gtnewhorizons.angelica.mixins.interfaces.FontRendererAccessor;
+
 import thaumcraft.client.lib.TCFontRenderer;
 
 @Mixin(value = TCFontRenderer.class, remap = false)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
@@ -21,7 +21,7 @@ public class MixinTCFontRenderer {
 
     /**
      * @author DeathFuel
-     * @reason test
+     * @reason Overwrite TC's copy-pasted font rendering code with Angelica's replacements
      */
     @Overwrite
     private int renderString(String text, int x, int y, int argb, boolean dropShadow) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer.java
@@ -1,0 +1,33 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.client.lib;
+
+import com.gtnewhorizons.angelica.client.font.BatchingFontRenderer;
+import com.gtnewhorizons.angelica.mixins.interfaces.FontRendererAccessor;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.FontRenderer;
+import org.spongepowered.asm.mixin.Mixin;
+
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+import thaumcraft.client.lib.TCFontRenderer;
+
+@Mixin(value = TCFontRenderer.class, remap = false)
+public class MixinTCFontRenderer {
+
+    @Unique
+    private static FontRenderer fr = Minecraft.getMinecraft().fontRenderer;
+
+    @Unique
+    private static BatchingFontRenderer bfr = ((FontRendererAccessor) fr).angelica$getBatcher();
+
+    /**
+     * @author DeathFuel
+     * @reason test
+     */
+    @Overwrite
+    private int renderString(String text, int x, int y, int argb, boolean dropShadow) {
+        bfr.setBookMode(true);
+        int i = ((FontRendererAccessor) fr).angelica$drawStringBatched(text, x, y, argb, dropShadow);
+        bfr.setBookMode(false);
+        return i;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer_AngelicaFontRenderer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer_AngelicaFontRenderer.java
@@ -13,7 +13,7 @@ import com.gtnewhorizons.angelica.mixins.interfaces.FontRendererAccessor;
 import thaumcraft.client.lib.TCFontRenderer;
 
 @Mixin(value = TCFontRenderer.class, remap = false)
-public class MixinTCFontRenderer {
+public abstract class MixinTCFontRenderer_AngelicaFontRenderer {
 
     @Unique
     private static FontRenderer sa$fr = Minecraft.getMinecraft().fontRenderer;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Mixin to replace the Thaumonomicon's font renderer with Angelica's, if the latter is present and has its font rendering features enabled.

**What is the current behavior?** / **What is the new behavior?**
Before and after with GUI scale 3:
![tc](https://github.com/user-attachments/assets/ff3867f5-8ae4-40b5-8aae-0305a3ddfa84)

**Does this PR introduce a breaking change?**
No

**Other information**:
Requires both https://github.com/GTNewHorizons/Angelica/pull/1489 and https://github.com/GTNewHorizons/GTNHLib/pull/300 to work and look right.