### PR TITLE
Add a null check to fix a crash during Outer Lands generation

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -24,6 +24,12 @@ the only valid variant.
 Prevent eldritch crabs, thaumic slimes, and all taintacles from being able to attack while performing their death
 animation.
 
+## Fix Outer Lands Null Crash
+
+**Config option:** `fixOuterLandsNull`
+
+Fixes generation of the Outer Lands dungeons failing due to attempting to set the orientation of an invalid tile entity.
+
 ## Infernal Furnace Item Duplication Fix
 
 **Config option:** `infernalFurnaceDupeFix`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -325,6 +325,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "fixInventoryAspects",
         "Fixes a bug where some GUIs would render the wrong aspects when shifting over a slot. Also improves the performance of this overlay.");
 
+    public final ToggleSetting fixOuterLandsNull = new ToggleSetting(
+        this,
+        "fixOuterLandsNull",
+        "Fixes generation of the Outer Lands dungeons failing due to attempting to set the orientation of an invalid tile entity.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -289,6 +289,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.betterParticleEngine)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_SkipRendering")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    FIX_OUTER_LANDS_NULL_TE(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.fixOuterLandsNull)
+        .addClientMixins("thaumcraft.common.lib.world.dim.MixinGenCommon_NullCheck")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/dim/MixinGenCommon_NullCheck.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/dim/MixinGenCommon_NullCheck.java
@@ -1,0 +1,31 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.lib.world.dim;
+
+import net.minecraft.world.World;
+import net.sf.cglib.asm.Opcodes;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.common.lib.world.dim.GenCommon;
+import thaumcraft.common.tiles.TileCrystal;
+
+@Mixin(value = GenCommon.class, remap = false)
+public class MixinGenCommon_NullCheck {
+
+    @Inject(
+        method = "processDecorations",
+        at = @At(
+            value = "FIELD",
+            target = "Lthaumcraft/common/tiles/TileCrystal;orientation:S",
+            opcode = Opcodes.PUTFIELD),
+        cancellable = true)
+    private static void preventNullOrientation(World world, CallbackInfo ci, @Local(name = "te") TileCrystal te) {
+        if (te == null) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/dim/MixinGenCommon_NullCheck.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/dim/MixinGenCommon_NullCheck.java
@@ -14,7 +14,7 @@ import thaumcraft.common.lib.world.dim.GenCommon;
 import thaumcraft.common.tiles.TileCrystal;
 
 @Mixin(value = GenCommon.class, remap = false)
-public class MixinGenCommon_NullCheck {
+public abstract class MixinGenCommon_NullCheck {
 
     @Inject(
         method = "processDecorations",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

**What is the current behavior?** (You can also link to an open issue here)
Sometimes the Outer Lands generation causes this crash (happened to me in Blightfall, may be made worse by some other mod like archaicfix which is in the stacktrace because I haven't noticed this problem before):
https://mclo.gs/qph8Fc3

**What is the new behavior (if this is a feature change)?**
It will not attempt to write to a null TE.

**Does this PR introduce a breaking change?**
No
