### PR TITLE
fix thaumcraft tree generators leaking world instance

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -293,7 +293,7 @@ Fix Thaumcraft's tree generators leaking the world instance.
 
 **Config option:** `muteExcessiveWarpSounds`
 
-Prevent warp sounds from blasting out your eardrums when you obtains lots of warp in an instant.
+Prevent warp sounds from blasting out your eardrums when obtaining lots of warp in an instant.
 
 ## Handle Invalid Focus NBT on Wands
 

--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -283,6 +283,12 @@ Prevent large item stacks from partially dissolving into aspects if the Crucible
 
 Prevents a world object memory leak in the TeleporterThaumcraft class.
 
+## Fix Tree Generators World memory leak
+
+**Config option:** `fixTreeGenWorldLeak`
+
+Fix Thaumcraft's tree generators leaking the world instance.
+
 ## Prevent Warp Sounds from Blasting Out Your Eardrums
 
 **Config option:** `muteExcessiveWarpSounds`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -325,6 +325,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "fixInventoryAspects",
         "Fixes a bug where some GUIs would render the wrong aspects when shifting over a slot. Also improves the performance of this overlay.");
 
+    public final ToggleSetting fixTreeGenWorldLeak = new ToggleSetting(
+        this,
+        "fixTreeGenWorldLeak",
+        "Fix Thaumcraft's tree generators leaking the world instance");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -174,6 +174,11 @@ public class ConfigThaumcraft extends ConfigGroup {
         "Improves the particle engine of Thaumcraft by removing unnecessary GL operations.")
             .setCategory(tc4PerformanceCategory);
 
+    public final ToggleSetting fixTreeGenWorldLeak = new ToggleSetting(
+        this,
+        "fixTreeGenWorldLeak",
+        "Fix thaumcraft tree generators leaking the world instance");
+
     @Override
     public @NotNull String getGroupName() {
         return "thaumcraft_configuration";

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -174,11 +174,6 @@ public class ConfigThaumcraft extends ConfigGroup {
         "Improves the particle engine of Thaumcraft by removing unnecessary GL operations.")
             .setCategory(tc4PerformanceCategory);
 
-    public final ToggleSetting fixTreeGenWorldLeak = new ToggleSetting(
-        this,
-        "fixTreeGenWorldLeak",
-        "Fix thaumcraft tree generators leaking the world instance");
-
     @Override
     public @NotNull String getGroupName() {
         return "thaumcraft_configuration";

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -289,6 +289,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.betterParticleEngine)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_SkipRendering")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    FIX_TREE_GEN_LEAK(new SalisBuilder()
+        .applyIf(SalisConfig.thaum.fixTreeGenWorldLeak)
+        .addCommonMixins("thaumcraft.common.lib.world.MixinGenTrees_FixLeak")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -290,7 +290,7 @@ public enum Mixins implements IMixins {
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_SkipRendering")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     FIX_TREE_GEN_LEAK(new SalisBuilder()
-        .applyIf(SalisConfig.thaum.fixTreeGenWorldLeak)
+        .applyIf(SalisConfig.bugfixes.fixTreeGenWorldLeak)
         .addCommonMixins("thaumcraft.common.lib.world.MixinGenTrees_FixLeak")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinGenTrees_FixLeak.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinGenTrees_FixLeak.java
@@ -13,7 +13,7 @@ import thaumcraft.common.lib.world.WorldGenGreatwoodTrees;
 import thaumcraft.common.lib.world.WorldGenSilverwoodTreesOld;
 
 @Mixin({ WorldGenBigMagicTree.class, WorldGenGreatwoodTrees.class, WorldGenSilverwoodTreesOld.class })
-public class MixinGenTrees_FixLeak {
+public abstract class MixinGenTrees_FixLeak {
 
     @Shadow(remap = false)
     World worldObj;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinGenTrees_FixLeak.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinGenTrees_FixLeak.java
@@ -1,0 +1,25 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.lib.world;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import thaumcraft.common.lib.world.WorldGenBigMagicTree;
+import thaumcraft.common.lib.world.WorldGenGreatwoodTrees;
+import thaumcraft.common.lib.world.WorldGenSilverwoodTreesOld;
+
+@Mixin({ WorldGenBigMagicTree.class, WorldGenGreatwoodTrees.class, WorldGenSilverwoodTreesOld.class })
+public class MixinGenTrees_FixLeak {
+
+    @Shadow(remap = false)
+    World worldObj;
+
+    @Inject(method = "generate(Lnet/minecraft/world/World;Ljava/util/Random;III)Z", at = @At("RETURN"))
+    private void clearWorldRef(CallbackInfoReturnable<Boolean> cir) {
+        this.worldObj = null;
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
fix tree generators leaking the world instance

**What is the current behavior?** (You can also link to an open issue here)
leaking the world instance

**What is the new behavior (if this is a feature change)?**
not leaking the world instance

<img width="452" height="113" alt="image" src="https://github.com/user-attachments/assets/5a571187-6dce-46ad-b88d-11aaac9136a7" />
