### PR TITLE
Make the crucible's decay scale more with how full it is

### DIFF
--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -6,6 +6,9 @@ Config file: `config/salisarcana/thaumcraft_configuration.cfg`
 If true, disables the tinting of aspect images, this can be useful in combination with resource packs
 that provide images that are already colored.
 
+### Config Option: `crucibleScalingAspectDecay` (Default `true`)
+If true, the crucible's contained aspects will decay at an increasing rate based on how full the crucible is.
+
 ## Node Behaviors (Group `node_behaviors`)
 
 ### Config Option: `hungryDynamicReach` (Default `false`)

--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -7,7 +7,35 @@ If true, disables the tinting of aspect images, this can be useful in combinatio
 that provide images that are already colored.
 
 ### Config Option: `crucibleScalingAspectDecay` (Default `true`)
-If true, the crucible's contained aspects will decay at an increasing rate based on how full the crucible is.
+If true, the crucible's contained aspects will decay at an increasing rate based on how over full the crucible is.
+
+All overfull decay will break down compound aspects in to one of their components.
+
+For example, with the default start of `200`, range of `800`, and maximum rate of `4.2`%, a crucible with 200 total
+aspects will start to experience decay, and the decay will increase for 800 aspects until it reaches a maximum of 4.2%
+at 1000 total aspects and above. Because compound aspects' components are returned to the pool, you will not see a
+strict 4.2% reduction in total aspect count each second.
+
+The vanilla crucible will decay 1 aspect every 5 seconds, splitting any non-primal aspect in to a component.
+When the crucible is over 100 total aspects, it will remove 4 random aspects per second.
+
+### Config Option: `crucibleAspectDecayStart` (Default `200`)
+Requires `crucibleScalingAspectDecay`.
+
+The total aspect count of a crucible at which point the percent scaled decay will start.
+
+### Config Option: `crucibleAspectDecayRange` (Default `800`)
+Requires `crucibleScalingAspectDecay`.
+
+The range, in aspect count, between the point scaling aspect decay starts and the point it reaches its maximum rate.
+
+### Config Option: `crucibleAspectDecayMaximumRate` (Default `4.2`)
+Requires `crucibleScalingAspectDecay`.
+
+The maximum percentage of the crucible's total aspect count that will be removed per second, when the crucible is at or
+above the decay's start plus range.
+
+The default maximum rate of 4.2% is vanilla Thaumcraft's maximum decay rate with its flat decay at 100 total aspects.
 
 ## Node Behaviors (Group `node_behaviors`)
 

--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -7,16 +7,16 @@ If true, disables the tinting of aspect images, this can be useful in combinatio
 that provide images that are already colored.
 
 ### Config Option: `crucibleScalingAspectDecay` (Default `true`)
-If true, the crucible's contained aspects will decay at an increasing rate based on how over full the crucible is.
+If true, the crucible's contained aspects will decay at an increasing rate based on how overfull the crucible is.
 
-All overfull decay will break down compound aspects in to one of their components.
+All overfull decay will break down compound aspects into one of their components.
 
 For example, with the default start of `200`, range of `800`, and maximum rate of `4.2`%, a crucible with 200 total
 aspects will start to experience decay, and the decay will increase for 800 aspects until it reaches a maximum of 4.2%
 at 1000 total aspects and above. Because compound aspects' components are returned to the pool, you will not see a
 strict 4.2% reduction in total aspect count each second.
 
-The vanilla crucible will decay 1 aspect every 5 seconds, splitting any non-primal aspect in to a component.
+The vanilla crucible will decay 1 aspect every 5 seconds, splitting any non-primal aspect into a component.
 When the crucible is over 100 total aspects, it will remove 4 random aspects per second.
 
 ### Config Option: `crucibleAspectDecayStart` (Default `200`)
@@ -33,7 +33,7 @@ The range, in aspect count, between the point scaling aspect decay starts and th
 Requires `crucibleScalingAspectDecay`.
 
 The maximum percentage of the crucible's total aspect count that will be removed per second, when the crucible is at or
-above the decay's start plus range.
+above the decay's maximum range.
 
 The default maximum rate of 4.2% is vanilla Thaumcraft's maximum decay rate with its flat decay at 100 total aspects.
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -177,7 +177,8 @@ public class ConfigThaumcraft extends ConfigGroup {
     public final ToggleSetting crucibleScalingAspectDecay = new ToggleSetting(
         this,
         "crucibleScalingAspectDecay",
-        "If true, the Thaumcraft crucible's contained aspects will decay at an increasing rate based on how full the crucible is.");
+        "If true, the crucible's contained aspects will decay at an increasing rate based on how full the crucible is.")
+            .setEnabled(true);
 
     @Override
     public @NotNull String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -174,6 +174,11 @@ public class ConfigThaumcraft extends ConfigGroup {
         "Improves the particle engine of Thaumcraft by removing unnecessary GL operations.")
             .setCategory(tc4PerformanceCategory);
 
+    public final ToggleSetting crucibleScalingAspectDecay = new ToggleSetting(
+        this,
+        "crucibleScalingAspectDecay",
+        "If true, the Thaumcraft crucible's contained aspects will decay at an increasing rate based on how full the crucible is.");
+
     @Override
     public @NotNull String getGroupName() {
         return "thaumcraft_configuration";

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -177,8 +177,7 @@ public class ConfigThaumcraft extends ConfigGroup {
     public final ToggleSetting crucibleScalingAspectDecay = new ToggleSetting(
         this,
         "crucibleScalingAspectDecay",
-        "If true, the crucible's contained aspects will decay at an increasing rate based on how full the crucible is.")
-            .setEnabled(true);
+        "If true, the crucible's contained aspects will decay at an increasing rate based on how full the crucible is.");
 
     @Override
     public @NotNull String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -179,14 +179,14 @@ public class ConfigThaumcraft extends ConfigGroup {
         this,
         "crucibleScalingAspectDecay",
         """
-            If true, the crucible's contained aspects will decay at an increasing rate based on how over full the crucible is.
-            All over full decay will break down compound aspects in to one of their components.
+            If true, the crucible's contained aspects will decay at an increasing rate based on how overfull the crucible is.
+            All over full decay will break down compound aspects into one of their components.
             """);
 
     public final IntSetting crucibleAspectDecayStart = new IntSetting(
         crucibleScalingAspectDecay,
         "crucibleAspectDecayStart",
-        "The total aspect count of a crucible at which point the percent scaled decay will start.",
+        "The total aspect count of a crucible at which point the scaling aspect decay will start.",
         200).setMinValue(0);
 
     public final IntSetting crucibleAspectDecayRange = new IntSetting(
@@ -198,7 +198,7 @@ public class ConfigThaumcraft extends ConfigGroup {
     public final FloatSetting crucibleAspectDecayMaximumRate = new FloatSetting(
         crucibleScalingAspectDecay,
         "crucibleAspectDecayMaximumRate",
-        "The maximum percentage of the crucible's total aspect count that will be removed per second at the end of its range.",
+        "The maximum percentage of the crucible's total aspect count that will be removed per second.",
         4.2f).setMinValue(0.01f)
             .setMaxValue(100f);
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import org.jetbrains.annotations.NotNull;
 
 import dev.rndmorris.salisarcana.config.ConfigGroup;
+import dev.rndmorris.salisarcana.config.settings.FloatSetting;
 import dev.rndmorris.salisarcana.config.settings.IntSetting;
 import dev.rndmorris.salisarcana.config.settings.ToggleSetting;
 
@@ -177,7 +178,28 @@ public class ConfigThaumcraft extends ConfigGroup {
     public final ToggleSetting crucibleScalingAspectDecay = new ToggleSetting(
         this,
         "crucibleScalingAspectDecay",
-        "If true, the crucible's contained aspects will decay at an increasing rate based on how full the crucible is.");
+        """
+            If true, the crucible's contained aspects will decay at an increasing rate based on how over full the crucible is.
+            All over full decay will break down compound aspects in to one of their components.
+            """);
+
+    public final IntSetting crucibleAspectDecayStart = new IntSetting(
+        crucibleScalingAspectDecay,
+        "crucibleAspectDecayStart",
+        "The total aspect count of a crucible at which point the percent scaled decay will start.",
+        200).setMinValue(0);
+
+    public final IntSetting crucibleAspectDecayRange = new IntSetting(
+        crucibleScalingAspectDecay,
+        "crucibleAspectDecayRange",
+        "The range, in aspect count, between the point scaling aspect decay starts and the point it reaches its maximum rate.",
+        800).setMinValue(0);
+
+    public final FloatSetting crucibleAspectDecayMaximumRate = new FloatSetting(
+        crucibleScalingAspectDecay,
+        "crucibleAspectDecayMaximumRate",
+        "The maximum percentage of the crucible's total aspect count that will be removed per second at the end of its range.",
+        4.2f).setMinValue(0.01f).setMaxValue(100f);
 
     @Override
     public @NotNull String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -199,7 +199,8 @@ public class ConfigThaumcraft extends ConfigGroup {
         crucibleScalingAspectDecay,
         "crucibleAspectDecayMaximumRate",
         "The maximum percentage of the crucible's total aspect count that will be removed per second at the end of its range.",
-        4.2f).setMinValue(0.01f).setMaxValue(100f);
+        4.2f).setMinValue(0.01f)
+            .setMaxValue(100f);
 
     @Override
     public @NotNull String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -619,6 +619,11 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)
         .addRequiredMod(TargetedMod.ANGELICA)),
 
+    CRUCIBLE_SCALING_ASPECT_DECAY(new SalisBuilder()
+        .applyIf(SalisConfig.thaum.crucibleScalingAspectDecay)
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileCrucible_ScalingAspectDecay")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
+
     // Required
     ADD_VISCONTAINER_INTERFACE(new SalisBuilder()
         .setRequired()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -1,7 +1,5 @@
 package com.TheHoblit.ThaumicEnlightenment.mixins.late;
 
-import net.minecraftforge.fluids.FluidTank;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -34,15 +32,13 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
         if (worldObj.isRemote || heat <= 150 || ((int) counter + 1) % 20 != 0) return;
 
         int total = tagAmount();
+        // 100 base + 100 for base decay
         int excess = total - 200;
         if (excess <= 0) return;
 
-        // ~0.2% per 100 over the vanilla limit + 100 for thaums base decay, capped at thaums decay of 4.2/s
+        // ~0.2% per 100 over, capped at thaums base decay of 4.2/s
         float percentage = Math.min(excess * 0.00002f, 0.042f);
         int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
-
-        System.out.println(
-            total + " total aspects, " + percentage * 100 + "% removed, " + removeCount + " additional removals");
 
         for (int i = 0; i < removeCount - 1; i++) {
             if (aspects.size() == 0) break;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -1,0 +1,73 @@
+package com.TheHoblit.ThaumicEnlightenment.mixins.late;
+
+import net.minecraftforge.fluids.FluidTank;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.api.aspects.AspectList;
+import thaumcraft.common.tiles.TileCrucible;
+
+@Mixin(value = TileCrucible.class, remap = false)
+public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraft {
+
+    @Shadow
+    public short heat;
+    @Shadow
+    public AspectList aspects;
+    @Shadow
+    private long counter;
+
+    @Shadow
+    public abstract int tagAmount();
+
+    @Shadow
+    public abstract void spill();
+
+    @Inject(method = "updateEntity", at = @At("TAIL"))
+    private void additionalScaledAspectDrain(CallbackInfo ci) {
+        if (worldObj.isRemote || heat <= 150 || ((int) counter + 1) % 20 != 0) return;
+
+        int total = tagAmount();
+        int excess = total - 200;
+        if (excess <= 0) return;
+
+        // ~0.2% per 100 over the vanilla limit + 100 for thaums base decay, capped at thaums decay of 4.2/s
+        float percentage = Math.min(excess * 0.00002f, 0.042f);
+        int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
+
+        System.out.println(
+            total + " total aspects, " + percentage * 100 + "% removed, " + removeCount + " additional removals");
+
+        for (int i = 0; i < removeCount - 1; i++) {
+            if (aspects.size() == 0) break;
+
+            Aspect[] availableAspects = aspects.getAspects();
+            Aspect a = availableAspects[worldObj.rand.nextInt(availableAspects.length)];
+            if (a.isPrimal()) {
+                a = availableAspects[worldObj.rand.nextInt(availableAspects.length)];
+            }
+            aspects.remove(a, 1);
+
+            if (!a.isPrimal()) {
+                if (worldObj.rand.nextBoolean()) {
+                    aspects.add(a.getComponents()[0], 1);
+                } else {
+                    aspects.add(a.getComponents()[1], 1);
+                }
+            } else {
+                spill();
+            }
+        }
+
+        if (removeCount > 1) {
+            markDirty();
+            worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -1,7 +1,10 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
+import java.util.Random;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
@@ -38,24 +41,7 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
         double percentage = Math.min(total / 1000.00 * 0.042, 0.042);
         int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
 
-        for (int i = 0; i < removeCount - 1; i++) {
-            if (aspects.size() == 0) break;
-
-            Aspect[] availableAspects = aspects.getAspects();
-            Aspect a = availableAspects[worldObj.rand.nextInt(availableAspects.length)];
-            if (a.isPrimal()) {
-                a = availableAspects[worldObj.rand.nextInt(availableAspects.length)];
-            }
-            aspects.remove(a, 1);
-
-            if (!a.isPrimal()) {
-                if (worldObj.rand.nextBoolean()) {
-                    aspects.add(a.getComponents()[0], 1);
-                } else {
-                    aspects.add(a.getComponents()[1], 1);
-                }
-            }
-        }
+        salis_Arcana$removeAndSplit(removeCount);
 
         int spills = Math.min(1 + (removeCount / 10), 5);
         for (int i = 0; i < spills; i++) {
@@ -64,5 +50,40 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
 
         markDirty();
         worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+    }
+
+    @Unique
+    private void salis_Arcana$removeAndSplit(int removeCount) {
+        if (aspects.size() == 0 || removeCount <= 1) return;
+        Random rand = worldObj.rand;
+
+        int splitRemoval = (int) Math.ceil((double) removeCount / aspects.size());
+
+        int toRemove;
+        int remainder = 0;
+        int totalRemoved = 0;
+        while (totalRemoved < removeCount) {
+            Aspect[] availableAspects = aspects.getAspects();
+            Aspect a = availableAspects[rand.nextInt(availableAspects.length)];
+            if (a.isPrimal()) {
+                a = availableAspects[rand.nextInt(availableAspects.length)];
+            }
+            toRemove = Math.min(splitRemoval + remainder, removeCount - totalRemoved);
+            if (toRemove > aspects.getAmount(a)) {
+                remainder = toRemove - aspects.getAmount(a);
+                toRemove = aspects.getAmount(a);
+            } else {
+                remainder = 0;
+            }
+            aspects.remove(a, toRemove);
+            if (!a.isPrimal()) {
+                if (rand.nextBoolean()) {
+                    aspects.add(a.getComponents()[0], toRemove);
+                } else {
+                    aspects.add(a.getComponents()[1], toRemove);
+                }
+            }
+            totalRemoved += toRemove;
+        }
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -32,12 +32,10 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
         if (worldObj.isRemote || heat <= 150 || ((int) counter + 1) % 20 != 0) return;
 
         int total = tagAmount();
-        // 100 base + 100 for base decay
         int excess = total - 200;
         if (excess <= 0) return;
 
-        // ~0.2% per 100 over, capped at thaums base decay of 4.2/s
-        float percentage = Math.min(excess * 0.00002f, 0.042f);
+        double percentage = Math.min(total / 1000.00 * 0.042, 0.042);
         int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
 
         for (int i = 0; i < removeCount - 1; i++) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -54,14 +54,15 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
                 } else {
                     aspects.add(a.getComponents()[1], 1);
                 }
-            } else {
-                spill();
             }
         }
 
-        if (removeCount > 1) {
-            markDirty();
-            worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
+        int spills = Math.min(1 + (removeCount / 10), 5);
+        for (int i = 0; i < spills; i++) {
+            spill();
         }
+
+        markDirty();
+        worldObj.markBlockForUpdate(xCoord, yCoord, zCoord);
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -1,4 +1,4 @@
-package com.TheHoblit.ThaumicEnlightenment.mixins.late;
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
+import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.api.TileThaumcraft;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
@@ -25,6 +26,14 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
     public AspectList aspects;
     @Shadow
     private long counter;
+    @Unique
+    private final int salis_Arcana$aspectDecayStart = SalisConfig.thaum.crucibleAspectDecayStart.getValue();
+    @Unique
+    private final int salis_Arcana$aspectDecayEnd = salis_Arcana$aspectDecayStart
+        + SalisConfig.thaum.crucibleAspectDecayRange.getValue();
+    @Unique
+    private final float salis_Arcana$aspectDecayMaximumRate = SalisConfig.thaum.crucibleAspectDecayMaximumRate
+        .getValue() / 100f;
 
     @Shadow
     public abstract int tagAmount();
@@ -37,10 +46,12 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
         if (worldObj.isRemote || heat <= 150 || ((int) counter + 1) % 20 != 0) return;
 
         int total = tagAmount();
-        int excess = total - 200;
+        int excess = total - salis_Arcana$aspectDecayStart;
         if (excess <= 0) return;
 
-        double percentage = Math.min(total / 1000.00 * 0.042, 0.042);
+        double percentage = Math.min(
+            (double) total / salis_Arcana$aspectDecayEnd * salis_Arcana$aspectDecayMaximumRate,
+            salis_Arcana$aspectDecayMaximumRate);
         int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
 
         salis_Arcana$removeAndSplit(removeCount);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -49,7 +49,7 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
             maxRate);
         int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
 
-        salis_Arcana$removeAndSplit(removeCount);
+        salisArcana$removeAndSplit(removeCount);
 
         int spills = Math.min(1 + (removeCount / 10), 5);
         for (int i = 0; i < spills; i++) {
@@ -61,7 +61,7 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
     }
 
     @Unique
-    private void salis_Arcana$removeAndSplit(int removeCount) {
+    private void salisArcana$removeAndSplit(int removeCount) {
         if (aspects.size() == 0 || removeCount <= 1) return;
         Random rand = worldObj.rand;
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -25,8 +25,10 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
     public AspectList aspects;
     @Shadow
     private long counter;
+
     @Shadow
     public abstract int tagAmount();
+
     @Shadow
     public abstract void spill();
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -26,14 +26,6 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
     public AspectList aspects;
     @Shadow
     private long counter;
-    @Unique
-    private final int salis_Arcana$aspectDecayStart = SalisConfig.thaum.crucibleAspectDecayStart.getValue();
-    @Unique
-    private final int salis_Arcana$aspectDecayEnd = salis_Arcana$aspectDecayStart
-        + SalisConfig.thaum.crucibleAspectDecayRange.getValue();
-    @Unique
-    private final float salis_Arcana$aspectDecayMaximumRate = SalisConfig.thaum.crucibleAspectDecayMaximumRate
-        .getValue() / 100f;
 
     @Shadow
     public abstract int tagAmount();
@@ -46,12 +38,15 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
         if (worldObj.isRemote || heat <= 150 || ((int) counter + 1) % 20 != 0) return;
 
         int total = tagAmount();
-        int excess = total - salis_Arcana$aspectDecayStart;
+        int decayStart = SalisConfig.thaum.crucibleAspectDecayStart.getValue();
+        float maxRate = SalisConfig.thaum.crucibleAspectDecayMaximumRate.getValue() / 100f;
+
+        int excess = total - decayStart;
         if (excess <= 0) return;
 
         double percentage = Math.min(
-            (double) total / salis_Arcana$aspectDecayEnd * salis_Arcana$aspectDecayMaximumRate,
-            salis_Arcana$aspectDecayMaximumRate);
+            (double) total / (decayStart + SalisConfig.thaum.crucibleAspectDecayRange.getValue()) * maxRate,
+            maxRate);
         int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
 
         salis_Arcana$removeAndSplit(removeCount);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -49,7 +49,7 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
             maxRate);
         int removeCount = Math.max(0, (int) Math.ceil((total * percentage)));
 
-        salisArcana$removeAndSplit(removeCount);
+        salisarcana$removeAndSplit(removeCount);
 
         int spills = Math.min(1 + (removeCount / 10), 5);
         for (int i = 0; i < spills; i++) {
@@ -61,7 +61,7 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
     }
 
     @Unique
-    private void salisArcana$removeAndSplit(int removeCount) {
+    private void salisarcana$removeAndSplit(int removeCount) {
         if (aspects.size() == 0 || removeCount <= 1) return;
         Random rand = worldObj.rand;
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -16,7 +16,7 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileCrucible;
 
-@Mixin(value = TileCrucible.class)
+@Mixin(value = TileCrucible.class, remap = false)
 public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraft {
 
     @Shadow
@@ -32,7 +32,7 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
     @Shadow
     public abstract void spill();
 
-    @Inject(method = "updateEntity", at = @At("TAIL"))
+    @Inject(method = "updateEntity", at = @At("TAIL"), remap = true)
     private void additionalScaledAspectDrain(CallbackInfo ci) {
         if (worldObj.isRemote || heat <= 150 || ((int) counter + 1) % 20 != 0) return;
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -1,5 +1,7 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Random;
 
 import org.spongepowered.asm.mixin.Mixin;
@@ -62,28 +64,41 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
         int toRemove;
         int remainder = 0;
         int totalRemoved = 0;
+        final var newAspects = new HashMap<>(aspects.aspects);
+        final var availableAspects = new ArrayList<>(newAspects.keySet());
+
         while (totalRemoved < removeCount) {
-            Aspect[] availableAspects = aspects.getAspects();
-            Aspect a = availableAspects[rand.nextInt(availableAspects.length)];
+            Aspect a = availableAspects.get(rand.nextInt(availableAspects.size()));
             if (a.isPrimal()) {
-                a = availableAspects[rand.nextInt(availableAspects.length)];
+                a = availableAspects.get(rand.nextInt(availableAspects.size()));
             }
+
             toRemove = Math.min(splitRemoval + remainder, removeCount - totalRemoved);
-            if (toRemove > aspects.getAmount(a)) {
-                remainder = toRemove - aspects.getAmount(a);
-                toRemove = aspects.getAmount(a);
+
+            int aspectAmount = newAspects.get(a);
+            remainder = Math.max(0, toRemove - aspectAmount);
+            toRemove = Math.min(toRemove, aspectAmount);
+
+            int newAmount = aspectAmount - toRemove;
+            if (newAmount <= 0) {
+                newAspects.remove(a);
+                availableAspects.remove(a);
             } else {
-                remainder = 0;
+                newAspects.put(a, newAmount);
             }
-            aspects.remove(a, toRemove);
+
             if (!a.isPrimal()) {
-                if (rand.nextBoolean()) {
-                    aspects.add(a.getComponents()[0], toRemove);
-                } else {
-                    aspects.add(a.getComponents()[1], toRemove);
+                Aspect component = rand.nextBoolean() ? a.getComponents()[0] : a.getComponents()[1];
+                newAspects.merge(component, toRemove, Integer::sum);
+                if (!availableAspects.contains(component)) {
+                    availableAspects.add(component);
                 }
             }
+
             totalRemoved += toRemove;
         }
+
+        aspects.aspects.clear();
+        aspects.aspects.putAll(newAspects);
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -16,7 +16,7 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileCrucible;
 
-@Mixin(value = TileCrucible.class, remap = false)
+@Mixin(value = TileCrucible.class)
 public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraft {
 
     @Shadow
@@ -25,10 +25,8 @@ public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraf
     public AspectList aspects;
     @Shadow
     private long counter;
-
     @Shadow
     public abstract int tagAmount();
-
     @Shadow
     public abstract void spill();
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

**What is the current behavior?** (You can also link to an open issue here)

The vanilla crucible decays 1 aspect every 5 seconds, with a possibility and bias toward breaking it down in to a component. Additionally, it will remove 4 aspects per second when the crucible has more than 100 total aspects. This decay will never break down a compound aspect and will just remove them.

**What is the new behavior (if this is a feature change)?**

Starting at 200 total aspects, the crucible now decays a percent of the total aspects, with bias toward breaking each aspect down in to a component. This percent slowly increases to 4.2% at 1000 total aspects, 10x the first cap. In practice, it is not always a clean 4.2% as the additional decay will break down compound aspects in to a component, making that "decay" a net 0 aspect change, removing one and adding one.

The starting point of 200 total aspects was chosen to give the default Thaumcraft's decay a place.

The cap of 4.2% was chosen because that is the maximum decay rate vanilla Thaumcraft uses, at exactly 100 aspects it will decay 4 aspects per second and 1 every 5 seconds that breaks down compound aspects.

**Does this PR introduce a breaking change?**

No.

**Other information**:

This is an iteration on my previous crucible PR after feedback in the GTNH discord: https://github.com/rndmorris/Salis-Arcana/pull/474