### PR TITLE
[Memory-opti:fix leak] fix Thaumcraft's particle engine leaking the world instance

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -289,6 +289,12 @@ Prevents a world object memory leak in the TeleporterThaumcraft class.
 
 Fix Thaumcraft's tree generators leaking the world instance.
 
+## Fix Particle Engine World memory leak
+
+**Config option:** `fixParticleEngineLeak`
+
+Fix Thaumcraft's particle engine leaking the world instance.
+
 ## Prevent Warp Sounds from Blasting Out Your Eardrums
 
 **Config option:** `muteExcessiveWarpSounds`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -330,6 +330,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "fixTreeGenWorldLeak",
         "Fix Thaumcraft's tree generators leaking the world instance");
 
+    public final ToggleSetting fixParticleEngineLeak = new ToggleSetting(
+        this,
+        "fixParticleEngineLeak",
+        "Fix Thaumcraft's particle engine leaking the world instance");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -289,6 +289,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.betterParticleEngine)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_SkipRendering")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    FIX_PARTICLE_ENGINE_LEAK(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.fixParticleEngineLeak)
+        .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_FixLeak")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     FIX_TREE_GEN_LEAK(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.fixTreeGenWorldLeak)
         .addCommonMixins("thaumcraft.common.lib.world.MixinGenTrees_FixLeak")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_FixLeak.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_FixLeak.java
@@ -1,0 +1,29 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.client.fx;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import net.minecraft.client.particle.EntityFX;
+import net.minecraftforge.event.world.WorldEvent;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import thaumcraft.client.fx.ParticleEngine;
+
+@Mixin(value = ParticleEngine.class, remap = false)
+public class MixinParticleEngine_FixLeak {
+
+    @Shadow
+    private HashMap<Integer, ArrayList<EntityFX>>[] particles;
+
+    @SubscribeEvent
+    public void onWorldUnload(WorldEvent.Unload event) {
+        if (event.world.isRemote) {
+            for (HashMap<Integer, ArrayList<EntityFX>> map : this.particles) {
+                map.clear();
+            }
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fix particle engine leaking world instance

<img width="446" height="191" alt="image" src="https://github.com/user-attachments/assets/06307118-29ce-464b-807c-793e84e9ee20" />
