### PR TITLE
Fix scanning ghost stacks

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/client/ThaumicInventoryScanner.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/ThaumicInventoryScanner.java
@@ -115,7 +115,7 @@ public class ThaumicInventoryScanner {
             return;
         }
         // Handle scanning item
-        if (hoveringSlot != null && hoveringSlot.getStack() != null) {
+        if (hoveringSlot != null && hoveringSlot.getStack() != null && hoveringSlot.getStack().stackSize > 0) {
             // spotless:off
 
             // spotless made this completely unreadable

--- a/src/main/java/dev/rndmorris/salisarcana/lib/InventoryHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/InventoryHelper.java
@@ -53,7 +53,7 @@ public class InventoryHelper {
     public static void scanInventory(IInventory inventory, EntityPlayer player) {
         for (int i = 0; i < inventory.getSizeInventory(); i++) {
             ItemStack item = inventory.getStackInSlot(i);
-            if (item == null) {
+            if (item == null || item.stackSize < 1) {
                 continue;
             }
             ScanResult result = new ScanResult(


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fix

**What is the current behavior?** (You can also link to an open issue here)
Scanning containers that have ghost stacks will scan them as real items

**What is the new behavior (if this is a feature change)?**
ItemStacks with size 0 or negative (negative stack sizes are possible with some glitches) are ignored in both container scanning and inventory scanning.

**Does this PR introduce a breaking change?**
No

**Other information**:
