### PR TITLE
Prevent size-0 dynamic-reach nodes from crashing the game

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
@@ -18,7 +18,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
+public abstract class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
@@ -58,7 +58,11 @@ abstract class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
     @ModifyExpressionValue(
         method = "handleDarkNode",
         at = @At(value = "CONSTANT", args = "intValue=12"),
-        slice = @Slice(to = @At(value = "FIELD", target = "Lthaumcraft/common/config/Config;hardNode:Z")))
+        slice = @Slice(
+            to = @At(
+                value = "FIELD",
+                opcode = Opcodes.GETSTATIC,
+                target = "Lthaumcraft/common/config/Config;hardNode:Z")))
     private int adjustCoordsForBiome(int constant, @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef,
         @Share("reach") LocalIntRef reachRef) {
         return (int) (constant * sizeMultiplierRef.get());

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
@@ -24,6 +24,16 @@ public class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
     AspectList aspects;
 
     /**
+     * Prevent things from breaking at size 0
+     */
+    @Inject(method = "handleDarkNode", at = @At("HEAD"), cancellable = true)
+    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
+        if (this.aspects.visSize() == 0) {
+            cir.setReturnValue(change);
+        }
+    }
+
+    /**
      * At the first opportunity, just before we know the node will do dark activities, calculate and cache the node's
      * size
      * multiplier.

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
@@ -1,5 +1,6 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
+import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -24,26 +25,30 @@ public abstract class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
     AspectList aspects;
 
     /**
-     * Prevent things from breaking at size 0
-     */
-    @Inject(method = "handleDarkNode", at = @At("HEAD"), cancellable = true)
-    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
-        if (this.aspects.visSize() == 0) {
-            cir.setReturnValue(change);
-        }
-    }
-
-    /**
      * At the first opportunity, just before we know the node will do dark activities, calculate and cache the node's
-     * size
-     * multiplier.
+     * size multiplier.
      */
     @Inject(
         method = "handleDarkNode",
-        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;xCoord:I", remap = true, ordinal = 0),
-        slice = @Slice(from = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;count:I")))
+        at = @At(
+            value = "FIELD",
+            target = "Lthaumcraft/common/tiles/TileNode;xCoord:I",
+            opcode = Opcodes.GETFIELD,
+            remap = true,
+            ordinal = 0),
+        slice = @Slice(
+            from = @At(
+                value = "FIELD",
+                opcode = Opcodes.GETFIELD,
+                target = "Lthaumcraft/common/tiles/TileNode;count:I")),
+        cancellable = true)
     private void calculateSizeMultiplier(boolean change, CallbackInfoReturnable<Boolean> cir,
         @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef) {
+        final var visSize = this.aspects.visSize();
+        if (visSize == 0) {
+            cir.setReturnValue(change);
+            return;
+        }
         sizeMultiplierRef.set(DynamicNodeLogic.calculateSizeMultiplier(this.aspects.visSize()));
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
@@ -19,7 +19,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
+abstract class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Dark.java
@@ -49,7 +49,7 @@ abstract class MixinTileNode_DynamicReach_Dark extends TileThaumcraft {
             cir.setReturnValue(change);
             return;
         }
-        sizeMultiplierRef.set(DynamicNodeLogic.calculateSizeMultiplier(this.aspects.visSize()));
+        sizeMultiplierRef.set(DynamicNodeLogic.calculateSizeMultiplier(visSize));
     }
 
     /**

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
@@ -3,11 +3,12 @@ package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Slice;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Cancellable;
+import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
@@ -24,16 +25,6 @@ public abstract class MixinTileNode_DynamicReach_Hungry extends TileThaumcraft {
     AspectList aspects;
 
     /**
-     * Prevent things from breaking at size 0
-     */
-    @Inject(method = { "handleHungryNodeFirst", "handleHungryNodeSecond" }, at = @At("HEAD"), cancellable = true)
-    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
-        if (this.aspects.visSize() == 0) {
-            cir.setReturnValue(change);
-        }
-    }
-
-    /**
      * Adjust the volume within which a hungry node can draw particles.
      * Memoization is needed for {@code adjustMopDistance} below.
      * Wraps the first occurrence of a constant {@code 16} in each method, which should be part the very first
@@ -43,9 +34,17 @@ public abstract class MixinTileNode_DynamicReach_Hungry extends TileThaumcraft {
         method = { "handleHungryNodeFirst", "handleHungryNodeSecond" },
         at = @At(value = "CONSTANT", args = "intValue=16", ordinal = 0))
     private int adjustAndMemoReach(int constant, @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef,
-        @Share("reach") LocalIntRef reachRef) {
-        sizeMultiplierRef.set(DynamicNodeLogic.calculateSizeMultiplier(this.aspects.visSize()));
-        final var reach = (int) (constant * sizeMultiplierRef.get());
+        @Share("reach") LocalIntRef reachRef, @Local(argsOnly = true) boolean change,
+        @Cancellable CallbackInfoReturnable<Boolean> cir) {
+        final var visSize = this.aspects.visSize();
+        if (visSize == 0) {
+            cir.setReturnValue(change);
+            return 1;
+        }
+
+        final var sizeMultiplier = DynamicNodeLogic.calculateSizeMultiplier(visSize);
+        sizeMultiplierRef.set(sizeMultiplier);
+        final var reach = (int) (constant * sizeMultiplier);
         reachRef.set(reach);
         return reach;
     }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
@@ -19,7 +19,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_DynamicReach_Hungry extends TileThaumcraft {
+abstract class MixinTileNode_DynamicReach_Hungry extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
@@ -3,7 +3,9 @@ package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Slice;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Share;
@@ -20,6 +22,16 @@ public abstract class MixinTileNode_DynamicReach_Hungry extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;
+
+    /**
+     * Prevent things from breaking at size 0
+     */
+    @Inject(method = { "handleHungryNodeFirst", "handleHungryNodeSecond" }, at = @At("HEAD"), cancellable = true)
+    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
+        if (this.aspects.visSize() == 0) {
+            cir.setReturnValue(change);
+        }
+    }
 
     /**
      * Adjust the volume within which a hungry node can draw particles.

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Hungry.java
@@ -8,7 +8,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import com.llamalad7.mixinextras.sugar.Cancellable;
-import com.llamalad7.mixinextras.sugar.Local;
 import com.llamalad7.mixinextras.sugar.Share;
 import com.llamalad7.mixinextras.sugar.ref.LocalDoubleRef;
 import com.llamalad7.mixinextras.sugar.ref.LocalIntRef;
@@ -33,8 +32,8 @@ abstract class MixinTileNode_DynamicReach_Hungry extends TileThaumcraft {
     @ModifyExpressionValue(
         method = { "handleHungryNodeFirst", "handleHungryNodeSecond" },
         at = @At(value = "CONSTANT", args = "intValue=16", ordinal = 0))
-    private int adjustAndMemoReach(int constant, @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef,
-        @Share("reach") LocalIntRef reachRef, @Local(argsOnly = true) boolean change,
+    private int adjustAndMemoReach(int constant, boolean change,
+        @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef, @Share("reach") LocalIntRef reachRef,
         @Cancellable CallbackInfoReturnable<Boolean> cir) {
         final var visSize = this.aspects.visSize();
         if (visSize == 0) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
@@ -17,7 +17,7 @@ import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public class MixinTileNode_DynamicReach_Pure extends TileThaumcraft {
+public abstract class MixinTileNode_DynamicReach_Pure extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
@@ -1,5 +1,6 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
+import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -23,25 +24,25 @@ public abstract class MixinTileNode_DynamicReach_Pure extends TileThaumcraft {
     AspectList aspects;
 
     /**
-     * Prevent things from breaking at size 0
-     */
-    @Inject(method = "handlePureNode", at = @At("HEAD"), cancellable = true)
-    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
-        if (this.aspects.visSize() == 0) {
-            cir.setReturnValue(change);
-        }
-    }
-
-    /**
      * At the first opportunity, after we know the node will do tainty activities, calculate and cache the node's size
      * multiplier.
      */
     @Inject(
         method = "handlePureNode",
-        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;xCoord:I", remap = true, ordinal = 0))
+        at = @At(
+            value = "FIELD",
+            target = "Lthaumcraft/common/tiles/TileNode;xCoord:I",
+            opcode = Opcodes.GETFIELD,
+            remap = true,
+            ordinal = 0),
+        cancellable = true)
     private void calculateSizeMultiplier(boolean change, CallbackInfoReturnable<Boolean> cir,
         @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef) {
         final var visSize = this.aspects.visSize();
+        if (visSize == 0) {
+            cir.setReturnValue(change);
+            return;
+        }
         if (this.getBlockType() == ConfigBlocks.blockMagicalLog && visSize <= DynamicNodeLogic.NODE_SIZE_SMALL_MAX) {
             // special exception for sufficiently-small in-log nodes
             sizeMultiplierRef.set(DynamicNodeLogic.calculateSmallSizeMultiplier(visSize));

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
@@ -23,6 +23,16 @@ public class MixinTileNode_DynamicReach_Pure extends TileThaumcraft {
     AspectList aspects;
 
     /**
+     * Prevent things from breaking at size 0
+     */
+    @Inject(method = "handlePureNode", at = @At("HEAD"), cancellable = true)
+    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
+        if (this.aspects.visSize() == 0) {
+            cir.setReturnValue(change);
+        }
+    }
+
+    /**
      * At the first opportunity, after we know the node will do tainty activities, calculate and cache the node's size
      * multiplier.
      */

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Pure.java
@@ -18,7 +18,7 @@ import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_DynamicReach_Pure extends TileThaumcraft {
+abstract class MixinTileNode_DynamicReach_Pure extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
@@ -16,7 +16,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft {
+public abstract class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
@@ -22,6 +22,16 @@ public class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft {
     AspectList aspects;
 
     /**
+     * Prevent things from breaking at size 0
+     */
+    @Inject(method = "handleTaintNode", at = @At("HEAD"), cancellable = true)
+    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
+        if (this.aspects.visSize() == 0) {
+            cir.setReturnValue(change);
+        }
+    }
+
+    /**
      * At the first opportunity, after we know the node will do tainty activities, calculate and cache the node's size
      * multiplier.
      */

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
@@ -1,5 +1,6 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
+import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
@@ -27,7 +28,12 @@ abstract class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft {
      */
     @Inject(
         method = "handleTaintNode",
-        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;xCoord:I", remap = true, ordinal = 0),
+        at = @At(
+            value = "FIELD",
+            target = "Lthaumcraft/common/tiles/TileNode;xCoord:I",
+            opcode = Opcodes.GETFIELD,
+            remap = true,
+            ordinal = 0),
         cancellable = true)
     private void calculateSizeMultiplier(boolean change, CallbackInfoReturnable<Boolean> cir,
         @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
@@ -16,7 +16,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft {
+abstract class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft {
 
     @Shadow
     AspectList aspects;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
@@ -22,24 +22,20 @@ public abstract class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft 
     AspectList aspects;
 
     /**
-     * Prevent things from breaking at size 0
-     */
-    @Inject(method = "handleTaintNode", at = @At("HEAD"), cancellable = true)
-    private void abortIfSizeZero(boolean change, CallbackInfoReturnable<Boolean> cir) {
-        if (this.aspects.visSize() == 0) {
-            cir.setReturnValue(change);
-        }
-    }
-
-    /**
      * At the first opportunity, after we know the node will do tainty activities, calculate and cache the node's size
      * multiplier.
      */
     @Inject(
         method = "handleTaintNode",
-        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;xCoord:I", remap = true, ordinal = 0))
+        at = @At(value = "FIELD", target = "Lthaumcraft/common/tiles/TileNode;xCoord:I", remap = true, ordinal = 0),
+        cancellable = true)
     private void calculateSizeMultiplier(boolean change, CallbackInfoReturnable<Boolean> cir,
         @Share("sizeMultiplier") LocalDoubleRef sizeMultiplierRef) {
+        final var visSize = this.aspects.visSize();
+        if (visSize == 0) {
+            cir.setReturnValue(change);
+            return;
+        }
         sizeMultiplierRef.set(DynamicNodeLogic.calculateSizeMultiplier(this.aspects.visSize()));
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_DynamicReach_Tainted.java
@@ -36,7 +36,7 @@ abstract class MixinTileNode_DynamicReach_Tainted extends TileThaumcraft {
             cir.setReturnValue(change);
             return;
         }
-        sizeMultiplierRef.set(DynamicNodeLogic.calculateSizeMultiplier(this.aspects.visSize()));
+        sizeMultiplierRef.set(DynamicNodeLogic.calculateSizeMultiplier(visSize));
     }
 
     /**

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Dark.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public class MixinTileNode_ModifierSpeed_Dark {
+public abstract class MixinTileNode_ModifierSpeed_Dark {
 
     @Shadow
     private NodeModifier nodeModifier;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Dark.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Dark.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_ModifierSpeed_Dark {
+abstract class MixinTileNode_ModifierSpeed_Dark {
 
     @Shadow
     private NodeModifier nodeModifier;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Hungry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Hungry.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public class MixinTileNode_ModifierSpeed_Hungry {
+public abstract class MixinTileNode_ModifierSpeed_Hungry {
 
     @Shadow
     private NodeModifier nodeModifier;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Hungry.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Hungry.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_ModifierSpeed_Hungry {
+abstract class MixinTileNode_ModifierSpeed_Hungry {
 
     @Shadow
     private NodeModifier nodeModifier;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Pure.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Pure.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public class MixinTileNode_ModifierSpeed_Pure {
+public abstract class MixinTileNode_ModifierSpeed_Pure {
 
     @Shadow
     private NodeModifier nodeModifier;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Pure.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Pure.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_ModifierSpeed_Pure {
+abstract class MixinTileNode_ModifierSpeed_Pure {
 
     @Shadow
     private NodeModifier nodeModifier;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Tainted.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public class MixinTileNode_ModifierSpeed_Tainted {
+public abstract class MixinTileNode_ModifierSpeed_Tainted {
 
     @Shadow
     private NodeModifier nodeModifier;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Tainted.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ModifierSpeed_Tainted.java
@@ -11,7 +11,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_ModifierSpeed_Tainted {
+abstract class MixinTileNode_ModifierSpeed_Tainted {
 
     @Shadow
     private NodeModifier nodeModifier;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix

**What is the current behavior?** (You can also link to an open issue here)
Nodes with dynamic reach enabled crash the game when they contain 0 vis. See #484.

**What is the new behavior (if this is a feature change)?**
Early-exit the responsible methods when the node's size is 0.

**Does this PR introduce a breaking change?**
No

**Other information**:
