### PR TITLE
Add feature to allow creative players use enchantment infusion without xp

### DIFF
--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -258,6 +258,10 @@ Hovering over an unknown aspect inside the Research Table will show a tooltip wi
 
 # Enhancements - Infusion
 
+## Config option: `creativeNoXPInfusionEnchanting`
+
+Allow Creative players to use Infusion Enchanting without the necessary XP.
+
 ## Config option: `useStabilizerRewrite`
 
 Rewrites the Runic Matrix's surroundings-check logic to be more flexible when checking for pedestals and stabilizers.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -140,6 +140,11 @@ public class ConfigFeatures extends ConfigGroup {
         "creativeNoXPManipulator",
         "Allow Creative players to use the Focal Manipulator without the necessary XP.");
 
+    public final ToggleSetting creativeNoXPInfusionEnchanting = new ToggleSetting(
+        this,
+        "creativeNoXPInfusionEnchanting",
+        "Allow Creative players to use Infusion Enchanting without the necessary XP.");
+
     public final ToggleSetting focalDisenchanterReturnXP = new ToggleSetting(
         this,
         "focalDisenchanterReturnXP",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -401,6 +401,10 @@ public enum Mixins implements IMixins {
         .addCommonMixins("thaumcraft.common.tiles.MixinTileFocalManipulator_NoXP")
         .addClientMixins("thaumcraft.client.gui.MixinGuiFocalManipulator_CreativeNoXP")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    CREATIVE_NO_XP_INFUSION_ENCHANTING(new SalisBuilder()
+        .applyIf(SalisConfig.features.creativeNoXPInfusionEnchanting)
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileInfusionMatrix_NoXP")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     FOCAL_MANIPULATOR_STORE_XP(new SalisBuilder()
         .setApplyIf(() -> SalisConfig.features.enableFocusDisenchanting.isEnabled() || SalisConfig.features.focalDisenchanterReturnXP.isEnabled())
         .addCommonMixins(

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_NoXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_NoXP.java
@@ -2,30 +2,33 @@ package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
 import net.minecraft.entity.player.EntityPlayer;
 
+import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
+import com.llamalad7.mixinextras.sugar.Local;
 
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
 @Mixin(TileInfusionMatrix.class)
 public class MixinTileInfusionMatrix_NoXP {
 
-    @WrapOperation(
+    @ModifyExpressionValue(
         method = "craftCycle",
-        at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;experienceLevel:I"))
-    private int creativeXP(EntityPlayer player, Operation<Integer> original) {
-        return player.capabilities.isCreativeMode ? Integer.MAX_VALUE : original.call(player);
+        at = @At(
+            value = "FIELD",
+            opcode = Opcodes.GETFIELD,
+            target = "Lnet/minecraft/entity/player/EntityPlayer;experienceLevel:I"))
+    private int creativeXP(int original, @Local EntityPlayer player) {
+        return player.capabilities.isCreativeMode ? Integer.MAX_VALUE : original;
     }
 
-    @WrapOperation(
+    @WrapWithCondition(
         method = "craftCycle",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;addExperienceLevel(I)V"))
-    private void skipCreativeXPDrain(EntityPlayer player, int levels, Operation<Void> original) {
-        if (!player.capabilities.isCreativeMode) {
-            original.call(player, levels);
-        }
+    private boolean skipCreativeXPDrain(EntityPlayer player, int levels) {
+        return !player.capabilities.isCreativeMode;
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_NoXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_NoXP.java
@@ -1,0 +1,31 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
+
+import net.minecraft.entity.player.EntityPlayer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import thaumcraft.common.tiles.TileInfusionMatrix;
+
+@Mixin(TileInfusionMatrix.class)
+public class MixinTileInfusionMatrix_NoXP {
+
+    @WrapOperation(
+        method = "craftCycle",
+        at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;experienceLevel:I"))
+    private int creativeXP(EntityPlayer player, Operation<Integer> original) {
+        return player.capabilities.isCreativeMode ? Integer.MAX_VALUE : original.call(player);
+    }
+
+    @WrapOperation(
+        method = "craftCycle",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/entity/player/EntityPlayer;addExperienceLevel(I)V"))
+    private void skipCreativeXPDrain(EntityPlayer player, int levels, Operation<Void> original) {
+        if (!player.capabilities.isCreativeMode) {
+            original.call(player, levels);
+        }
+    }
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds a feature to allow creative players to use infusion enchantment without XP

**What is the current behavior?** (You can also link to an open issue here)

Creative players need to have the required levels for the infusion matrix to drain. This is counter intuitive since you don't even see your levels, and all other logic assumes creative players have enough XP.

**What is the new behavior (if this is a feature change)?**

Infusion skips the XP check and just proceeeds.

**Does this PR introduce a breaking change?**

No.

**Other information**:
