### PR TITLE
Fix stabilizer strength check

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/lib/InfusionMatrixLogic.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/InfusionMatrixLogic.java
@@ -140,7 +140,7 @@ public class InfusionMatrixLogic {
 
         // If we're not using the rewrite, use the default stabilizer strength
         // Should only be called by the symmetry-check command
-        if (!features.stabilizerStrength.isEnabled()) {
+        if (!features.stabilizerRewrite.isEnabled()) {
             return features.stabilizerStrength.getDefaultValue();
         }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This should have stabilizer rewrite working even if stabilizerStrength has its default value

**What is the current behavior?** (You can also link to an open issue here)

IntSetting has the following override:
```
 @Override
    public boolean isEnabled() {
        return value != defaultValue && super.isEnabled();
    }
```

So unless stabilizerStrength is different from its default value it will be treated as disabled. Which seems wrong, since this skips all the addon logic, tool.



**What is the new behavior (if this is a feature change)?**

This aims to fix that behavior and allow rewrite even with default strength.


**Does this PR introduce a breaking change?**

No


**Other information**:

Not sure why that IntSetting override exists, maybe that is the real problem? It got added in c518dc89 (#163).
