### PR TITLE
Add option to have unstable nodes not spawn orbs in unloaded chunks

### DIFF
--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -75,7 +75,7 @@ be adjusted by their modifier: 20% more often when bright, 20% less often when p
 
 ### Config Option: `unstableAspectDropsRequireLoadedChunks` (Default `true`)
 If true, unstable nodes not under the effects of a Node Stabilizer will not drain or spawn aspect orbs unless the nearby chunks needed to tick the spawned
-orb are loaded.
+orb are loaded. Additionally, aspect orbs will immediately despawn if they enter a chunk where they can't be ticked to further prevent their accumulation.
 
 ## Pickaxe of the Core Detection Ore Dictionary Labels (Group `tools`)
 

--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -74,7 +74,7 @@ If true, the rate at which tainted nodes will convert their surroundings to Tain
 be adjusted by their modifier: 20% more often when bright, 20% less often when pale, 50% less often when fading.
 
 ### Config Option: `unstableAspectDropsRequireLoadedChunks` (Default `true`)
-If true, unlocked unstable nodes will not drain or spawn aspect orbs unless the nearby chunks needed to tick the spawned
+If true, unstable nodes not under the effects of a Node Stabilizer will not drain or spawn aspect orbs unless the nearby chunks needed to tick the spawned
 orb are loaded.
 
 ## Pickaxe of the Core Detection Ore Dictionary Labels (Group `tools`)

--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -73,6 +73,10 @@ will scale with the current amount of vis of the node.
 If true, the rate at which tainted nodes will convert their surroundings to Tainted Lands and spawn taint tendrils will
 be adjusted by their modifier: 20% more often when bright, 20% less often when pale, 50% less often when fading.
 
+### Config Option: `unstableAspectDropsRequireLoadedChunks` (Default `true`)
+If true, unlocked unstable nodes will not drain or spawn aspect orbs unless the nearby chunks needed to tick the spawned
+orb are loaded.
+
 ## Pickaxe of the Core Detection Ore Dictionary Labels (Group `tools`)
 
 ### Config Option: `elementalPickOredictFilter`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -70,8 +70,9 @@ public class ConfigThaumcraft extends ConfigGroup {
         this,
         "unstableAspectDropsRequireLoadedChunks",
         """
-            If true, unlocked unstable nodes will not drain or spawn aspect orbs unless the nearby chunks needed to
-            tick the spawned orb are loaded.""").setCategory(nodeBehaviorsCategory);
+            If true, unstable nodes not under the effects of a Node Stabilizer will not drain or spawn aspect orbs unless the nearby chunks needed to tick the spawned
+            orb are loaded. Additionally, aspect orbs will immediately despawn if they enter a chunk where they can't be ticked to further prevent their accumulation.""")
+            .setCategory(nodeBehaviorsCategory);
 
     //
     // Potion Ids

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -66,6 +66,13 @@ public class ConfigThaumcraft extends ConfigGroup {
         tendrils will be adjusted by their modifier: 20% more often when bright, 20% less often when pale, 50% less
         often when fading.""").setCategory(nodeBehaviorsCategory);
 
+    public final ToggleSetting unstableAspectDropsRequireLoadedChunks = new ToggleSetting(
+        this,
+        "unstableAspectDropsRequireLoadedChunks",
+        """
+            If true, unlocked unstable nodes will not drain or spawn aspect orbs unless the nearby chunks needed to
+            tick the spawned orb are loaded.""").setCategory(nodeBehaviorsCategory);
+
     //
     // Potion Ids
     //

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -609,6 +609,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.taintedModifierSpeed)
         .addCommonMixins("thaumcraft.common.tiles.MixinTileNode_ModifierSpeed_Tainted")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    NODE_UNSTABLE_ASPECT_DROPS_CHUNK_GUARD(new SalisBuilder()
+        .applyIf(SalisConfig.thaum.unstableAspectDropsRequireLoadedChunks)
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileNode_UnstableAspectDropsChunkGuard")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     NODE_FIX_GET_BLOCK(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.fixNodeTriggeringChunkLoading)
         .addCommonMixins("thaumcraft.common.tiles.MixinTileNode_ProtectGetBlock")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -611,7 +611,9 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     NODE_UNSTABLE_ASPECT_DROPS_CHUNK_GUARD(new SalisBuilder()
         .applyIf(SalisConfig.thaum.unstableAspectDropsRequireLoadedChunks)
-        .addCommonMixins("thaumcraft.common.tiles.MixinTileNode_UnstableAspectDropsChunkGuard")
+        .addCommonMixins(
+            "thaumcraft.common.entities.MixinEntityAspectOrb_ChunkGuard",
+            "thaumcraft.common.tiles.MixinTileNode_UnstableAspectDropsChunkGuard")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     NODE_FIX_GET_BLOCK(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.fixNodeTriggeringChunkLoading)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/MixinEntityAspectOrb_ChunkGuard.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/MixinEntityAspectOrb_ChunkGuard.java
@@ -1,0 +1,33 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.entities;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.MathHelper;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import thaumcraft.common.entities.EntityAspectOrb;
+
+@Mixin(EntityAspectOrb.class)
+public abstract class MixinEntityAspectOrb_ChunkGuard extends Entity {
+
+    public MixinEntityAspectOrb_ChunkGuard(World world) {
+        super(world);
+    }
+
+    @Inject(method = "onUpdate", at = @At(value = "TAIL"))
+    private void setDeadWhenMovedIntoUnloadedChunk(CallbackInfo ci) {
+        if (worldObj.isRemote) {
+            return;
+        }
+
+        int x = MathHelper.floor_double(posX);
+        int z = MathHelper.floor_double(posZ);
+        if (!worldObj.checkChunksExist(x - 32, 0, z - 32, x + 32, 0, z + 32)) {
+            setDead();
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/MixinEntityAspectOrb_ChunkGuard.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/MixinEntityAspectOrb_ChunkGuard.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.entities.EntityAspectOrb;
 
 @Mixin(EntityAspectOrb.class)
-public abstract class MixinEntityAspectOrb_ChunkGuard extends Entity {
+abstract class MixinEntityAspectOrb_ChunkGuard extends Entity {
 
     public MixinEntityAspectOrb_ChunkGuard(World world) {
         super(world);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_UnstableAspectDropsChunkGuard.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_UnstableAspectDropsChunkGuard.java
@@ -1,0 +1,27 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.api.aspects.Aspect;
+import thaumcraft.common.tiles.TileNode;
+
+@Mixin(value = TileNode.class, remap = false)
+public abstract class MixinTileNode_UnstableAspectDropsChunkGuard extends TileThaumcraft {
+
+    @WrapOperation(
+        method = "handleNodeStability",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/tiles/TileNode;takeRandomPrimalFromSource()Lthaumcraft/api/aspects/Aspect;"))
+    private Aspect skipUnstableDropsWhenNearbyChunksAreUnloaded(TileNode instance, Operation<Aspect> original) {
+        if (!worldObj.checkChunksExist(xCoord - 32, 0, zCoord - 32, xCoord + 32, 0, zCoord + 32)) {
+            return null;
+        }
+        return original.call(instance);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_UnstableAspectDropsChunkGuard.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_UnstableAspectDropsChunkGuard.java
@@ -11,7 +11,7 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class, remap = false)
-public abstract class MixinTileNode_UnstableAspectDropsChunkGuard extends TileThaumcraft {
+abstract class MixinTileNode_UnstableAspectDropsChunkGuard extends TileThaumcraft {
 
     @WrapOperation(
         method = "handleNodeStability",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR adds a feature to prevent unstable nodes from creating aspect orbs when they are close to unloaded chunks.


**What is the current behavior?** (You can also link to an open issue here)

Currently, unstable nodes spawn aspect orbs when they're getting ticked. Those orbs normally despawn ober time automatically.

But orbs only get updated if `World.updateEntityWithOptionalForce` passes the following check:
```
byte b0 = isForced ? (byte)0 : 32;
boolean canUpdate = !p_72866_2_ || this.checkChunksExist(i - b0, 0, j - b0, i + b0, 0, j + b0);
```

So, if orbs either
- spawn in a chunk that is not force loaded and touches unloaded chunks or
- fly into an unloaded chunk

Then the orb will never tick, and therefore never die. This leads to orbs piling up, especially since unstable nodes do randomly recharge, i.e. will never run out of aspects.


**What is the new behavior (if this is a feature change)?**

This adds a config to simply never spawn orbs if they can't be ticked - preventing infinite pileup.


**Does this PR introduce a breaking change?**

No


**Other information**:

A user reported an "Oversized chunk" warning from hodgepodge, upon investigation I noticed 39666 Thaumcraft Aspect orbs. The player built a mining outpost far away from their base, chunk loaded it and the unstable node was in a chunk next to the force loaded chunks. Since Minecraft still loads neighboring chunks from time to time due to block updates, this lead to the node spawning a lot of orbs.

I tested by putting an unstable node at a chunk border, making unstable nodes spawn 10 orbs per tick and force loading only the chunk the node is in. After a few minutes there's thousands of aspect orbs in unloaded chunks.