### PR TITLE
Make Thaumcraft particles pause with the game

### DIFF
--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -37,6 +37,9 @@ above the decay's maximum range.
 
 The default maximum rate of 4.2% is vanilla Thaumcraft's maximum decay rate with its flat decay at 100 total aspects.
 
+### ConfigOption: `pauseTCParticlesWithGame`
+If true, Thaumcraft particles will behave like vanilla particles and pause when the game is paused.
+
 ## Node Behaviors (Group `node_behaviors`)
 
 ### Config Option: `hungryDynamicReach` (Default `false`)

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -202,6 +202,11 @@ public class ConfigThaumcraft extends ConfigGroup {
         4.2f).setMinValue(0.01f)
             .setMaxValue(100f);
 
+    public final ToggleSetting pauseTCParticlesWithGame = new ToggleSetting(
+        this,
+        "pauseTCParticlesWithGame",
+        "If true, Thaumcraft particles will behave like vanilla particles and pause when the game is paused.");
+
     @Override
     public @NotNull String getGroupName() {
         return "thaumcraft_configuration";

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -301,6 +301,11 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.fixTESRWorldLeak)
         .addClientMixins("thaumcraft.client.renderers.tile.MixinTESR_FixLeak")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    PAUSE_TC_PARTICLES(new SalisBuilder()
+        .applyIf(SalisConfig.thaum.pauseTCParticlesWithGame)
+        .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_PauseParticles")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
+
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_PauseParticles.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_PauseParticles.java
@@ -1,0 +1,24 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.client.fx;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.client.FMLClientHandler;
+import cpw.mods.fml.common.gameevent.TickEvent;
+import thaumcraft.client.fx.ParticleEngine;
+
+@Mixin(value = ParticleEngine.class, remap = false)
+abstract class MixinParticleEngine_PauseParticles {
+
+    @Inject(method = "updateParticles", at = @At("HEAD"), cancellable = true)
+    private void onUpdateParticles(TickEvent.ClientTickEvent event, CallbackInfo ci) {
+        if (FMLClientHandler.instance()
+            .getClient()
+            .isGamePaused()) {
+            ci.cancel();
+        }
+    }
+
+}


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Client-side tweak

**What is the current behavior?** (You can also link to an open issue here)
Thaumcraft particles update and expire even when the game is paused.

**What is the new behavior (if this is a feature change)?**
Thaumcraft particle processing is paused when the game is paused.

**Does this PR introduce a breaking change?**
No

**Other information**:
