### PR TITLE
lower frequency of thaum arcane bore cvis checks for speedup

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -370,3 +370,9 @@ Runic Matrices which are too stable will not fly far out from the center of the 
 **Config option:** `fixInventoryAspects`
 
 Fixes a bug where some GUIs would render the wrong aspects when shifting over a slot. Also improves the performance of this overlay.
+
+## Fix Arcane Bores look-up frequency
+
+**Config option:** `boreDecreaseCVisCheckFrequency`
+
+Fixes Arcane Bores looking up vis nets too frequently, if they aren't maxed out on cvis for speedup.

--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -375,4 +375,4 @@ Fixes a bug where some GUIs would render the wrong aspects when shifting over a 
 
 **Config option:** `boreDecreaseCVisCheckFrequency`
 
-Fixes Arcane Bores looking up vis nets too frequently, if they aren't maxed out on cvis for speedup.
+Lowers the frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup, and therefore calls to find vis nets.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -340,6 +340,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "fixParticleEngineLeak",
         "Fix Thaumcraft's particle engine leaking the world instance");
 
+    public final ToggleSetting boreDecreaseCVisCheckFrequency = new ToggleSetting(
+        this,
+        "boreDecreaseCVisCheckFrequency",
+        "Lower frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup, and therefore calls to find vis nets.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -301,6 +301,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.fixTESRWorldLeak)
         .addClientMixins("thaumcraft.client.renderers.tile.MixinTESR_FixLeak")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    ARCANE_BORE_VIS_DRAIN_FREQUENCY(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.boreDecreaseCVisCheckFrequency)
+        .addCommonMixins("thaumcraft.common.tiles.MixinBoreVisFrequencyReduction")
+        .setPhase(Phase.LATE)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -303,7 +303,7 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     ARCANE_BORE_VIS_DRAIN_FREQUENCY(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.boreDecreaseCVisCheckFrequency)
-        .addCommonMixins("thaumcraft.common.tiles.MixinBoreVisFrequencyReduction")
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileArcaneBore_DecreaseCVisCheckFrequency")
         .setPhase(Phase.LATE)),
     PAUSE_TC_PARTICLES(new SalisBuilder()
         .applyIf(SalisConfig.thaum.pauseTCParticlesWithGame)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -303,8 +303,7 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     ARCANE_BORE_VIS_DRAIN_FREQUENCY(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.boreDecreaseCVisCheckFrequency)
-        .addCommonMixins("thaumcraft.common.tiles.MixinTileArcaneBore_DecreaseCVisCheckFrequency")
-        .setPhase(Phase.LATE)),
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileArcaneBore_DecreaseCVisCheckFrequency")),
     PAUSE_TC_PARTICLES(new SalisBuilder()
         .applyIf(SalisConfig.thaum.pauseTCParticlesWithGame)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_PauseParticles")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
@@ -1,0 +1,73 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
+
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import thaumcraft.common.tiles.TileArcaneBore;
+
+@Mixin(value = TileArcaneBore.class, remap = true)
+public abstract class MixinTileArcaneBore_DecreaseCVisCheckFrequency {
+
+    @Shadow
+    public abstract boolean gettingPower();
+
+    @Shadow
+    private float speedyTime;
+
+    @Unique
+    private int salisArcana$cooldown = 0;
+    @Unique
+    private float salisArcana$cachedTime = 0;
+
+    // Add a cooldown to the if statement.
+    @ModifyExpressionValue(
+        method = "updateEntity",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/world/World;isRemote:Z",
+            ordinal = 0,
+            opcode = Opcodes.GETFIELD))
+    public boolean powerAndSleep(boolean isRemote) {
+        // The returned value is inverted.
+
+        // Client thread, return
+        if (isRemote) return true;
+
+        // Cooldown expired, do checks
+        if (salisArcana$cooldown-- <= 0) {
+            if (this.gettingPower()) {
+                // Do a cvis check, sleep 10s
+                salisArcana$cooldown = 10 * 20;
+                // double cooldown if it never had cvis
+                // imprecision means it will never be 0 again. I think.
+                salisArcana$cooldown *= this.speedyTime == 0 ? 2 : 1;
+                return false;
+            } else {
+                // Block isn't powered, so do cvis thing but choke to 30s instead
+                salisArcana$cooldown = 30 * 20;
+                // double cooldown if it never had cvis
+                salisArcana$cooldown *= this.speedyTime == 0 ? 2 : 1;
+                return false;
+            }
+        }
+
+        // if it has any cached speedyTime, but less than the max, skip cooldown
+        // Speedy time can be exhausted in 1 second by a constantly-digging bore.
+        // if the speedyTime doesn't change since last lookup, increase cooldown to 1/2s
+        if (this.speedyTime != 0 && this.speedyTime < 20) {
+            if (this.speedyTime == salisArcana$cachedTime) {
+                salisArcana$cooldown = Math.min(salisArcana$cooldown, 10);
+            } else salisArcana$cooldown = 0;
+            salisArcana$cachedTime = this.speedyTime;
+        }
+
+        // Cooldown's not up, don't do cvis thing.
+        return true;
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import thaumcraft.common.tiles.TileArcaneBore;
 
 @Mixin(value = TileArcaneBore.class, remap = true)
-public abstract class MixinTileArcaneBore_DecreaseCVisCheckFrequency {
+abstract class MixinTileArcaneBore_DecreaseCVisCheckFrequency {
 
     @Shadow
     public abstract boolean gettingPower();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
@@ -10,19 +10,19 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 
 import thaumcraft.common.tiles.TileArcaneBore;
 
-@Mixin(value = TileArcaneBore.class, remap = true)
+@Mixin(TileArcaneBore.class)
 abstract class MixinTileArcaneBore_DecreaseCVisCheckFrequency {
 
-    @Shadow
+    @Shadow(remap = false)
     public abstract boolean gettingPower();
 
-    @Shadow
+    @Shadow(remap = false)
     private float speedyTime;
 
     @Unique
-    private int salisArcana$cooldown = 0;
+    private int salisarcana$cooldown = 0;
     @Unique
-    private float salisArcana$cachedTime = 0;
+    private float salisarcana$cachedTime = 0;
 
     // Add a cooldown to the if statement.
     @ModifyExpressionValue(
@@ -39,31 +39,28 @@ abstract class MixinTileArcaneBore_DecreaseCVisCheckFrequency {
         if (isRemote) return true;
 
         // Cooldown expired, do checks
-        if (salisArcana$cooldown-- <= 0) {
+        if (salisarcana$cooldown-- <= 0) {
             if (this.gettingPower()) {
                 // Do a cvis check, sleep 10s
-                salisArcana$cooldown = 10 * 20;
-                // double cooldown if it never had cvis
-                // imprecision means it will never be 0 again. I think.
-                salisArcana$cooldown *= this.speedyTime == 0 ? 2 : 1;
-                return false;
+                salisarcana$cooldown = 10 * 20;
             } else {
                 // Block isn't powered, so do cvis thing but choke to 30s instead
-                salisArcana$cooldown = 30 * 20;
-                // double cooldown if it never had cvis
-                salisArcana$cooldown *= this.speedyTime == 0 ? 2 : 1;
-                return false;
+                salisarcana$cooldown = 30 * 20;
             }
+            // double cooldown if it never had cvis
+            // imprecision means it will never be 0 again. I think.
+            salisarcana$cooldown *= this.speedyTime == 0 ? 2 : 1;
+            return false;
         }
 
         // if it has any cached speedyTime, but less than the max, skip cooldown
         // Speedy time can be exhausted in 1 second by a constantly-digging bore.
         // if the speedyTime doesn't change since last lookup, increase cooldown to 1/2s
         if (this.speedyTime != 0 && this.speedyTime < 20) {
-            if (this.speedyTime == salisArcana$cachedTime) {
-                salisArcana$cooldown = Math.min(salisArcana$cooldown, 10);
-            } else salisArcana$cooldown = 0;
-            salisArcana$cachedTime = this.speedyTime;
+            if (this.speedyTime == salisarcana$cachedTime) {
+                salisarcana$cooldown = Math.min(salisarcana$cooldown, 10);
+            } else salisarcana$cooldown = 0;
+            salisarcana$cachedTime = this.speedyTime;
         }
 
         // Cooldown's not up, don't do cvis thing.

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileArcaneBore_DecreaseCVisCheckFrequency.java
@@ -41,10 +41,10 @@ abstract class MixinTileArcaneBore_DecreaseCVisCheckFrequency {
         // Cooldown expired, do checks
         if (salisarcana$cooldown-- <= 0) {
             if (this.gettingPower()) {
-                // Do a cvis check, sleep 10s
+                // Do a speedyTime refill, sleep 10s
                 salisarcana$cooldown = 10 * 20;
             } else {
-                // Block isn't powered, so do cvis thing but choke to 30s instead
+                // Block isn't powered, so do speedyTime refill but choke to 30s instead
                 salisarcana$cooldown = 30 * 20;
             }
             // double cooldown if it never had cvis
@@ -63,7 +63,7 @@ abstract class MixinTileArcaneBore_DecreaseCVisCheckFrequency {
             salisarcana$cachedTime = this.speedyTime;
         }
 
-        // Cooldown's not up, don't do cvis thing.
+        // Cooldown's not up, don't refill speedyTime.
         return true;
     }
 


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix

**What is the current behavior?** (You can also link to an open issue here)

any time it does not have 20 or more speedyTime saved up, it attempts to drain cvis. 

**What is the new behavior (if this is a feature change)?**

Add cooldown to thaum's arcane bore cvis handling to decrease calls for cvis source checking. Should icnrease performance, especially since bores are usually spammed by hte hundreds.

If it has redstone, cooldown is 10s. If not, 30.

If it has any speedy time cached, the cooldown is skipped as long as its refilling. Otherwise, if it just has a bunch cached but isn't refilling or draining, it goes to 1/2s. This is still 10x less calls, even if they get suck in a state of only having some cvis forever.

If it never had cvis (going off of floating point imprecision for it), cooldown doubles. This won't happen on first placement if it has a source nearby, and presumably if you ever use cvis, it will never return to 0 (it subracts 1, without limiting it to 0). Otherwise, once cooldown is over, it won't double again.

**Does this PR introduce a breaking change?**

i don't believe so.

**Other information**:
