### PR TITLE
Standardize on package-private abstract mixins.

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/automagy/blocks/MixinBlockBoiler_FakePlayer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/automagy/blocks/MixinBlockBoiler_FakePlayer.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import tuhljin.automagy.blocks.BlockBoiler;
 
 @Mixin(BlockBoiler.class)
-public abstract class MixinBlockBoiler_FakePlayer {
+abstract class MixinBlockBoiler_FakePlayer {
 
     @WrapOperation(
         method = "onBlockActivated",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/automagy/config/ModResearchItem_Extended.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/automagy/config/ModResearchItem_Extended.java
@@ -9,7 +9,7 @@ import tuhljin.automagy.config.ModResearchItem;
 
 @SuppressWarnings("AddedMixinMembersNamePattern")
 @Mixin(value = ModResearchItem.class, remap = false)
-public abstract class ModResearchItem_Extended extends ResearchItem implements IResearchItemExtended {
+abstract class ModResearchItem_Extended extends ResearchItem implements IResearchItemExtended {
 
     public ModResearchItem_Extended(String key, String category) {
         super(key, category);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/research/ResearchItem_Extended.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/research/ResearchItem_Extended.java
@@ -9,7 +9,7 @@ import thaumcraft.api.research.ResearchItem;
 
 @SuppressWarnings("AddedMixinMembersNamePattern")
 @Mixin(value = ResearchItem.class, remap = false)
-public abstract class ResearchItem_Extended implements IResearchItemExtended {
+abstract class ResearchItem_Extended implements IResearchItemExtended {
 
     @Shadow
     @Final

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/wands/MixinItemFocusBasic_WandUpgradeLevel.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/wands/MixinItemFocusBasic_WandUpgradeLevel.java
@@ -11,7 +11,7 @@ import thaumcraft.api.wands.ItemFocusBasic;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(ItemFocusBasic.class)
-public class MixinItemFocusBasic_WandUpgradeLevel {
+abstract class MixinItemFocusBasic_WandUpgradeLevel {
 
     @WrapMethod(method = "getAppliedUpgrades", remap = false)
     public short[] unwrapWandItem(ItemStack focusStack, Operation<short[]> original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_FixLeak.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_FixLeak.java
@@ -13,7 +13,7 @@ import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import thaumcraft.client.fx.ParticleEngine;
 
 @Mixin(value = ParticleEngine.class, remap = false)
-public class MixinParticleEngine_FixLeak {
+abstract class MixinParticleEngine_FixLeak {
 
     @Shadow
     private HashMap<Integer, ArrayList<EntityFX>>[] particles;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_SkipRendering.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/MixinParticleEngine_SkipRendering.java
@@ -16,7 +16,7 @@ import cpw.mods.fml.common.gameevent.TickEvent;
 import thaumcraft.client.fx.ParticleEngine;
 
 @Mixin(value = ParticleEngine.class, remap = false)
-public class MixinParticleEngine_SkipRendering {
+abstract class MixinParticleEngine_SkipRendering {
 
     @Unique
     private boolean sa$hasParticles;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/beams/MixinFXBeamWand_FociStaffVisualFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/fx/beams/MixinFXBeamWand_FociStaffVisualFix.java
@@ -15,7 +15,7 @@ import thaumcraft.api.wands.WandRod;
 import thaumcraft.client.fx.beams.FXBeamWand;
 
 @Mixin(value = FXBeamWand.class, remap = false)
-public class MixinFXBeamWand_FociStaffVisualFix {
+abstract class MixinFXBeamWand_FociStaffVisualFix {
 
     @Shadow
     private double offset;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiArcaneWorkbench_MissingResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiArcaneWorkbench_MissingResearch.java
@@ -24,7 +24,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(GuiArcaneWorkbench.class)
-public abstract class MixinGuiArcaneWorkbench_MissingResearch extends GuiContainer {
+abstract class MixinGuiArcaneWorkbench_MissingResearch extends GuiContainer {
 
     public MixinGuiArcaneWorkbench_MissingResearch(Container p_i1072_1_) {
         super(p_i1072_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiArcaneWorkbench_SingleWandReplacement.java
@@ -20,7 +20,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(GuiArcaneWorkbench.class)
-public class MixinGuiArcaneWorkbench_SingleWandReplacement {
+abstract class MixinGuiArcaneWorkbench_SingleWandReplacement {
 
     @Shadow(remap = false)
     private TileArcaneWorkbench tileEntity;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiFocalManipulator_CreativeNoXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiFocalManipulator_CreativeNoXP.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import thaumcraft.client.gui.GuiFocalManipulator;
 
 @Mixin(GuiFocalManipulator.class)
-public abstract class MixinGuiFocalManipulator_CreativeNoXP extends GuiContainer {
+abstract class MixinGuiFocalManipulator_CreativeNoXP extends GuiContainer {
 
     public MixinGuiFocalManipulator_CreativeNoXP(Container p_i1072_1_) {
         super(p_i1072_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiFocalManipulator_FocusDisenchanting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiFocalManipulator_FocusDisenchanting.java
@@ -28,7 +28,7 @@ import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.tiles.TileFocalManipulator;
 
 @Mixin(GuiFocalManipulator.class)
-public class MixinGuiFocalManipulator_FocusDisenchanting {
+abstract class MixinGuiFocalManipulator_FocusDisenchanting {
 
     @Shadow(remap = false)
     ArrayList<FocusUpgradeType> upgrades;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiFocalManipulator_UseExtendedEnchantmentPacket.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiFocalManipulator_UseExtendedEnchantmentPacket.java
@@ -13,7 +13,7 @@ import dev.rndmorris.salisarcana.network.NetworkHandler;
 import thaumcraft.client.gui.GuiFocalManipulator;
 
 @Mixin(GuiFocalManipulator.class)
-public class MixinGuiFocalManipulator_UseExtendedEnchantmentPacket {
+abstract class MixinGuiFocalManipulator_UseExtendedEnchantmentPacket {
 
     @WrapOperation(
         method = "mouseClicked",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_Creative_Scroll.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_Creative_Scroll.java
@@ -32,7 +32,7 @@ import thaumcraft.client.gui.GuiResearchBrowser;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(value = GuiResearchBrowser.class)
-public abstract class MixinGuiResearchBrowser_Creative_Scroll extends GuiScreen {
+abstract class MixinGuiResearchBrowser_Creative_Scroll extends GuiScreen {
 
     @Shadow(remap = false)
     public abstract void updateResearch();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_DuplicateButton.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_DuplicateButton.java
@@ -37,7 +37,7 @@ import thaumcraft.common.Thaumcraft;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(GuiResearchBrowser.class)
-public class MixinGuiResearchBrowser_DuplicateButton extends GuiScreen {
+abstract class MixinGuiResearchBrowser_DuplicateButton extends GuiScreen {
 
     @Unique
     private static final ResourceLocation sa$duplicationButtonTexture = new ResourceLocation(

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_RightClickClose.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_RightClickClose.java
@@ -17,7 +17,7 @@ import thaumcraft.client.gui.GuiResearchBrowser;
 import thaumcraft.client.gui.GuiResearchRecipe;
 
 @Mixin(value = GuiResearchBrowser.class)
-public class MixinGuiResearchBrowser_RightClickClose extends GuiScreen {
+abstract class MixinGuiResearchBrowser_RightClickClose extends GuiScreen {
 
     @Shadow(remap = false)
     protected double guiMapX;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_ShowResearchID.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchBrowser_ShowResearchID.java
@@ -15,7 +15,7 @@ import thaumcraft.api.research.ResearchItem;
 import thaumcraft.client.gui.GuiResearchBrowser;
 
 @Mixin(GuiResearchBrowser.class)
-public class MixinGuiResearchBrowser_ShowResearchID extends GuiScreen {
+abstract class MixinGuiResearchBrowser_ShowResearchID extends GuiScreen {
 
     @Unique
     private boolean sa$isControlHeld;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchRecipe_RightClickNavigation.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchRecipe_RightClickNavigation.java
@@ -21,7 +21,7 @@ import thaumcraft.client.gui.GuiResearchBrowser;
 import thaumcraft.client.gui.GuiResearchRecipe;
 
 @Mixin(GuiResearchRecipe.class)
-public class MixinGuiResearchRecipe_RightClickNavigation extends GuiScreen {
+abstract class MixinGuiResearchRecipe_RightClickNavigation extends GuiScreen {
 
     @Shadow(remap = false)
     protected double guiMapX;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchTable_FreeDuplicates.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchTable_FreeDuplicates.java
@@ -12,7 +12,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.client.gui.GuiResearchTable;
 
 @Mixin(GuiResearchTable.class)
-public class MixinGuiResearchTable_FreeDuplicates {
+abstract class MixinGuiResearchTable_FreeDuplicates {
 
     @Unique
     private static final AspectList sa$noAspects = new AspectList();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchTable_UnknownAspectTooltip.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/gui/MixinGuiResearchTable_UnknownAspectTooltip.java
@@ -20,7 +20,7 @@ import thaumcraft.common.lib.research.ResearchNoteData;
 import thaumcraft.common.lib.utils.HexUtils;
 
 @Mixin(value = GuiResearchTable.class, remap = false)
-public abstract class MixinGuiResearchTable_UnknownAspectTooltip extends GuiContainer {
+abstract class MixinGuiResearchTable_UnknownAspectTooltip extends GuiContainer {
 
     @Shadow
     public ResearchNoteData note;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinClientTickEventsFML_SlotAspectPopup.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinClientTickEventsFML_SlotAspectPopup.java
@@ -24,7 +24,7 @@ import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 import thaumcraft.common.lib.research.ScanManager;
 
 @Mixin(value = ClientTickEventsFML.class, remap = false, priority = 999)
-public class MixinClientTickEventsFML_SlotAspectPopup {
+abstract class MixinClientTickEventsFML_SlotAspectPopup {
 
     /**
      * @author Sisyphussy

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinClientTickEventsFML_VisOverflow.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinClientTickEventsFML_VisOverflow.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import thaumcraft.client.lib.ClientTickEventsFML;
 
 @Mixin(value = ClientTickEventsFML.class, remap = false)
-public class MixinClientTickEventsFML_VisOverflow {
+abstract class MixinClientTickEventsFML_VisOverflow {
 
     @ModifyVariable(method = "renderCastingWandHud", name = "loc", at = @At("STORE"))
     private int clampVisBar(int value) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinREHWandHandler_ExtendedBaublesSupport.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinREHWandHandler_ExtendedBaublesSupport.java
@@ -11,7 +11,7 @@ import baubles.api.BaublesApi;
 import thaumcraft.client.lib.REHWandHandler;
 
 @Mixin(value = REHWandHandler.class, remap = false)
-public class MixinREHWandHandler_ExtendedBaublesSupport {
+abstract class MixinREHWandHandler_ExtendedBaublesSupport {
 
     @ModifyConstant(method = "handleFociRadial", constant = @Constant(intValue = 4, ordinal = 0), remap = false)
     private int handleFociRadial(int value, Minecraft mc, long time, RenderGameOverlayEvent event) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_DetectLapisOre.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_DetectLapisOre.java
@@ -12,7 +12,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.client.lib.RenderEventHandler;
 
 @Mixin(value = RenderEventHandler.class, remap = false)
-public abstract class MixinRenderEventHandler_DetectLapisOre {
+abstract class MixinRenderEventHandler_DetectLapisOre {
 
     @WrapOperation(
         method = "startScan",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_DetectLitRedstoneOre.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_DetectLitRedstoneOre.java
@@ -12,7 +12,7 @@ import thaumcraft.client.lib.RenderEventHandler;
 
 // this priority positions it to be executed before the big mixin
 @Mixin(value = RenderEventHandler.class, remap = false, priority = 1001)
-public class MixinRenderEventHandler_DetectLitRedstoneOre {
+abstract class MixinRenderEventHandler_DetectLitRedstoneOre {
 
     @ModifyExpressionValue(
         method = "startScan",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_DetectZeroAspectBlocks.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_DetectZeroAspectBlocks.java
@@ -8,7 +8,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import thaumcraft.client.lib.RenderEventHandler;
 
 @Mixin(value = RenderEventHandler.class, remap = false)
-public abstract class MixinRenderEventHandler_DetectZeroAspectBlocks {
+abstract class MixinRenderEventHandler_DetectZeroAspectBlocks {
 
     @ModifyExpressionValue(
         method = "startScan",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_ElementalPickOredict.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinRenderEventHandler_ElementalPickOredict.java
@@ -20,7 +20,7 @@ import dev.rndmorris.salisarcana.SalisArcana;
 import thaumcraft.client.lib.RenderEventHandler;
 
 @Mixin(value = RenderEventHandler.class, remap = false)
-public abstract class MixinRenderEventHandler_ElementalPickOredict {
+abstract class MixinRenderEventHandler_ElementalPickOredict {
 
     @WrapOperation(
         method = "startScan",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer_AngelicaFontRenderer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinTCFontRenderer_AngelicaFontRenderer.java
@@ -13,7 +13,7 @@ import com.gtnewhorizons.angelica.mixins.interfaces.FontRendererAccessor;
 import thaumcraft.client.lib.TCFontRenderer;
 
 @Mixin(value = TCFontRenderer.class, remap = false)
-public abstract class MixinTCFontRenderer_AngelicaFontRenderer {
+abstract class MixinTCFontRenderer_AngelicaFontRenderer {
 
     @Unique
     private static FontRenderer sa$fr = Minecraft.getMinecraft().fontRenderer;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_DisableAspectTint.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_DisableAspectTint.java
@@ -10,7 +10,7 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.client.lib.UtilsFX;
 
 @Mixin(value = UtilsFX.class, remap = false)
-public abstract class MixinUtilsFX_DisableAspectTint {
+abstract class MixinUtilsFX_DisableAspectTint {
 
     @WrapOperation(
         method = "drawTag(DDLthaumcraft/api/aspects/Aspect;FIDIFZ)V",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_ReflectionToAccessors.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_ReflectionToAccessors.java
@@ -20,7 +20,7 @@ import dev.rndmorris.salisarcana.mixins.early.accessor.AccessorMinecraft;
 import thaumcraft.client.lib.UtilsFX;
 
 @Mixin(value = UtilsFX.class, remap = false)
-public class MixinUtilsFX_ReflectionToAccessors {
+abstract class MixinUtilsFX_ReflectionToAccessors {
     // Replace reflection with AT/accessors
 
     /**

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/block/MixinBlockCandleRenderer_OOB.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/block/MixinBlockCandleRenderer_OOB.java
@@ -15,7 +15,7 @@ import thaumcraft.client.renderers.block.BlockCandleRenderer;
 import thaumcraft.common.lib.utils.Utils;
 
 @Mixin(BlockCandleRenderer.class)
-public abstract class MixinBlockCandleRenderer_OOB {
+abstract class MixinBlockCandleRenderer_OOB {
 
     /**
      * @author jss2a98aj

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/tile/MixinTESR_FixLeak.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/tile/MixinTESR_FixLeak.java
@@ -12,7 +12,7 @@ import thaumcraft.client.renderers.tile.TileFocalManipulatorRenderer;
 import thaumcraft.client.renderers.tile.TileThaumatoriumRenderer;
 
 @Mixin({ TileEldritchCapRenderer.class, TileFocalManipulatorRenderer.class, TileThaumatoriumRenderer.class })
-public abstract class MixinTESR_FixLeak extends TileEntitySpecialRenderer {
+abstract class MixinTESR_FixLeak extends TileEntitySpecialRenderer {
 
     @Shadow(remap = false)
     EntityItem entityitem;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/tile/MixinTileRunicMatrixRenderer_StableAltar.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/tile/MixinTileRunicMatrixRenderer_StableAltar.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import thaumcraft.client.renderers.tile.TileRunicMatrixRenderer;
 
 @Mixin(value = TileRunicMatrixRenderer.class, remap = false)
-public class MixinTileRunicMatrixRenderer_StableAltar {
+abstract class MixinTileRunicMatrixRenderer_StableAltar {
 
     @ModifyVariable(method = "renderInfusionMatrix", name = "instability", at = @At("STORE"))
     private float limitInstability(float value) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/MixinThaumcraft_FakePlayerWarp.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/MixinThaumcraft_FakePlayerWarp.java
@@ -12,7 +12,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import thaumcraft.common.Thaumcraft;
 
 @Mixin(Thaumcraft.class)
-public class MixinThaumcraft_FakePlayerWarp {
+abstract class MixinThaumcraft_FakePlayerWarp {
 
     @WrapMethod(method = "addWarpToPlayer", remap = false)
     private static void cancelFakePlayers(EntityPlayer player, int amount, boolean temporary,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockAiry_EarthShockCheckSolidGround.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockAiry_EarthShockCheckSolidGround.java
@@ -10,7 +10,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import thaumcraft.common.blocks.BlockAiry;
 
 @Mixin(BlockAiry.class)
-public class MixinBlockAiry_EarthShockCheckSolidGround {
+abstract class MixinBlockAiry_EarthShockCheckSolidGround {
 
     @ModifyExpressionValue(
         method = "onNeighborBlockChange",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockArcaneFurnace_DupeFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockArcaneFurnace_DupeFix.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.blocks.BlockArcaneFurnace;
 
 @Mixin(BlockArcaneFurnace.class)
-public class MixinBlockArcaneFurnace_DupeFix {
+abstract class MixinBlockArcaneFurnace_DupeFix {
 
     @Inject(method = "onEntityCollidedWithBlock", at = @At(value = "HEAD"), cancellable = true)
     private void mixinOnEntityCollidedWithBlock(World world, int x, int y, int z, Entity entity, CallbackInfo ci) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCandle_OOB.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCandle_OOB.java
@@ -17,7 +17,7 @@ import thaumcraft.common.blocks.BlockCandle;
 import thaumcraft.common.lib.utils.Utils;
 
 @Mixin(BlockCandle.class)
-public abstract class MixinBlockCandle_OOB {
+abstract class MixinBlockCandle_OOB {
 
     /**
      * @author jss2a98aj

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCandle_SetBlockBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCandle_SetBlockBounds.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.blocks.BlockCandle;
 
 @Mixin(BlockCandle.class)
-public abstract class MixinBlockCandle_SetBlockBounds extends Block {
+abstract class MixinBlockCandle_SetBlockBounds extends Block {
 
     protected MixinBlockCandle_SetBlockBounds(Material materialIn) {
         super(materialIn);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockChestHungry_SetBlockBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockChestHungry_SetBlockBounds.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.blocks.BlockChestHungry;
 
 @Mixin(BlockChestHungry.class)
-public abstract class MixinBlockChestHungry_SetBlockBounds extends BlockContainer {
+abstract class MixinBlockChestHungry_SetBlockBounds extends BlockContainer {
 
     protected MixinBlockChestHungry_SetBlockBounds(Material p_i45386_1_) {
         super(p_i45386_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCosmeticSolid_BeaconBlocks.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCosmeticSolid_BeaconBlocks.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import thaumcraft.common.blocks.BlockCosmeticSolid;
 
 @Mixin(BlockCosmeticSolid.class)
-public abstract class MixinBlockCosmeticSolid_BeaconBlocks extends Block {
+abstract class MixinBlockCosmeticSolid_BeaconBlocks extends Block {
 
     protected MixinBlockCosmeticSolid_BeaconBlocks(Material materialIn) {
         super(materialIn);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCrystal_SilkTouch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCrystal_SilkTouch.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import thaumcraft.common.blocks.BlockCrystal;
 
 @Mixin(BlockCrystal.class)
-public abstract class MixinBlockCrystal_SilkTouch extends Block {
+abstract class MixinBlockCrystal_SilkTouch extends Block {
 
     protected MixinBlockCrystal_SilkTouch(Material materialIn) {
         super(materialIn);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCustomOre_RedstoneFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCustomOre_RedstoneFix.java
@@ -6,7 +6,7 @@ import org.spongepowered.asm.mixin.Overwrite;
 import thaumcraft.common.blocks.BlockCustomOre;
 
 @Mixin(BlockCustomOre.class)
-public abstract class MixinBlockCustomOre_RedstoneFix {
+abstract class MixinBlockCustomOre_RedstoneFix {
 
     /**
      * @author Midnight145

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockEldritch_CreativeMode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockEldritch_CreativeMode.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import thaumcraft.common.blocks.BlockEldritch;
 
 @Mixin(BlockEldritch.class)
-public class MixinBlockEldritch_CreativeMode {
+abstract class MixinBlockEldritch_CreativeMode {
 
     @Inject(
         method = "onBlockActivated",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockEssentiaReservoir_SetBlockBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockEssentiaReservoir_SetBlockBounds.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.blocks.BlockEssentiaReservoir;
 
 @Mixin(BlockEssentiaReservoir.class)
-public abstract class MixinBlockEssentiaReservoir_SetBlockBounds extends BlockContainer {
+abstract class MixinBlockEssentiaReservoir_SetBlockBounds extends BlockContainer {
 
     protected MixinBlockEssentiaReservoir_SetBlockBounds(Material p_i45386_1_) {
         super(p_i45386_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockJar_NoCreativeDrops.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockJar_NoCreativeDrops.java
@@ -12,7 +12,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.blocks.BlockJar;
 
 @Mixin(BlockJar.class)
-public class MixinBlockJar_NoCreativeDrops {
+abstract class MixinBlockJar_NoCreativeDrops {
 
     @WrapWithCondition(
         method = "onBlockHarvested",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockJar_PickBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockJar_PickBlock.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import thaumcraft.common.blocks.BlockJar;
 
 @Mixin(BlockJar.class)
-public abstract class MixinBlockJar_PickBlock extends BlockContainer {
+abstract class MixinBlockJar_PickBlock extends BlockContainer {
 
     @Shadow(remap = false)
     public abstract ArrayList<ItemStack> getDrops(World world, int x, int y, int z, int metadata, int fortune);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockJar_SetBlockBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockJar_SetBlockBounds.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.blocks.BlockJar;
 
 @Mixin(BlockJar.class)
-public abstract class MixinBlockJar_SetBlockBounds extends BlockContainer {
+abstract class MixinBlockJar_SetBlockBounds extends BlockContainer {
 
     protected MixinBlockJar_SetBlockBounds(Material p_i45386_1_) {
         super(p_i45386_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockLoot_SetBlockBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockLoot_SetBlockBounds.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.blocks.BlockLoot;
 
 @Mixin(BlockLoot.class)
-public abstract class MixinBlockLoot_SetBlockBounds extends Block {
+abstract class MixinBlockLoot_SetBlockBounds extends Block {
 
     protected MixinBlockLoot_SetBlockBounds(Material materialIn) {
         super(materialIn);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMagicalLogItem_NameFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMagicalLogItem_NameFix.java
@@ -8,7 +8,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import thaumcraft.common.blocks.BlockMagicalLogItem;
 
 @Mixin(BlockMagicalLogItem.class)
-public class MixinBlockMagicalLogItem_NameFix {
+abstract class MixinBlockMagicalLogItem_NameFix {
 
     @ModifyExpressionValue(
         method = "getUnlocalizedName",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockManaPod_GrowthRate.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockManaPod_GrowthRate.java
@@ -8,7 +8,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.blocks.BlockManaPod;
 
 @Mixin(value = BlockManaPod.class)
-public class MixinBlockManaPod_GrowthRate {
+abstract class MixinBlockManaPod_GrowthRate {
 
     @ModifyConstant(method = "updateTick", constant = @Constant(intValue = 30))
     private int growthChance(int original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMetalDevice_CreativePreserveWater.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMetalDevice_CreativePreserveWater.java
@@ -14,7 +14,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.blocks.BlockMetalDevice;
 
 @Mixin(BlockMetalDevice.class)
-public class MixinBlockMetalDevice_CreativePreserveWater {
+abstract class MixinBlockMetalDevice_CreativePreserveWater {
 
     @WrapWithCondition(
         method = "onBlockActivated",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMetalDevice_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMetalDevice_LocalizeCorrectly.java
@@ -16,7 +16,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import thaumcraft.common.blocks.BlockMetalDevice;
 
 @Mixin(BlockMetalDevice.class)
-public class MixinBlockMetalDevice_LocalizeCorrectly {
+abstract class MixinBlockMetalDevice_LocalizeCorrectly {
 
     @Unique
     private static final ChatStyle salisArcana$alembicStyle = new ChatStyle().setColor(EnumChatFormatting.DARK_AQUA);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMirrorItem_LocalizableText.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMirrorItem_LocalizableText.java
@@ -14,7 +14,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.blocks.BlockMirrorItem;
 
 @Mixin(BlockMirrorItem.class)
-public class MixinBlockMirrorItem_LocalizableText {
+abstract class MixinBlockMirrorItem_LocalizableText {
 
     @Unique
     private static final ChatStyle salisArcana$errorStyle = new ChatStyle().setColor(EnumChatFormatting.DARK_PURPLE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockStoneDevice_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockStoneDevice_LocalizeCorrectly.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import thaumcraft.common.blocks.BlockStoneDevice;
 
 @Mixin(BlockStoneDevice.class)
-public class MixinBlockStoneDevice_LocalizeCorrectly {
+abstract class MixinBlockStoneDevice_LocalizeCorrectly {
 
     @Unique
     private static final ChatStyle salisArcana$redTextStyle = new ChatStyle().setColor(EnumChatFormatting.RED);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockTube_BBoxConserveBlockBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockTube_BBoxConserveBlockBounds.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.sugar.Cancellable;
 import thaumcraft.common.blocks.BlockTube;
 
 @Mixin(BlockTube.class)
-public abstract class MixinBlockTube_BBoxConserveBlockBounds {
+abstract class MixinBlockTube_BBoxConserveBlockBounds {
 
     @Redirect(
         method = "getSelectedBoundingBoxFromPool",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_BannerPhialConsumption.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_BannerPhialConsumption.java
@@ -16,7 +16,7 @@ import thaumcraft.common.blocks.BlockWoodenDevice;
 import thaumcraft.common.config.ConfigItems;
 
 @Mixin(BlockWoodenDevice.class)
-public class MixinBlockWoodenDevice_BannerPhialConsumption {
+abstract class MixinBlockWoodenDevice_BannerPhialConsumption {
 
     @WrapOperation(
         method = "onBlockActivated",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_BannerPickBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_BannerPickBlock.java
@@ -13,7 +13,7 @@ import thaumcraft.common.blocks.BlockWoodenDevice;
 import thaumcraft.common.tiles.TileBanner;
 
 @Mixin(BlockWoodenDevice.class)
-public abstract class MixinBlockWoodenDevice_BannerPickBlock extends BlockContainer {
+abstract class MixinBlockWoodenDevice_BannerPickBlock extends BlockContainer {
 
     protected MixinBlockWoodenDevice_BannerPickBlock(Material materialIn) {
         super(materialIn);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_LocalizableText.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_LocalizableText.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import thaumcraft.common.blocks.BlockWoodenDevice;
 
 @Mixin(BlockWoodenDevice.class)
-public class MixinBlockWoodenDevice_LocalizableText {
+abstract class MixinBlockWoodenDevice_LocalizableText {
 
     @ModifyConstant(
         method = "onBlockActivated",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_NoBannerCreativeDrops.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockWoodenDevice_NoBannerCreativeDrops.java
@@ -12,7 +12,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.blocks.BlockWoodenDevice;
 
 @Mixin(BlockWoodenDevice.class)
-public class MixinBlockWoodenDevice_NoBannerCreativeDrops {
+abstract class MixinBlockWoodenDevice_NoBannerCreativeDrops {
 
     @WrapWithCondition(
         method = "onBlockHarvested",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigItems_UnOredictGoldCoin.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigItems_UnOredictGoldCoin.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.config.ConfigItems;
 
 @Mixin(value = ConfigItems.class, remap = false)
-public class MixinConfigItems_UnOredictGoldCoin {
+abstract class MixinConfigItems_UnOredictGoldCoin {
 
     @WrapOperation(
         method = "init",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfig_PotionIds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfig_PotionIds.java
@@ -28,7 +28,7 @@ import dev.rndmorris.salisarcana.notifications.StartupNotifications;
 import thaumcraft.common.config.Config;
 
 @Mixin(value = Config.class, remap = false)
-public abstract class MixinConfig_PotionIds {
+abstract class MixinConfig_PotionIds {
 
     @Inject(
         method = "initPotions",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerArcaneWorkbench_MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerArcaneWorkbench_MultiContainer.java
@@ -22,7 +22,7 @@ import thaumcraft.common.container.SlotCraftingArcaneWorkbench;
 import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(ContainerArcaneWorkbench.class)
-public abstract class MixinContainerArcaneWorkbench_MultiContainer extends Container
+abstract class MixinContainerArcaneWorkbench_MultiContainer extends Container
     implements IReconnectableContainer, IInventory {
 
     @Shadow(remap = false)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerArcaneWorkbench_SingleWandReplacement.java
@@ -20,7 +20,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(ContainerArcaneWorkbench.class)
-public abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extends Container {
+abstract class MixinContainerArcaneWorkbench_SingleWandReplacement extends Container {
 
     @Shadow(remap = false)
     private TileArcaneWorkbench tileEntity;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerArcaneWorkbench_UseCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerArcaneWorkbench_UseCache.java
@@ -17,7 +17,7 @@ import thaumcraft.common.container.ContainerArcaneWorkbench;
 import thaumcraft.common.tiles.TileArcaneWorkbench;
 
 @Mixin(ContainerArcaneWorkbench.class)
-public class MixinContainerArcaneWorkbench_UseCache {
+abstract class MixinContainerArcaneWorkbench_UseCache {
 
     @Shadow(remap = false)
     private TileArcaneWorkbench tileEntity;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerFocalManipulator_StoreXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerFocalManipulator_StoreXP.java
@@ -16,7 +16,7 @@ import thaumcraft.common.container.ContainerFocalManipulator;
 import thaumcraft.common.tiles.TileFocalManipulator;
 
 @Mixin(ContainerFocalManipulator.class)
-public abstract class MixinContainerFocalManipulator_StoreXP extends Container {
+abstract class MixinContainerFocalManipulator_StoreXP extends Container {
 
     @Shadow(remap = false)
     private TileFocalManipulator table;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerThaumatorium_MultiContainer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinContainerThaumatorium_MultiContainer.java
@@ -18,7 +18,7 @@ import thaumcraft.common.container.ContainerThaumatorium;
 import thaumcraft.common.tiles.TileThaumatorium;
 
 @Mixin(ContainerThaumatorium.class)
-public abstract class MixinContainerThaumatorium_MultiContainer extends Container implements IReconnectableContainer {
+abstract class MixinContainerThaumatorium_MultiContainer extends Container implements IReconnectableContainer {
 
     @Shadow(remap = false)
     private TileThaumatorium thaumatorium;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinSlotCraftingArcaneWorkbench_ForgeEventBridge.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/MixinSlotCraftingArcaneWorkbench_ForgeEventBridge.java
@@ -15,7 +15,7 @@ import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 import thaumcraft.common.tiles.TileMagicWorkbench;
 
 @Mixin(SlotCraftingArcaneWorkbench.class)
-public class MixinSlotCraftingArcaneWorkbench_ForgeEventBridge {
+abstract class MixinSlotCraftingArcaneWorkbench_ForgeEventBridge {
 
     @Shadow(remap = false)
     private EntityPlayer thePlayer;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/golems/MixinItemGolemBell_PreventDeadInteractions.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/golems/MixinItemGolemBell_PreventDeadInteractions.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import thaumcraft.common.entities.golems.ItemGolemBell;
 
 @Mixin(ItemGolemBell.class)
-public abstract class MixinItemGolemBell_PreventDeadInteractions {
+abstract class MixinItemGolemBell_PreventDeadInteractions {
 
     @WrapMethod(method = "onLeftClickEntity", remap = false)
     private boolean preventLeftClicks(ItemStack stack, EntityPlayer player, Entity entity,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/MixinEntityEldritchCrab_NoAttackWhenDead.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/MixinEntityEldritchCrab_NoAttackWhenDead.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import thaumcraft.common.entities.monster.EntityEldritchCrab;
 
 @Mixin(value = EntityEldritchCrab.class)
-public abstract class MixinEntityEldritchCrab_NoAttackWhenDead extends EntityMob {
+abstract class MixinEntityEldritchCrab_NoAttackWhenDead extends EntityMob {
 
     public MixinEntityEldritchCrab_NoAttackWhenDead(World p_i1738_1_) {
         super(p_i1738_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/MixinEntityTaintacle_NoAttackWhenDead.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/MixinEntityTaintacle_NoAttackWhenDead.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.entities.monster.EntityTaintacle;
 
 @Mixin(value = EntityTaintacle.class)
-public abstract class MixinEntityTaintacle_NoAttackWhenDead extends EntityMob {
+abstract class MixinEntityTaintacle_NoAttackWhenDead extends EntityMob {
 
     public MixinEntityTaintacle_NoAttackWhenDead(World p_i1738_1_) {
         super(p_i1738_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/MixinEntityThaumicSlime_NoAttackWhenDead.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/MixinEntityThaumicSlime_NoAttackWhenDead.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.entities.monster.EntityThaumicSlime;
 
 @Mixin(value = EntityThaumicSlime.class)
-public class MixinEntityThaumicSlime_NoAttackWhenDead extends EntityMob {
+abstract class MixinEntityThaumicSlime_NoAttackWhenDead extends EntityMob {
 
     public MixinEntityThaumicSlime_NoAttackWhenDead(World p_i1738_1_) {
         super(p_i1738_1_);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/boss/MixinEntityThaumcraftBosses_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/monster/boss/MixinEntityThaumcraftBosses_LocalizeCorrectly.java
@@ -14,7 +14,7 @@ import thaumcraft.common.entities.monster.boss.EntityTaintacleGiant;
 import thaumcraft.common.entities.monster.boss.EntityThaumcraftBoss;
 
 @Mixin({ EntityTaintacleGiant.class, EntityThaumcraftBoss.class })
-public class MixinEntityThaumcraftBosses_LocalizeCorrectly {
+abstract class MixinEntityThaumcraftBosses_LocalizeCorrectly {
 
     @WrapOperation(
         method = "attackEntityFrom",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/projectile/MixinEntityShockOrb_CheckSolidGround.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/projectile/MixinEntityShockOrb_CheckSolidGround.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.entities.projectile.EntityShockOrb;
 
 @Mixin(EntityShockOrb.class)
-public class MixinEntityShockOrb_CheckSolidGround {
+abstract class MixinEntityShockOrb_CheckSolidGround {
 
     @WrapOperation(
         method = "onImpact",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinAmuletWand_AddInterface.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinAmuletWand_AddInterface.java
@@ -9,5 +9,5 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 // todo: break me into multiple files to fit package structure
 
 @Mixin(value = { ItemAmuletVis.class, ItemWandCasting.class }, remap = false)
-public abstract class MixinAmuletWand_AddInterface implements IVisContainer {
+abstract class MixinAmuletWand_AddInterface implements IVisContainer {
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemEldritchObject_EldritchObjectStackSize.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemEldritchObject_EldritchObjectStackSize.java
@@ -8,7 +8,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.items.ItemEldritchObject;
 
 @Mixin(value = ItemEldritchObject.class, remap = false)
-public class MixinItemEldritchObject_EldritchObjectStackSize {
+abstract class MixinItemEldritchObject_EldritchObjectStackSize {
 
     @ModifyConstant(method = "<init>", constant = { @Constant(intValue = 1, ordinal = 0) })
     private int modifyEldritchObject(int original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemEldritchObject_FakePlayerFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemEldritchObject_FakePlayerFix.java
@@ -15,7 +15,7 @@ import thaumcraft.common.items.ItemEldritchObject;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(ItemEldritchObject.class)
-public class MixinItemEldritchObject_FakePlayerFix {
+abstract class MixinItemEldritchObject_FakePlayerFix {
 
     @WrapMethod(method = "onItemRightClick")
     private ItemStack cancelFakePlayer(ItemStack stack, World par2World, EntityPlayer player,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemEssence_CreativeItemConsumption.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemEssence_CreativeItemConsumption.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import thaumcraft.common.items.ItemEssence;
 
 @Mixin(ItemEssence.class)
-public class MixinItemEssence_CreativeItemConsumption {
+abstract class MixinItemEssence_CreativeItemConsumption {
 
     @Inject(
         method = "onItemUseFirst",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemKey_ExtraSecurityChecks.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemKey_ExtraSecurityChecks.java
@@ -23,7 +23,7 @@ import thaumcraft.common.items.ItemKey;
 import thaumcraft.common.tiles.TileOwned;
 
 @Mixin(ItemKey.class)
-public class MixinItemKey_ExtraSecurityChecks {
+abstract class MixinItemKey_ExtraSecurityChecks {
 
     @ModifyExpressionValue(
         method = "onItemUseFirst",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemKey_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemKey_LocalizeCorrectly.java
@@ -18,7 +18,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import thaumcraft.common.items.ItemKey;
 
 @Mixin(ItemKey.class)
-public class MixinItemKey_LocalizeCorrectly {
+abstract class MixinItemKey_LocalizeCorrectly {
 
     @Unique
     private static final ChatStyle salisArcana$wardedDoorStyle = new ChatStyle()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemResearchNotes_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemResearchNotes_LocalizeCorrectly.java
@@ -9,7 +9,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.items.ItemResearchNotes;
 
 @Mixin(ItemResearchNotes.class)
-public class MixinItemResearchNotes_LocalizeCorrectly {
+abstract class MixinItemResearchNotes_LocalizeCorrectly {
 
     @WrapOperation(
         method = "onItemRightClick",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemResource_DecayChance.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemResource_DecayChance.java
@@ -12,7 +12,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.items.ItemResource;
 
 @Mixin(ItemResource.class)
-public abstract class MixinItemResource_DecayChance {
+abstract class MixinItemResource_DecayChance {
 
     @WrapOperation(
         method = "onUpdate",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemResource_DisableCreativeDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemResource_DisableCreativeDecay.java
@@ -15,7 +15,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.items.ItemResource;
 
 @Mixin(ItemResource.class)
-public abstract class MixinItemResource_DisableCreativeDecay {
+abstract class MixinItemResource_DisableCreativeDecay {
 
     @WrapOperation(
         method = "onUpdate",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemShard_OOB.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/MixinItemShard_OOB.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import thaumcraft.common.items.ItemShard;
 
 @Mixin(ItemShard.class)
-public class MixinItemShard_OOB extends Item {
+abstract class MixinItemShard_OOB extends Item {
 
     @WrapMethod(method = "getColorFromItemStack")
     public int preventOOBColor(ItemStack stack, int par2, Operation<Integer> original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_ExpandBoundingBox.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_ExpandBoundingBox.java
@@ -9,7 +9,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.items.baubles.ItemAmuletVis;
 
 @Mixin(value = ItemAmuletVis.class, remap = false)
-public class MixinItemAmuletVis_ExpandBoundingBox {
+abstract class MixinItemAmuletVis_ExpandBoundingBox {
 
     @Unique
     private static final double sa$Expanded = SalisConfig.features.visRelayBoxExpansion.getValue();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_InventoryCheck.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_InventoryCheck.java
@@ -19,7 +19,7 @@ import thaumcraft.common.items.baubles.ItemAmuletVis;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(value = ItemAmuletVis.class, remap = false)
-public abstract class MixinItemAmuletVis_InventoryCheck {
+abstract class MixinItemAmuletVis_InventoryCheck {
 
     @Shadow
     public abstract int getVis(ItemStack is, Aspect aspect);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_TickRate.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_TickRate.java
@@ -9,7 +9,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.items.baubles.ItemAmuletVis;
 
 @Mixin(value = ItemAmuletVis.class, remap = false)
-public abstract class MixinItemAmuletVis_TickRate {
+abstract class MixinItemAmuletVis_TickRate {
 
     @Unique
     private final int sa$tickRate = SalisConfig.features.visAmuletTickRate.getValue();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_TransferRate.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/baubles/MixinItemAmuletVis_TransferRate.java
@@ -11,7 +11,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.items.baubles.ItemAmuletVis;
 
 @Mixin(value = ItemAmuletVis.class, remap = false)
-public abstract class MixinItemAmuletVis_TransferRate {
+abstract class MixinItemAmuletVis_TransferRate {
 
     @Unique
     private final int sa$transferRate = SalisConfig.features.visAmuletTransferRate.getValue();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/equipment/MixinItemPrimalCrusher_HarvestLevel.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/equipment/MixinItemPrimalCrusher_HarvestLevel.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.items.equipment.ItemPrimalCrusher;
 
 @Mixin(value = ItemPrimalCrusher.class, remap = false)
-public class MixinItemPrimalCrusher_HarvestLevel {
+abstract class MixinItemPrimalCrusher_HarvestLevel {
 
     @WrapOperation(
         method = "onBlockDestroyed",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/equipment/PrimalCrusher_StoneOredictCompat.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/equipment/PrimalCrusher_StoneOredictCompat.java
@@ -15,7 +15,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.items.equipment.ItemPrimalCrusher;
 
 @Mixin(value = ItemPrimalCrusher.class, remap = false)
-public abstract class PrimalCrusher_StoneOredictCompat {
+abstract class PrimalCrusher_StoneOredictCompat {
 
     @Unique
     private int sa$stoneOreId = -1;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/relics/MixinItemHandMirror_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/relics/MixinItemHandMirror_LocalizeCorrectly.java
@@ -13,7 +13,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 import thaumcraft.common.items.relics.ItemHandMirror;
 
 @Mixin(ItemHandMirror.class)
-public class MixinItemHandMirror_LocalizeCorrectly {
+abstract class MixinItemHandMirror_LocalizeCorrectly {
 
     @Unique
     private static final ChatStyle salisArcana$mirrorStyle = new ChatStyle().setColor(EnumChatFormatting.DARK_PURPLE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/relics/MixinItemThaumometer_CustomDuration.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/relics/MixinItemThaumometer_CustomDuration.java
@@ -8,7 +8,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.items.relics.ItemThaumometer;
 
 @Mixin(ItemThaumometer.class)
-public class MixinItemThaumometer_CustomDuration {
+abstract class MixinItemThaumometer_CustomDuration {
 
     @ModifyConstant(method = "getMaxItemUseDuration", constant = @Constant(intValue = 25))
     private int customDuration(int original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/relics/MixinItemThaumometer_ScanContainers.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/relics/MixinItemThaumometer_ScanContainers.java
@@ -24,7 +24,7 @@ import thaumcraft.common.items.relics.ItemThaumometer;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(value = ItemThaumometer.class)
-public class MixinItemThaumometer_ScanContainers extends Item {
+abstract class MixinItemThaumometer_ScanContainers extends Item {
 
     @Inject(
         method = "onUsingTick",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemFocusPouchBauble_ExpandedBaublesSlot.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemFocusPouchBauble_ExpandedBaublesSlot.java
@@ -10,7 +10,7 @@ import dev.rndmorris.salisarcana.common.compat.BaublesExpandedCompat;
 import thaumcraft.common.items.wands.ItemFocusPouchBauble;
 
 @Mixin(ItemFocusPouchBauble.class)
-public abstract class MixinItemFocusPouchBauble_ExpandedBaublesSlot implements IBaubleExpanded {
+abstract class MixinItemFocusPouchBauble_ExpandedBaublesSlot implements IBaubleExpanded {
 
     @Override
     public String[] getBaubleTypes(ItemStack itemStack) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_CreativeVis.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_CreativeVis.java
@@ -14,7 +14,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(value = ItemWandCasting.class, remap = false)
-public class MixinItemWandCasting_CreativeVis {
+abstract class MixinItemWandCasting_CreativeVis {
 
     @Unique
     private static boolean sa$isCreative(EntityPlayer player) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_DefaultWandComponents.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_DefaultWandComponents.java
@@ -21,7 +21,7 @@ import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(value = ItemWandCasting.class, remap = false)
-public abstract class MixinItemWandCasting_DefaultWandComponents {
+abstract class MixinItemWandCasting_DefaultWandComponents {
 
     @Shadow
     public abstract WandCap getCap(ItemStack stack);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_DisableSpendingCheck.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_DisableSpendingCheck.java
@@ -8,7 +8,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(value = ItemWandCasting.class)
-public class MixinItemWandCasting_DisableSpendingCheck {
+abstract class MixinItemWandCasting_DisableSpendingCheck {
 
     @ModifyExpressionValue(
         method = "consumeAllVis",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_FociCustomNames.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_FociCustomNames.java
@@ -15,7 +15,7 @@ import thaumcraft.api.wands.ItemFocusBasic;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(ItemWandCasting.class)
-public abstract class MixinItemWandCasting_FociCustomNames {
+abstract class MixinItemWandCasting_FociCustomNames {
 
     @WrapOperation(
         method = "addInformation",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_InvalidFoci.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_InvalidFoci.java
@@ -14,7 +14,7 @@ import thaumcraft.api.wands.ItemFocusBasic;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(ItemWandCasting.class)
-public abstract class MixinItemWandCasting_InvalidFoci {
+abstract class MixinItemWandCasting_InvalidFoci {
 
     @WrapOperation(
         method = "getFocus",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_NamedStaffters.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_NamedStaffters.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 @Mixin(value = ItemWandCasting.class, remap = false)
-public abstract class MixinItemWandCasting_NamedStaffters {
+abstract class MixinItemWandCasting_NamedStaffters {
 
     @Shadow
     public abstract boolean isStaff(ItemStack stack);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandRod_MetadataSafety.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandRod_MetadataSafety.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import thaumcraft.common.items.wands.ItemWandRod;
 
 @Mixin(value = ItemWandRod.class, remap = false)
-public abstract class MixinItemWandRod_MetadataSafety {
+abstract class MixinItemWandRod_MetadataSafety {
 
     @Shadow
     public IIcon[] iconWand;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinWandManager_ExtendedBaublesSupport.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinWandManager_ExtendedBaublesSupport.java
@@ -14,7 +14,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.items.wands.WandManager;
 
 @Mixin(WandManager.class)
-public abstract class MixinWandManager_ExtendedBaublesSupport {
+abstract class MixinWandManager_ExtendedBaublesSupport {
 
     @ModifyConstant(method = "getTotalVisDiscount", constant = @Constant(intValue = 4, ordinal = 0), remap = false)
     private static int getTotalVisDiscountWithAllBaubles(int value, EntityPlayer player, Aspect aspect) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusExcavation_DeterministicCost.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusExcavation_DeterministicCost.java
@@ -14,7 +14,7 @@ import thaumcraft.api.wands.ItemFocusBasic;
 import thaumcraft.common.items.wands.foci.ItemFocusExcavation;
 
 @Mixin(value = ItemFocusExcavation.class, remap = false)
-public class MixinItemFocusExcavation_DeterministicCost extends ItemFocusBasic {
+abstract class MixinItemFocusExcavation_DeterministicCost extends ItemFocusBasic {
 
     @Unique
     private static final AspectList sa$silkTouchCost = new AspectList().add(Aspect.AIR, 1)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusExcavation_HarvestLevel.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusExcavation_HarvestLevel.java
@@ -18,7 +18,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.items.wands.foci.ItemFocusExcavation;
 
 @Mixin(ItemFocusExcavation.class)
-public class MixinItemFocusExcavation_HarvestLevel extends ItemFocusBasic {
+abstract class MixinItemFocusExcavation_HarvestLevel extends ItemFocusBasic {
 
     // i dunno why this has to be static, but it does
     // the definition just wouldn't be embedded into the class otherwise

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusTrade_AddPotency.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusTrade_AddPotency.java
@@ -11,7 +11,7 @@ import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.common.items.wands.foci.ItemFocusTrade;
 
 @Mixin(ItemFocusTrade.class)
-public class MixinItemFocusTrade_AddPotency {
+abstract class MixinItemFocusTrade_AddPotency {
 
     @WrapMethod(method = "getPossibleUpgradesByRank", remap = false)
     public FocusUpgradeType[] getPossibleUpgradesByRank(ItemStack itemstack, int rank,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusTrade_BreakBlocks.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusTrade_BreakBlocks.java
@@ -13,7 +13,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.items.wands.foci.ItemFocusTrade;
 
 @Mixin(value = ItemFocusTrade.class, remap = false)
-public class MixinItemFocusTrade_BreakBlocks extends ItemFocusBasic {
+abstract class MixinItemFocusTrade_BreakBlocks extends ItemFocusBasic {
 
     @WrapMethod(method = "func_150893_a") // getStrVsBlock
     public float fixGetStrVsBlock(ItemStack itemstack, Block block, Operation<Float> original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusTrade_HarvestLevel.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusTrade_HarvestLevel.java
@@ -24,7 +24,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.items.wands.foci.ItemFocusTrade;
 
 @Mixin(value = ItemFocusTrade.class, remap = false)
-public abstract class MixinItemFocusTrade_HarvestLevel extends ItemFocusBasic implements IArchitect {
+abstract class MixinItemFocusTrade_HarvestLevel extends ItemFocusBasic implements IArchitect {
 
     @Unique
     private final int sa$harvestLevel = SalisConfig.features.equalTradeFocusHarvestLevel.getValue();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/MixinWarpEvents_BaubleSlots.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/MixinWarpEvents_BaubleSlots.java
@@ -12,7 +12,7 @@ import baubles.api.BaublesApi;
 import thaumcraft.common.lib.WarpEvents;
 
 @Mixin(WarpEvents.class)
-public class MixinWarpEvents_BaubleSlots {
+abstract class MixinWarpEvents_BaubleSlots {
 
     @ModifyConstant(method = "getWarpFromGear", constant = @Constant(intValue = 4, ordinal = 1), remap = false)
     private static int useAllBaubleSlots(int constant, @Local(name = "player") EntityPlayer player) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/MixinWarpEvents_DeadlyGaze.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/MixinWarpEvents_DeadlyGaze.java
@@ -16,7 +16,7 @@ import dev.rndmorris.salisarcana.lib.DeadlyGazeEntitySelector;
 import thaumcraft.common.lib.WarpEvents;
 
 @Mixin(WarpEvents.class)
-public class MixinWarpEvents_DeadlyGaze {
+abstract class MixinWarpEvents_DeadlyGaze {
 
     @WrapOperation(
         method = "checkDeathGaze",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/MixinWarpEvents_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/MixinWarpEvents_LocalizeCorrectly.java
@@ -18,7 +18,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import thaumcraft.common.lib.WarpEvents;
 
 @Mixin(WarpEvents.class)
-public class MixinWarpEvents_LocalizeCorrectly {
+abstract class MixinWarpEvents_LocalizeCorrectly {
 
     @Unique
     private static final ChatStyle salisArcana$warpChatStyle = new ChatStyle().setColor(EnumChatFormatting.DARK_PURPLE)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/crafting/MixinArcaneSceptreRecipe_MissingResearchWorkbench.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/crafting/MixinArcaneSceptreRecipe_MissingResearchWorkbench.java
@@ -13,7 +13,7 @@ import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.lib.crafting.ArcaneSceptreRecipe;
 
 @Mixin(ArcaneSceptreRecipe.class)
-public abstract class MixinArcaneSceptreRecipe_MissingResearchWorkbench implements IMultipleResearchArcaneRecipe {
+abstract class MixinArcaneSceptreRecipe_MissingResearchWorkbench implements IMultipleResearchArcaneRecipe {
 
     @Override
     public String[] salisArcana$getResearches(IInventory inv, World world, EntityPlayer player) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/crafting/MixinArcaneWandRecipe_MissingResearchWorkbench.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/crafting/MixinArcaneWandRecipe_MissingResearchWorkbench.java
@@ -13,7 +13,7 @@ import thaumcraft.api.wands.WandRod;
 import thaumcraft.common.lib.crafting.ArcaneWandRecipe;
 
 @Mixin(ArcaneWandRecipe.class)
-public abstract class MixinArcaneWandRecipe_MissingResearchWorkbench implements IMultipleResearchArcaneRecipe {
+abstract class MixinArcaneWandRecipe_MissingResearchWorkbench implements IMultipleResearchArcaneRecipe {
 
     @Override
     public String[] salisArcana$getResearches(IInventory inv, World world, EntityPlayer player) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/crafting/MixinThaumcraftCraftingManager_UseCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/crafting/MixinThaumcraftCraftingManager_UseCache.java
@@ -16,7 +16,7 @@ import thaumcraft.api.crafting.IArcaneRecipe;
 import thaumcraft.common.lib.crafting.ThaumcraftCraftingManager;
 
 @Mixin(ThaumcraftCraftingManager.class)
-public class MixinThaumcraftCraftingManager_UseCache {
+abstract class MixinThaumcraftCraftingManager_UseCache {
 
     @WrapMethod(method = "findMatchingArcaneRecipe", remap = false)
     private static ItemStack checkArcaneRecipeCache(IInventory awb, EntityPlayer player,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinCommandThaumcraft_TabCompletion.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinCommandThaumcraft_TabCompletion.java
@@ -21,7 +21,7 @@ import thaumcraft.common.lib.events.CommandThaumcraft;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(CommandThaumcraft.class)
-public abstract class MixinCommandThaumcraft_TabCompletion extends CommandBase {
+abstract class MixinCommandThaumcraft_TabCompletion extends CommandBase {
 
     /**
      * @author Midnight145

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinCommandThaumcraft_WarpArg.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinCommandThaumcraft_WarpArg.java
@@ -17,7 +17,7 @@ import thaumcraft.common.lib.network.playerdata.PacketSyncWarp;
 import thaumcraft.common.lib.network.playerdata.PacketWarpMessage;
 
 @Mixin(CommandThaumcraft.class)
-public class MixinCommandThaumcraft_WarpArg {
+abstract class MixinCommandThaumcraft_WarpArg {
 
     @Inject(method = "setWarp", at = @At("HEAD"), remap = false)
     private void warpAllParams(ICommandSender icommandsender, EntityPlayerMP player, int i, String type,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_LocalizeCorrectly.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
 import thaumcraft.common.lib.events.EventHandlerEntity;
 
 @Mixin(EventHandlerEntity.class)
-public class MixinEventHandlerEntity_LocalizeCorrectly {
+abstract class MixinEventHandlerEntity_LocalizeCorrectly {
 
     @Unique
     private static final ChatStyle salisArcana$disableFlyStyle = new ChatStyle().setColor(EnumChatFormatting.GRAY)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_LootBagFakePlayer.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_LootBagFakePlayer.java
@@ -7,7 +7,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import thaumcraft.common.lib.events.EventHandlerEntity;
 
 @Mixin(value = EventHandlerEntity.class, remap = false, priority = 1001)
-public abstract class MixinEventHandlerEntity_LootBagFakePlayer {
+abstract class MixinEventHandlerEntity_LootBagFakePlayer {
 
     @ModifyVariable(method = "livingDrops", at = @At("STORE"), name = "fakeplayer")
     private static boolean fakePlayersDropLootBags(boolean original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_MobVisWhitelist.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_MobVisWhitelist.java
@@ -17,7 +17,7 @@ import dev.rndmorris.salisarcana.lib.EntityHelper;
 import thaumcraft.common.lib.events.EventHandlerEntity;
 
 @Mixin(value = EventHandlerEntity.class, remap = false)
-public class MixinEventHandlerEntity_MobVisWhitelist {
+abstract class MixinEventHandlerEntity_MobVisWhitelist {
 
     @Unique
     private final boolean sa$isWhitelist = SalisConfig.features.mobVisWhitelist.isEnabled();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_SuppressCreativeWarp.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerEntity_SuppressCreativeWarp.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.lib.events.EventHandlerEntity;
 
 @Mixin(value = EventHandlerEntity.class, remap = false)
-public abstract class MixinEventHandlerEntity_SuppressCreativeWarp {
+abstract class MixinEventHandlerEntity_SuppressCreativeWarp {
 
     @WrapOperation(
         method = "livingTick(Lnet/minecraftforge/event/entity/living/LivingEvent$LivingUpdateEvent;)V",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerRunic_ExtendedBaublesSupport.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinEventHandlerRunic_ExtendedBaublesSupport.java
@@ -11,7 +11,7 @@ import baubles.api.BaublesApi;
 import thaumcraft.common.lib.events.EventHandlerRunic;
 
 @Mixin(value = EventHandlerRunic.class, remap = false)
-public abstract class MixinEventHandlerRunic_ExtendedBaublesSupport {
+abstract class MixinEventHandlerRunic_ExtendedBaublesSupport {
 
     @ModifyConstant(method = "livingTick", constant = @Constant(intValue = 4, ordinal = 1), remap = false)
     private int useAllBaubleSlots(int value, LivingEvent.LivingUpdateEvent event) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/network/playerdata/MixinPacketPlayerCompleteToServer_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/network/playerdata/MixinPacketPlayerCompleteToServer_LocalizeCorrectly.java
@@ -9,7 +9,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.lib.network.playerdata.PacketPlayerCompleteToServer;
 
 @Mixin(PacketPlayerCompleteToServer.class)
-public class MixinPacketPlayerCompleteToServer_LocalizeCorrectly {
+abstract class MixinPacketPlayerCompleteToServer_LocalizeCorrectly {
 
     @WrapOperation(
         method = "onMessage(Lthaumcraft/common/lib/network/playerdata/PacketPlayerCompleteToServer;Lcpw/mods/fml/common/network/simpleimpl/MessageContext;)Lcpw/mods/fml/common/network/simpleimpl/IMessage;",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/network/playerdata/MixinPacketWarpMessage_MuteExcessiveSounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/network/playerdata/MixinPacketWarpMessage_MuteExcessiveSounds.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import thaumcraft.common.lib.network.playerdata.PacketWarpMessage;
 
 @Mixin(PacketWarpMessage.class)
-public class MixinPacketWarpMessage_MuteExcessiveSounds {
+abstract class MixinPacketWarpMessage_MuteExcessiveSounds {
 
     @Unique
     private static long salisArcana$lastTickTriggered;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinResearchManager_CreativeOPThaumonomicon.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinResearchManager_CreativeOPThaumonomicon.java
@@ -15,7 +15,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(ResearchManager.class)
-public class MixinResearchManager_CreativeOPThaumonomicon {
+abstract class MixinResearchManager_CreativeOPThaumonomicon {
 
     @WrapMethod(method = "consumeInkFromPlayer", remap = false)
     private static boolean creativeThaumonomiconInkCheck(EntityPlayer player, boolean doit,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinResearchManager_RandomizeProperly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinResearchManager_RandomizeProperly.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(value = ResearchManager.class, remap = false)
-public class MixinResearchManager_RandomizeProperly {
+abstract class MixinResearchManager_RandomizeProperly {
 
     @WrapOperation(method = "findHiddenResearch", at = @At(value = "NEW", target = "(J)Ljava/util/Random;"))
     private static Random useWorldRandom(long seed, Operation<Random> original, EntityPlayer player) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinResearchManager_SkipResearchInInventory.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinResearchManager_SkipResearchInInventory.java
@@ -14,7 +14,7 @@ import thaumcraft.common.config.ConfigItems;
 import thaumcraft.common.lib.research.ResearchManager;
 
 @Mixin(value = ResearchManager.class, remap = false)
-public class MixinResearchManager_SkipResearchInInventory {
+abstract class MixinResearchManager_SkipResearchInInventory {
 
     @ModifyReceiver(
         method = "findHiddenResearch",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinScanManager_ScanContainers.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinScanManager_ScanContainers.java
@@ -22,7 +22,7 @@ import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.lib.research.ScanManager;
 
 @Mixin(value = ScanManager.class, remap = false)
-public class MixinScanManager_ScanContainers {
+abstract class MixinScanManager_ScanContainers {
 
     @Inject(
         method = "completeScan",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinInventoryUtils_AmountCounting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinInventoryUtils_AmountCounting.java
@@ -15,7 +15,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.lib.utils.InventoryUtils;
 
 @Mixin(value = InventoryUtils.class, remap = false)
-public class MixinInventoryUtils_AmountCounting {
+abstract class MixinInventoryUtils_AmountCounting {
 
     @Unique
     private static final ItemStack sa$nonNullItemStack = new ItemStack(Items.stick);

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinUtils_UpdateBiomeColor.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinUtils_UpdateBiomeColor.java
@@ -12,7 +12,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.lib.utils.Utils;
 
 @Mixin(Utils.class)
-public class MixinUtils_UpdateBiomeColor {
+abstract class MixinUtils_UpdateBiomeColor {
 
     @Inject(method = "setBiomeAt", at = @At("TAIL"), remap = false)
     private static void updateClientColor(World world, int x, int z, BiomeGenBase biome, CallbackInfo ci) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinGenTrees_FixLeak.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinGenTrees_FixLeak.java
@@ -13,7 +13,7 @@ import thaumcraft.common.lib.world.WorldGenGreatwoodTrees;
 import thaumcraft.common.lib.world.WorldGenSilverwoodTreesOld;
 
 @Mixin({ WorldGenBigMagicTree.class, WorldGenGreatwoodTrees.class, WorldGenSilverwoodTreesOld.class })
-public abstract class MixinGenTrees_FixLeak {
+abstract class MixinGenTrees_FixLeak {
 
     @Shadow(remap = false)
     World worldObj;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinThaumcraftWorldGenerator_NodeGenerationWeights.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/world/MixinThaumcraftWorldGenerator_NodeGenerationWeights.java
@@ -20,7 +20,7 @@ import thaumcraft.api.nodes.NodeType;
 import thaumcraft.common.lib.world.ThaumcraftWorldGenerator;
 
 @Mixin(value = ThaumcraftWorldGenerator.class, remap = false)
-public class MixinThaumcraftWorldGenerator_NodeGenerationWeights {
+abstract class MixinThaumcraftWorldGenerator_NodeGenerationWeights {
 
     @Unique
     private static final NodeModifier[] sa$modifiers = new NodeModifier[] { null, NodeModifier.BRIGHT,

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileAlchemyFurnaceAdvanced_PersistNbt.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileAlchemyFurnaceAdvanced_PersistNbt.java
@@ -15,7 +15,7 @@ import thaumcraft.api.TileThaumcraft;
 import thaumcraft.common.tiles.TileAlchemyFurnaceAdvanced;
 
 @Mixin(value = TileAlchemyFurnaceAdvanced.class)
-public abstract class MixinTileAlchemyFurnaceAdvanced_PersistNbt extends TileThaumcraft {
+abstract class MixinTileAlchemyFurnaceAdvanced_PersistNbt extends TileThaumcraft {
 
     @Unique
     private final static String sa$keyCount = "salisarcana:count";

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_EarlyTerminateCraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_EarlyTerminateCraft.java
@@ -10,7 +10,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import thaumcraft.common.tiles.TileCrucible;
 
 @Mixin(value = TileCrucible.class, remap = false)
-public class MixinTileCrucible_EarlyTerminateCraft {
+abstract class MixinTileCrucible_EarlyTerminateCraft {
 
     @Shadow
     public FluidTank tank;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_HeatSources.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_HeatSources.java
@@ -15,7 +15,7 @@ import thaumcraft.api.TileThaumcraft;
 import thaumcraft.common.tiles.TileCrucible;
 
 @Mixin(value = TileCrucible.class)
-public abstract class MixinTileCrucible_HeatSources extends TileThaumcraft {
+abstract class MixinTileCrucible_HeatSources extends TileThaumcraft {
 
     /**
      * Tap into the {@code mat == Material.lava} comparison and, if it's not a vanilla thaum heat source, check if the

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_MissingRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_MissingRecipe.java
@@ -25,7 +25,7 @@ import thaumcraft.common.lib.research.ResearchManager;
 import thaumcraft.common.tiles.TileCrucible;
 
 @Mixin(TileCrucible.class)
-public class MixinTileCrucible_MissingRecipe extends TileEntity {
+abstract class MixinTileCrucible_MissingRecipe extends TileEntity {
 
     // player -> crucible recipe -> last time the player matched that recipe
     // WeakHashMap ensures that the data being tracked can get garbage collected after the player entity does (such as

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_NoDupeDeadItems.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_NoDupeDeadItems.java
@@ -10,7 +10,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import thaumcraft.common.tiles.TileCrucible;
 
 @Mixin(TileCrucible.class)
-public abstract class MixinTileCrucible_NoDupeDeadItems {
+abstract class MixinTileCrucible_NoDupeDeadItems {
 
     @WrapMethod(method = "attemptSmelt", remap = false)
     private void ignoreDeadItems(EntityItem entity, Operation<Void> original) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileCrucible_ScalingAspectDecay.java
@@ -18,7 +18,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileCrucible;
 
 @Mixin(value = TileCrucible.class, remap = false)
-public abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraft {
+abstract class MixinTileCrucible_ScalingAspectDecay extends TileThaumcraft {
 
     @Shadow
     public short heat;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchAltar_SpawnMobs.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchAltar_SpawnMobs.java
@@ -17,7 +17,7 @@ import thaumcraft.api.TileThaumcraft;
 import thaumcraft.common.tiles.TileEldritchAltar;
 
 @Mixin(value = TileEldritchAltar.class, remap = false)
-public abstract class MixinTileEldritchAltar_SpawnMobs extends TileThaumcraft {
+abstract class MixinTileEldritchAltar_SpawnMobs extends TileThaumcraft {
 
     @WrapOperation(
         method = { "spawnGuards", "spawnGuardian" },

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchLock_LocalizeCorrectly.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchLock_LocalizeCorrectly.java
@@ -15,7 +15,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import thaumcraft.common.tiles.TileEldritchLock;
 
 @Mixin(TileEldritchLock.class)
-public class MixinTileEldritchLock_LocalizeCorrectly {
+abstract class MixinTileEldritchLock_LocalizeCorrectly {
 
     @WrapOperation(
         method = { "spawnWardenBossRoom", "spawnGolemBossRoom", "spawnCultistBossRoom", "spawnTaintBossRoom" },

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchLock_NegativeBossSpawnCount.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchLock_NegativeBossSpawnCount.java
@@ -10,7 +10,7 @@ import thaumcraft.common.lib.world.dim.MapBossData;
 import thaumcraft.common.tiles.TileEldritchLock;
 
 @Mixin(TileEldritchLock.class)
-public class MixinTileEldritchLock_NegativeBossSpawnCount {
+abstract class MixinTileEldritchLock_NegativeBossSpawnCount {
 
     @WrapOperation(
         method = "doBossSpawn",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchTrap_CreativeImmunity.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEldritchTrap_CreativeImmunity.java
@@ -12,7 +12,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.tiles.TileEldritchTrap;
 
 @Mixin(TileEldritchTrap.class)
-public class MixinTileEldritchTrap_CreativeImmunity {
+abstract class MixinTileEldritchTrap_CreativeImmunity {
 
     @WrapOperation(
         method = "updateEntity",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEtherealBloom_SaveNBT.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEtherealBloom_SaveNBT.java
@@ -14,7 +14,7 @@ import org.spongepowered.asm.mixin.Shadow;
 import thaumcraft.common.tiles.TileEtherealBloom;
 
 @Mixin(value = TileEtherealBloom.class, remap = false)
-public class MixinTileEtherealBloom_SaveNBT extends TileEntity {
+abstract class MixinTileEtherealBloom_SaveNBT extends TileEntity {
 
     @Shadow
     public int counter;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_CanStoreXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_CanStoreXP.java
@@ -16,7 +16,7 @@ import thaumcraft.common.tiles.TileFocalManipulator;
 import thaumcraft.common.tiles.TileThaumcraftInventory;
 
 @Mixin(TileFocalManipulator.class)
-public class MixinTileFocalManipulator_CanStoreXP extends TileThaumcraftInventory implements IFocalManipulatorWithXP {
+abstract class MixinTileFocalManipulator_CanStoreXP extends TileThaumcraftInventory implements IFocalManipulatorWithXP {
 
     @Unique
     private int salisArcana$storedXP = 0;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_CancelReturnXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_CancelReturnXP.java
@@ -18,7 +18,7 @@ import dev.rndmorris.salisarcana.lib.ifaces.IFocalManipulatorWithXP;
 import thaumcraft.common.tiles.TileFocalManipulator;
 
 @Mixin(TileFocalManipulator.class)
-public abstract class MixinTileFocalManipulator_CancelReturnXP implements IFocalManipulatorWithXP {
+abstract class MixinTileFocalManipulator_CancelReturnXP implements IFocalManipulatorWithXP {
 
     @Shadow(remap = false)
     public int size;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_FocusDisenchanting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_FocusDisenchanting.java
@@ -23,7 +23,7 @@ import thaumcraft.common.tiles.TileFocalManipulator;
 import thaumcraft.common.tiles.TileThaumcraftInventory;
 
 @Mixin(TileFocalManipulator.class)
-public abstract class MixinTileFocalManipulator_FocusDisenchanting extends TileThaumcraftInventory
+abstract class MixinTileFocalManipulator_FocusDisenchanting extends TileThaumcraftInventory
     implements IFocalManipulatorWithXP {
 
     @Shadow(remap = false)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_ForbidSwap.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_ForbidSwap.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.tiles.TileFocalManipulator;
 
 @Mixin(TileFocalManipulator.class)
-public class MixinTileFocalManipulator_ForbidSwap {
+abstract class MixinTileFocalManipulator_ForbidSwap {
 
     @Shadow(remap = false)
     public int size;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_NoXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileFocalManipulator_NoXP.java
@@ -10,7 +10,7 @@ import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import thaumcraft.common.tiles.TileFocalManipulator;
 
 @Mixin(TileFocalManipulator.class)
-public class MixinTileFocalManipulator_NoXP {
+abstract class MixinTileFocalManipulator_NoXP {
 
     @ModifyExpressionValue(
         method = "startCraft",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_InputEnforcement.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_InputEnforcement.java
@@ -11,7 +11,7 @@ import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
 @Mixin(value = TileInfusionMatrix.class, remap = false)
-public class MixinTileInfusionMatrix_InputEnforcement {
+abstract class MixinTileInfusionMatrix_InputEnforcement {
 
     @WrapOperation(
         method = "craftCycle",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_IntegerStabilizers.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_IntegerStabilizers.java
@@ -19,7 +19,7 @@ import thaumcraft.api.crafting.IInfusionStabiliser;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
 @Mixin(value = TileInfusionMatrix.class, remap = false)
-public class MixinTileInfusionMatrix_IntegerStabilizers extends TileThaumcraft {
+abstract class MixinTileInfusionMatrix_IntegerStabilizers extends TileThaumcraft {
 
     @Shadow
     public int symmetry;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_MissingResearch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_MissingResearch.java
@@ -18,7 +18,7 @@ import thaumcraft.api.crafting.InfusionRecipe;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
 @Mixin(TileInfusionMatrix.class)
-public class MixinTileInfusionMatrix_MissingResearch {
+abstract class MixinTileInfusionMatrix_MissingResearch {
 
     @WrapOperation(
         method = "craftingStart",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_StabilizerRewrite.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_StabilizerRewrite.java
@@ -13,7 +13,7 @@ import thaumcraft.api.TileThaumcraft;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
 @Mixin(value = TileInfusionMatrix.class, remap = false)
-public class MixinTileInfusionMatrix_StabilizerRewrite extends TileThaumcraft {
+abstract class MixinTileInfusionMatrix_StabilizerRewrite extends TileThaumcraft {
 
     @Shadow
     private ArrayList<ChunkCoordinates> pedestals;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileLifter_LevitatorShiftFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileLifter_LevitatorShiftFix.java
@@ -15,7 +15,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import thaumcraft.common.tiles.TileLifter;
 
 @Mixin(value = TileLifter.class)
-public abstract class MixinTileLifter_LevitatorShiftFix extends TileEntity {
+abstract class MixinTileLifter_LevitatorShiftFix extends TileEntity {
 
     @Shadow(remap = false)
     public int rangeAbove;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbenchCharger_AllowRechargeCrafting.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbenchCharger_AllowRechargeCrafting.java
@@ -13,7 +13,7 @@ import thaumcraft.common.tiles.TileMagicWorkbench;
 import thaumcraft.common.tiles.TileMagicWorkbenchCharger;
 
 @Mixin(TileMagicWorkbenchCharger.class)
-public class MixinTileMagicWorkbenchCharger_AllowRechargeCrafting {
+abstract class MixinTileMagicWorkbenchCharger_AllowRechargeCrafting {
 
     @Inject(
         method = "updateEntity",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -22,7 +22,7 @@ import thaumcraft.api.crafting.IArcaneRecipe;
 import thaumcraft.common.tiles.TileMagicWorkbench;
 
 @Mixin(TileMagicWorkbench.class)
-public abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
+abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
     implements IInventory, ICachedMagicWorkbench {
 
     @Shadow(remap = false)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbench_CacheRecipe.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbench_CacheRecipe.java
@@ -22,8 +22,7 @@ import thaumcraft.api.crafting.IArcaneRecipe;
 import thaumcraft.common.tiles.TileMagicWorkbench;
 
 @Mixin(TileMagicWorkbench.class)
-abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft
-    implements IInventory, ICachedMagicWorkbench {
+abstract class MixinTileMagicWorkbench_CacheRecipe extends TileThaumcraft implements IInventory, ICachedMagicWorkbench {
 
     @Shadow(remap = false)
     public ItemStack[] stackList;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbench_GhostItemFix.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileMagicWorkbench_GhostItemFix.java
@@ -13,7 +13,7 @@ import dev.rndmorris.salisarcana.SalisArcana;
 import thaumcraft.common.tiles.TileMagicWorkbench;
 
 @Mixin(value = TileMagicWorkbench.class, remap = false)
-public class MixinTileMagicWorkbench_GhostItemFix {
+abstract class MixinTileMagicWorkbench_GhostItemFix {
 
     @Inject(method = "readCustomNBT", at = @At("HEAD"))
     public void copyWandNBTTagOnClient(NBTTagCompound par1NBTTagCompound, CallbackInfo ci) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_ProtectGetBlock.java
@@ -20,7 +20,7 @@ import thaumcraft.common.tiles.TileNode;
  * running the code that would trigger chunk loading.
  */
 @Mixin(TileNode.class)
-public abstract class MixinTileNode_ProtectGetBlock extends TileEntity {
+abstract class MixinTileNode_ProtectGetBlock extends TileEntity {
 
     @Inject(
         method = "handleDischarge",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_PureNodeBiomeChange.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_PureNodeBiomeChange.java
@@ -11,7 +11,7 @@ import thaumcraft.common.config.ConfigBlocks;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(TileNode.class)
-public class MixinTileNode_PureNodeBiomeChange {
+abstract class MixinTileNode_PureNodeBiomeChange {
 
     @ModifyExpressionValue(
         method = "handlePureNode",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_RechargeTime.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_RechargeTime.java
@@ -20,7 +20,7 @@ import thaumcraft.api.nodes.NodeModifier;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class)
-public abstract class MixinTileNode_RechargeTime extends TileThaumcraft implements IGameTimeNode {
+abstract class MixinTileNode_RechargeTime extends TileThaumcraft implements IGameTimeNode {
 
     @Shadow(remap = false)
     public abstract NodeModifier getNodeModifier();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_RememberUpdates.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileNode_RememberUpdates.java
@@ -12,7 +12,7 @@ import thaumcraft.api.aspects.Aspect;
 import thaumcraft.common.tiles.TileNode;
 
 @Mixin(value = TileNode.class)
-public abstract class MixinTileNode_RememberUpdates extends TileThaumcraft {
+abstract class MixinTileNode_RememberUpdates extends TileThaumcraft {
 
     @Shadow(remap = false)
     long lastActive;

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileResearchTable_FreeDuplicates.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileResearchTable_FreeDuplicates.java
@@ -11,7 +11,7 @@ import thaumcraft.api.aspects.AspectList;
 import thaumcraft.common.tiles.TileResearchTable;
 
 @Mixin(TileResearchTable.class)
-public class MixinTileResearchTable_FreeDuplicates {
+abstract class MixinTileResearchTable_FreeDuplicates {
 
     @WrapOperation(
         method = "duplicate",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileThaumatorium_HeatSources.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileThaumatorium_HeatSources.java
@@ -15,7 +15,7 @@ import thaumcraft.api.TileThaumcraft;
 import thaumcraft.common.tiles.TileThaumatorium;
 
 @Mixin(value = TileThaumatorium.class)
-public abstract class MixinTileThaumatorium_HeatSources extends TileThaumcraft {
+abstract class MixinTileThaumatorium_HeatSources extends TileThaumcraft {
 
     /**
      * Tap into the {@code mat == Material.lava} comparison and, if it's not a vanilla thaum heat source, check if the

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileVisRelay_ExpandBoundingBox.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileVisRelay_ExpandBoundingBox.java
@@ -11,7 +11,7 @@ import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.common.tiles.TileVisRelay;
 
 @Mixin(value = TileVisRelay.class, remap = false)
-public class MixinTileVisRelay_ExpandBoundingBox extends TileEntity {
+abstract class MixinTileVisRelay_ExpandBoundingBox extends TileEntity {
 
     @Unique
     private static final double sa$Expanded = SalisConfig.features.visRelayBoxExpansion.getValue();

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileWandPedestal_WandPedestalCv.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileWandPedestal_WandPedestalCv.java
@@ -33,7 +33,7 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 import thaumcraft.common.tiles.TileWandPedestal;
 
 @Mixin(TileWandPedestal.class)
-public abstract class MixinTileWandPedestal_WandPedestalCv extends TileThaumcraft implements ISidedInventory {
+abstract class MixinTileWandPedestal_WandPedestalCv extends TileThaumcraft implements ISidedInventory {
 
     @Unique
     private int sa$ticksSinceLastSync = 0;


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Makes all mixins package-private & abstract, excluding accessor interfaces.

**What is the current behavior?** (You can also link to an open issue here)
Mixins are all over the place - most are public, some are abstract, and some are package-private.

**What is the new behavior (if this is a feature change)?**
All mixins have the new standard correct behavior which #339 will also document in our contribution guidelines.

**Does this PR introduce a breaking change?**
No