### PR TITLE
Fix one forgotten mixin signature

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_NoXP.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileInfusionMatrix_NoXP.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.sugar.Local;
 import thaumcraft.common.tiles.TileInfusionMatrix;
 
 @Mixin(TileInfusionMatrix.class)
-public class MixinTileInfusionMatrix_NoXP {
+abstract class MixinTileInfusionMatrix_NoXP {
 
     @ModifyExpressionValue(
         method = "craftCycle",


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tiny fix - replace `public` with `abstract` for a mixin.

**What is the new behavior (if this is a feature change)?**
The correct signature is used for the class

**Does this PR introduce a breaking change?**
No