### PR TITLE
Localize key-bind names

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -196,7 +196,8 @@ public enum Mixins implements IMixins {
             "thaumcraft.common.lib.events.MixinEventHandlerEntity_LocalizeCorrectly",
             "thaumcraft.common.lib.network.playerdata.MixinPacketPlayerCompleteToServer_LocalizeCorrectly",
             "thaumcraft.common.lib.MixinWarpEvents_LocalizeCorrectly",
-            "thaumcraft.common.tiles.MixinTileEldritchLock_LocalizeCorrectly")
+            "thaumcraft.common.tiles.MixinTileEldritchLock_LocalizeCorrectly",
+            "thaumcraft.common.lib.events.MixinKeyHandler_LocalizeKeybinds")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     EXCAVATION_DETERMINISTIC_COST(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.excavationFocusDeterministicCost)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinKeyHandler_LocalizeKeybinds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinKeyHandler_LocalizeKeybinds.java
@@ -1,0 +1,27 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.lib.events;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import thaumcraft.common.lib.events.KeyHandler;
+
+@Mixin(value = KeyHandler.class, remap = false)
+abstract class MixinKeyHandler_LocalizeKeybinds {
+
+    @ModifyExpressionValue(method = "<init>", at = @At(value = "CONSTANT", args = "stringValue=Change Wand Focus"))
+    private String localizeF(String original) {
+        return "tc.key.change_wand_focus";
+    }
+
+    @ModifyExpressionValue(method = "<init>", at = @At(value = "CONSTANT", args = "stringValue=Activate Hover Harness"))
+    private String localizeH(String original) {
+        return "tc.key.hover_harness";
+    }
+
+    @ModifyExpressionValue(method = "<init>", at = @At(value = "CONSTANT", args = "stringValue=Misc Wand Toggle"))
+    private String localizeG(String original) {
+        return "tc.key.wand_toggle";
+    }
+}

--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -279,3 +279,7 @@ salisarcana:wand_rod.special.alfheimSpiritual_staff.4=  §5regenerating vis by y
 
 salisarcana:wand_rod.special.tbthaumium=§5Regenerates §d1 vis§5 of a random uncapped aspect every 2.5 seconds (max §d10% vis§5)
 salisarcana:wand_rod.special.tbvoid=§5Regenerates §d1 vis§5 of a random uncapped aspect every 2.5 seconds (max §d10% vis§5)
+
+tc.key.change_wand_focus=Change Wand Focus
+tc.key.hover_harness=Activate Hover Harness
+tc.key.wand_toggle=Misc Wand Toggle


### PR DESCRIPTION
**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix - the names of Thaumcraft's key binds were not localized

**What is the current behavior?** (You can also link to an open issue here)
Thaumcraft key binds show English names, even in other languages

**What is the new behavior (if this is a feature change)?**
The keybinds have been assigned stable lang keys that can get localized for each language.

**Does this PR introduce a breaking change?**
Since the name of the key bind is also used in saving it in the settings, applying this mixin will reset all of Thaumcraft's keybinds to their default bindings.
