### PR TITLE
Fix Arcane Pressure Plates rendering as full blocks

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -180,7 +180,8 @@ public enum Mixins implements IMixins {
         .addCommonMixins("thaumcraft.common.blocks.MixinBlock_CollisionConserveBlockBounds", "thaumcraft.common.blocks.MixinBlockCandle_SetBlockBounds",
             "thaumcraft.common.blocks.MixinBlockChestHungry_SetBlockBounds", "thaumcraft.common.blocks.MixinBlockEssentiaReservoir_SetBlockBounds",
             "thaumcraft.common.blocks.MixinBlockJar_SetBlockBounds", "thaumcraft.common.blocks.MixinBlockLoot_SetBlockBounds")
-        .addClientMixins("thaumcraft.client.renderers.block.MixinBlockRenderer_ConserveBlockBounds", "thaumcraft.common.blocks.MixinBlockTube_BBoxConserveBlockBounds")
+        .addClientMixins("thaumcraft.client.renderers.block.MixinBlockRenderer_ConserveBlockBounds", "thaumcraft.common.blocks.MixinBlockTube_BBoxConserveBlockBounds",
+            "thaumcraft.client.renderers.block.MixinBlockWoodenDeviceRenderer_ApplyPressurePlateBounds")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     FIX_LOCALIZATION_SIDES(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.fixClientSideLocalization)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/block/MixinBlockWoodenDeviceRenderer_ApplyPressurePlateBounds.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/renderers/block/MixinBlockWoodenDeviceRenderer_ApplyPressurePlateBounds.java
@@ -1,0 +1,25 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.client.renderers.block;
+
+import net.minecraft.block.Block;
+import net.minecraft.client.renderer.RenderBlocks;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.client.renderers.block.BlockWoodenDeviceRenderer;
+
+@Mixin(value = BlockWoodenDeviceRenderer.class, priority = 1001)
+abstract class MixinBlockWoodenDeviceRenderer_ApplyPressurePlateBounds {
+
+    @Redirect(
+        method = "renderWorldBlock",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/block/Block;setBlockBounds(FFFFFF)V", ordinal = 11))
+    private void applyRenderBounds(Block instance, float minX, float minY, float minZ, float maxX, float maxY,
+        float maxZ, @Local(argsOnly = true) RenderBlocks renderBlocks, @Local(name = "md") int md) {
+        float height = md == 2 ? 0.0625f : 0.03125f;
+        renderBlocks.setRenderBounds(0.0625f, 0f, 0.0625f, 0.9375f, height, 0.9375f);
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix - closes #504

### What is the current behavior? (You can also link to an open issue here)
Arcane Pressure Plates are rendered as a full block when `fixBlockBoundsAlterations` is on.

### What is the new behavior?
We duplicate the block bound logic into the renderer, making sure the block gets rendered correctly.

### Does this PR introduce a breaking change?
No

### Other Information
I justify the following `@Redirect` by pointing out that the `MixinBlockRenderer_ConserveBlockBounds` mixin which this complements also uses `@Redirect` to replace all other calls of `block.setBlockBounds`, like this mixin does.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [ ] Changes have been tested using an obfuscated client connected to an obfuscated standalone server - cannot get obfuscated client to start.
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
