### PR TITLE
Allow sapling drops from living magical leaves

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -376,3 +376,9 @@ Fixes a bug where some GUIs would render the wrong aspects when shifting over a 
 **Config option:** `boreDecreaseCVisCheckFrequency`
 
 Lowers the frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup, and therefore calls to find vis nets.
+
+## Allow Sapling Drops from Connected Magical Leaves
+
+**Config option:** `allowDropsFromLiveLeaves`
+
+Allow saplings to be dropped from magical leaves which are still connected to a log (those that cannot decay over time).

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -345,6 +345,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "boreDecreaseCVisCheckFrequency",
         "Lower frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup, and therefore calls to find vis nets.");
 
+    public final ToggleSetting allowDropsFromLiveLeaves = new ToggleSetting(
+        this,
+        "allowDropsFromLiveLeaves",
+        "Allow saplings to be dropped from magical leaves which are still connected to a log.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -309,6 +309,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.pauseTCParticlesWithGame)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_PauseParticles")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    ALLOW_CONNECTED_LEAF_DROPS(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.allowDropsFromLiveLeaves)
+        .addCommonMixins("thaumcraft.common.blocks.MixinBlockMagicalLeaves_AllowConnectedLeafDrops")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
 
     // Features

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMagicalLeaves_AllowConnectedLeafDrops.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockMagicalLeaves_AllowConnectedLeafDrops.java
@@ -1,0 +1,19 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.blocks;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+
+import thaumcraft.common.blocks.BlockMagicalLeaves;
+
+@Mixin(BlockMagicalLeaves.class)
+abstract class MixinBlockMagicalLeaves_AllowConnectedLeafDrops {
+
+    @Expression("(? & 8) != 0")
+    @ModifyExpressionValue(method = "dropBlockAsItemWithChance", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private boolean skipDecayCheck(boolean original) {
+        return true;
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix - closes #503

### What is the current behavior? (You can also link to an open issue here)
Magical leaves that are connected to a log can never drop saplings, unlike vanilla saplings.

### What is the new behavior?
Magical leaves can drop saplings when broken even if they're still connected to a log.

Changes have been tested by redirecting `rand.nextInt` to always drop the sapling, then breaking a freshly generated leaf block.

### Does this PR introduce a breaking change?
No

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [ ] Changes have been tested using an obfuscated client connected to an obfuscated standalone server - cannot get obfuscated client to work
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
