### PR TITLE
Use bindTexture cache

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -388,6 +388,7 @@ Lowers the frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup,
 **Config option:** `fixBindTextureCache`
 
 Eliminates the per-frame ResourceLocation allocations by making UtilsFX populate its bound texture cache.
+
 ## Allow Sapling Drops from Connected Magical Leaves
 
 **Config option:** `allowDropsFromLiveLeaves`

--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -376,3 +376,9 @@ Fixes a bug where some GUIs would render the wrong aspects when shifting over a 
 **Config option:** `boreDecreaseCVisCheckFrequency`
 
 Lowers the frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup, and therefore calls to find vis nets.
+
+## Fix bound texture cache not being populated
+
+**Config option:** `fixBindTextureCache`
+
+Eliminates the per-frame ResourceLocation allocations by making UtilsFX populate its bound texture cache.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -359,7 +359,7 @@ public class ConfigBugfixes extends ConfigGroup {
         this,
         "fixBindTextureCache",
         "Eliminates the per-frame ResourceLocation allocations by making UtilsFX populate its texture cache.");
-                                                                  
+
     public final ToggleSetting allowDropsFromLiveLeaves = new ToggleSetting(
         this,
         "allowDropsFromLiveLeaves",

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -345,6 +345,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "boreDecreaseCVisCheckFrequency",
         "Lower frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup, and therefore calls to find vis nets.");
 
+    public final ToggleSetting fixBindTextureCache = new ToggleSetting(
+        this,
+        "fixBindTextureCache",
+        "Eliminates the per-frame ResourceLocation allocations by making UtilsFX populate its texture cache.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -305,6 +305,10 @@ public enum Mixins implements IMixins {
     ARCANE_BORE_VIS_DRAIN_FREQUENCY(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.boreDecreaseCVisCheckFrequency)
         .addCommonMixins("thaumcraft.common.tiles.MixinTileArcaneBore_DecreaseCVisCheckFrequency")),
+    FIX_BIND_TEXTURE_CACHE(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.fixBindTextureCache)
+        .addClientMixins("thaumcraft.client.lib.MixinUtilsFX_BindTextureCache")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     PAUSE_TC_PARTICLES(new SalisBuilder()
         .applyIf(SalisConfig.thaum.pauseTCParticlesWithGame)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_PauseParticles")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_BindTextureCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_BindTextureCache.java
@@ -1,0 +1,36 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.client.lib;
+
+import java.util.Map;
+
+import net.minecraft.util.ResourceLocation;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import thaumcraft.client.lib.UtilsFX;
+
+@Mixin(value = UtilsFX.class, remap = false)
+abstract class MixinUtilsFX_BindTextureCache {
+
+    @Shadow(remap = false)
+    private static Map<String, ResourceLocation> boundTextures;
+
+    @Inject(method = "bindTexture(Ljava/lang/String;)V", at = @At("HEAD"))
+    private static void salisarcana$cacheTexture(String texture, CallbackInfo ci) {
+        if (!boundTextures.containsKey(texture)) {
+            boundTextures.put(texture, new ResourceLocation("thaumcraft", texture));
+        }
+    }
+
+    @Inject(method = "bindTexture(Ljava/lang/String;Ljava/lang/String;)V", at = @At("HEAD"))
+    private static void salisarcana$cacheTexture(String mod, String texture, CallbackInfo ci) {
+        final var key = mod + ":" + texture;
+        if (!boundTextures.containsKey(key)) {
+            boundTextures.put(key, new ResourceLocation(mod, texture));
+        }
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_BindTextureCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_BindTextureCache.java
@@ -20,9 +20,7 @@ abstract class MixinUtilsFX_BindTextureCache {
 
     @Inject(method = "bindTexture(Ljava/lang/String;)V", at = @At("HEAD"))
     private static void salisarcana$cacheTexture(String texture, CallbackInfo ci) {
-        if (!boundTextures.containsKey(texture)) {
-            boundTextures.put(texture, new ResourceLocation("thaumcraft", texture));
-        }
+        boundTextures.computeIfAbsent(texture, key -> new ResourceLocation("thaumcraft", key));
     }
 
     @Inject(method = "bindTexture(Ljava/lang/String;Ljava/lang/String;)V", at = @At("HEAD"))


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Improve memory allocations

### What is the current behavior? (You can also link to an open issue here)
Currently, `UtilsFX.bindTexture` is checking if the string is inside the map, but if it's not, it does not populate the cache, so the cache is never used.

### What is the new behavior?
Make it so the cache is populated and work as intended.

### Does this PR introduce a breaking change?
No.

### Other information

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
