### PR TITLE
Prevent items from trying to float up out of the Infernal Furnace

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -179,7 +179,7 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.fixBlockBoundsAlterations)
         .addCommonMixins("thaumcraft.common.blocks.MixinBlock_CollisionConserveBlockBounds", "thaumcraft.common.blocks.MixinBlockCandle_SetBlockBounds",
             "thaumcraft.common.blocks.MixinBlockChestHungry_SetBlockBounds", "thaumcraft.common.blocks.MixinBlockEssentiaReservoir_SetBlockBounds",
-            "thaumcraft.common.blocks.MixinBlockJar_SetBlockBounds", "thaumcraft.common.blocks.MixinBlockLoot_SetBlockBounds")
+            "thaumcraft.common.blocks.MixinBlockJar_SetBlockBounds", "thaumcraft.common.blocks.MixinBlockLoot_SetBlockBounds", "thaumcraft.common.blocks.MixinBlockArcaneFurnace_AddCollisionAABB")
         .addClientMixins("thaumcraft.client.renderers.block.MixinBlockRenderer_ConserveBlockBounds", "thaumcraft.common.blocks.MixinBlockTube_BBoxConserveBlockBounds")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     FIX_LOCALIZATION_SIDES(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockArcaneFurnace_AddCollisionAABB.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockArcaneFurnace_AddCollisionAABB.java
@@ -1,0 +1,41 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.blocks;
+
+import net.minecraft.block.BlockContainer;
+import net.minecraft.block.material.Material;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import thaumcraft.common.blocks.BlockArcaneFurnace;
+
+@Mixin(BlockArcaneFurnace.class)
+abstract class MixinBlockArcaneFurnace_AddCollisionAABB extends BlockContainer {
+
+    protected MixinBlockArcaneFurnace_AddCollisionAABB(Material materialIn) {
+        super(materialIn);
+    }
+
+    @Override
+    public AxisAlignedBB getCollisionBoundingBoxFromPool(World worldIn, int x, int y, int z) {
+        int meta = worldIn.getBlockMetadata(x, y, z);
+
+        double minX = 0, minY = 0, minZ = 0, maxX = 1, maxY = 1, maxZ = 1;
+
+        if (meta == 0) {
+            maxY = 0.25;
+        } else if (meta == 10) {
+            if (worldIn.getBlockMetadata(x - 1, y, z) == 0) {
+                maxX = 0.5;
+            } else if (worldIn.getBlockMetadata(x + 1, y, z) == 0) {
+                minX = 0.5;
+            } else if (worldIn.getBlockMetadata(x, y, z - 1) == 0) {
+                maxZ = 0.5;
+            } else {
+                minZ = 0.5;
+            }
+        }
+
+        return AxisAlignedBB.getBoundingBox(x + minX, y + minY, z + minZ, x + maxX, y + maxY, z + maxZ);
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix - closes #509 

### What is the current behavior? (You can also link to an open issue here)
When you drop items into the Infernal Furnace while `fixBlockBoundsAlterations` is enabled, they bounce around instead of sinking down into the lava & getting smelted.

### What is the new behavior?
I implemented `getCollisionBoundingBoxFromPool` for it, which seems to have stopped the item entities from treating the center block as a full block.

### Does this PR introduce a breaking change?
No

### Other information
I don't actually understand why this works, to be precise, but it does seem that Minecraft sometimes checks `getCollisionBoundingBoxFromPool` outside of `addCollisionBoxesToList`. I suppose that somewhere, a call to `addCollisionBoxesToList` modified the bounding boxes of the block, thus causing `getCollisionBoundingBoxFromPool` to return the correct value afterwards.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
