### PR TITLE
Quick-stash Wand Foci

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,14 +34,13 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.40-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.93-GTNH:dev")
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.9.15:dev@jar")
     api("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev")
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
     // devOnlyNonPublishable(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))
     devOnlyNonPublishable("com.github.GTNewHorizons:AspectRecipeIndex:1.0.14:dev")
-    runtimeOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.91-GTNH:dev")
     compileOnly("curse.maven:hodgepodge-688899:6039713")
     compileOnly("maven.modrinth:bugtorch:1.2.13")
     compileOnly(rfg.deobf("maven.modrinth:etfuturum:2.6.2"))

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -34,8 +34,8 @@
  * For more details, see https://docs.gradle.org/8.0.1/userguide/java_library_plugin.html#sec:java_library_configurations_graph
  */
 dependencies {
-    api("com.github.GTNewHorizons:NotEnoughItems:2.8.40-GTNH:dev")
-    runtimeOnly("com.github.GTNewHorizons:waila:1.9.15:dev@jar")
+    devOnlyNonPublishable("com.github.GTNewHorizons:NotEnoughItems:2.8.40-GTNH:dev")
+    runtimeOnlyNonPublishable("com.github.GTNewHorizons:waila:1.9.15:dev@jar")
     api("com.github.GTNewHorizons:Baubles-Expanded:2.2.6-GTNH:dev")
     api("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
     compileOnly(rfg.deobf("curse.maven:tc4tweaks-431297:6321233"))

--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -260,9 +260,17 @@ Hovering over an unknown aspect inside the Research Table will show a tooltip wi
 
 **Config option:** `quickStashFocus`
 
-Add a keybind to move a Wand Focus from your hand (while in-game) or a hovered-over accessible slot (while in a GUI) into the player's Focus Pouch(es).
+Add a keybind to move a Wand Focus from your hand (while in-game) or a hovered-over accessible slot (while in a GUI) into
+the player's Focus Pouch(es). The keybind defaults to F, same as the "Switch Wand Focus" keybind.
 
-Defaults to F, same as the "Switch Wand Focus" keybind. If there are no mods loaded that allow two keybinds to share a key (Hodgepodge, Not Enough Items, )
+If there are no mods loaded that allow two keybinds to share a key, Salis Arcane will use the Thaumcraft "Switch Focus"
+keybind to activate this feature instead of creating a new keybind.
+
+Mods that allow two keybinds to share a key:
+- Hodgepodge, version 2.0.31 or newer (with `triggerAllConflictingKeybindings` enabled)
+- Not Enough Items (GTNH edition), version 2.8.113-GTNH or newer
+- Controlling
+- Modern Keybindings
 
 # Enhancements - Infusion
 

--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -262,7 +262,7 @@ Hovering over an unknown aspect inside the Research Table will show a tooltip wi
 
 Add a keybind to move a Wand Focus from your hand (while in-game) or a hovered-over accessible slot (while in a GUI) into the player's Focus Pouch(es).
 
-Defaults to F, same as the "Switch Wand Focus" keybind.
+Defaults to F, same as the "Switch Wand Focus" keybind. If there are no mods loaded that allow two keybinds to share a key (Hodgepodge, Not Enough Items, )
 
 # Enhancements - Infusion
 

--- a/docs/enhancements.md
+++ b/docs/enhancements.md
@@ -256,6 +256,14 @@ Wand caps & wand rods will show information about their vis capacity & discount 
 
 Hovering over an unknown aspect inside the Research Table will show a tooltip with a hint about where you can find it.
 
+## Quick-Stash Wand Foci
+
+**Config option:** `quickStashFocus`
+
+Add a keybind to move a Wand Focus from your hand (while in-game) or a hovered-over accessible slot (while in a GUI) into the player's Focus Pouch(es).
+
+Defaults to F, same as the "Switch Wand Focus" keybind.
+
 # Enhancements - Infusion
 
 ## Config option: `creativeNoXPInfusionEnchanting`

--- a/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
+++ b/src/main/java/dev/rndmorris/salisarcana/ClientProxy.java
@@ -8,11 +8,14 @@ import net.minecraftforge.common.MinecraftForge;
 
 import cpw.mods.fml.common.event.FMLInitializationEvent;
 import cpw.mods.fml.common.event.FMLPostInitializationEvent;
+import dev.rndmorris.salisarcana.client.QuickStashFocus;
 import dev.rndmorris.salisarcana.client.ThaumicInventoryScanner;
 import dev.rndmorris.salisarcana.client.handlers.GuiHandler;
+import dev.rndmorris.salisarcana.client.handlers.SalisContainerInputHandler;
 import dev.rndmorris.salisarcana.common.compat.nei.IMCForNEI;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import dev.rndmorris.salisarcana.lib.WandPartTooltipEventHandler;
+import dev.rndmorris.salisarcana.mixins.TargetedMod;
 
 public class ClientProxy extends CommonProxy {
 
@@ -30,6 +33,12 @@ public class ClientProxy extends CommonProxy {
         }
         if (SalisConfig.modCompat.aspectRecipeIndex.isEnabled()) {
             IMCForNEI.IMCSender();
+        }
+        if (TargetedMod.NOT_ENOUGH_ITEMS.isLoaded()) {
+            SalisContainerInputHandler.register();
+        }
+        if (SalisConfig.features.quickStashFocus.isEnabled()) {
+            QuickStashFocus.register();
         }
         new GuiHandler();
     }

--- a/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
@@ -1,6 +1,7 @@
 package dev.rndmorris.salisarcana.client;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.inventory.GuiContainerCreative;
 import net.minecraft.client.settings.KeyBinding;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.Container;
@@ -33,8 +34,22 @@ public final class QuickStashFocus {
 
     public static void tryStashSlot(Slot slot, Container container) {
         final var mc = Minecraft.getMinecraft();
+        final var player = mc.thePlayer;
 
-        if (WandFocusHelper.storeFocusFromSlot(container, slot, mc.thePlayer)) {
+        if (mc.currentScreen instanceof GuiContainerCreative) {
+            // Since the server still thinks that `InventoryContainer` is the open container, the slot ID won't match
+            // up. Therefore, we fix up the parameters to refer to the player's `InventoryContainer` instead.
+
+            // If the current slot does not refer to the player's inventory, we cannot extract from it since it doesn't
+            // exist on the server.
+            // TODO Implement direct extraction from creative / NEI slots for Creative players.
+            if (slot.inventory != player.inventory) return;
+
+            container = player.inventoryContainer;
+            slot = player.inventoryContainer.getSlotFromInventory(player.inventory, slot.getSlotIndex());
+        }
+
+        if (WandFocusHelper.storeFocusFromSlot(container, slot, player)) {
             NetworkHandler.instance.sendToServer(new MessageQuickStashFocus(slot.slotNumber, container.windowId));
         }
     }

--- a/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
@@ -14,6 +14,7 @@ import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent;
 import dev.rndmorris.salisarcana.lib.WandFocusHelper;
+import dev.rndmorris.salisarcana.mixins.early.accessor.AccessorCreativeSlot;
 import dev.rndmorris.salisarcana.network.MessageQuickStashFocus;
 import dev.rndmorris.salisarcana.network.NetworkHandler;
 
@@ -39,16 +40,23 @@ public final class QuickStashFocus {
         final var player = mc.thePlayer;
 
         if (mc.currentScreen instanceof GuiContainerCreative) {
-            // Since the server still thinks that `InventoryContainer` is the open container, the slot ID won't match
-            // up. Therefore, we fix up the parameters to refer to the player's `InventoryContainer` instead.
+            // When the Creative GUI is open, the server still thinks that `InventoryContainer` is the open container,
+            // so the slot ID won't match up. Therefore, we fix up the parameters to refer to the player's
+            // `InventoryContainer` instead.
 
-            // If the current slot does not refer to the player's inventory, we cannot extract from it since it doesn't
-            // exist on the server.
-            // TODO Implement direct extraction from creative / NEI slots for Creative players.
-            if (slot.inventory != player.inventory) return;
+            if (slot instanceof AccessorCreativeSlot creativeSlot) {
+                slot = creativeSlot.salisarcana$getBaseSlot();
 
-            container = player.inventoryContainer;
-            slot = player.inventoryContainer.getSlotFromInventory(player.inventory, slot.getSlotIndex());
+                // If the current slot does not refer to the player's inventory, we cannot extract from it since it
+                // doesn't exist on the server. (This should only be the "trash can" slot in the Inventory tab.)
+                if (slot.inventory != player.inventory) return;
+
+                container = player.inventoryContainer;
+                slot = player.inventoryContainer.getSlotFromInventory(player.inventory, slot.getSlotIndex());
+            } else {
+                // TODO Implement direct extraction from creative / NEI slots for Creative players.
+                return;
+            }
         }
 
         if (WandFocusHelper.storeFocusFromSlot(container, slot, player)) {

--- a/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
@@ -13,6 +13,7 @@ import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent;
+import dev.rndmorris.salisarcana.common.compat.MixinModCompat;
 import dev.rndmorris.salisarcana.lib.WandFocusHelper;
 import dev.rndmorris.salisarcana.mixins.early.accessor.AccessorCreativeSlot;
 import dev.rndmorris.salisarcana.network.MessageQuickStashFocus;
@@ -20,13 +21,17 @@ import dev.rndmorris.salisarcana.network.NetworkHandler;
 
 public final class QuickStashFocus {
 
-    public static final KeyBinding KEYBIND = new KeyBinding(
-        "salisarcana:keybind.quick_stash_focus",
-        Keyboard.KEY_F,
-        "salisarcana:keybind_category");
+    public static KeyBinding KEYBIND;
 
     public static void register() {
-        ClientRegistry.registerKeyBinding(KEYBIND);
+        // If none of these mods are present, use the Thaumcraft keybind instead.
+        if (MixinModCompat.multiKeyBindsPermitted()) {
+            KEYBIND = new KeyBinding(
+                "salisarcana:keybind.quick_stash_focus",
+                Keyboard.KEY_F,
+                "salisarcana:keybind_category");
+            ClientRegistry.registerKeyBinding(KEYBIND);
+        }
 
         FMLCommonHandler.instance()
             .bus()

--- a/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
@@ -1,0 +1,67 @@
+package dev.rndmorris.salisarcana.client;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+
+import org.lwjgl.input.Keyboard;
+
+import cpw.mods.fml.client.registry.ClientRegistry;
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.SubscribeEvent;
+import cpw.mods.fml.common.gameevent.InputEvent;
+import dev.rndmorris.salisarcana.lib.WandFocusHelper;
+import dev.rndmorris.salisarcana.network.MessageQuickStashFocus;
+import dev.rndmorris.salisarcana.network.NetworkHandler;
+
+public final class QuickStashFocus {
+
+    public static final KeyBinding KEYBIND = new KeyBinding(
+        "salisarcana:keybind.quick_stash_focus",
+        Keyboard.KEY_F,
+        "salisarcana:keybind_category");
+
+    public static void register() {
+        ClientRegistry.registerKeyBinding(KEYBIND);
+
+        FMLCommonHandler.instance()
+            .bus()
+            .register(new EventHandler());
+    }
+
+    public static void tryStashSlot(Slot slot, Container container) {
+        final var mc = Minecraft.getMinecraft();
+
+        if (WandFocusHelper.storeFocusFromSlot(container, slot, mc.thePlayer)) {
+            NetworkHandler.instance.sendToServer(new MessageQuickStashFocus(slot.slotNumber, container.windowId));
+        }
+    }
+
+    private static Slot getHeldSlot(EntityPlayer player) {
+        final int hotbarIndex = player.inventory.currentItem;
+
+        // Fast path: in vanilla, hotbar slots are slots 36-45.
+        Slot slot = player.inventoryContainer.getSlot(36 + hotbarIndex);
+        if (slot != null && slot.inventory == player.inventory && slot.getSlotIndex() == hotbarIndex) {
+            return slot;
+        }
+
+        // Slow path: search through all slots for one that is linked to that hotbar slot.
+        return player.inventoryContainer.getSlotFromInventory(player.inventory, hotbarIndex);
+    }
+
+    public static final class EventHandler {
+
+        private EventHandler() {}
+
+        @SubscribeEvent
+        public void stashInGame(InputEvent.KeyInputEvent event) {
+            final var mc = Minecraft.getMinecraft();
+            if (!mc.inGameHasFocus || !KEYBIND.isPressed()) return;
+
+            tryStashSlot(getHeldSlot(mc.thePlayer), mc.thePlayer.inventoryContainer);
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
@@ -33,6 +33,8 @@ public final class QuickStashFocus {
     }
 
     public static void tryStashSlot(Slot slot, Container container) {
+        if (slot == null) return;
+
         final var mc = Minecraft.getMinecraft();
         final var player = mc.thePlayer;
 

--- a/src/main/java/dev/rndmorris/salisarcana/client/handlers/SalisContainerInputHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/handlers/SalisContainerInputHandler.java
@@ -14,6 +14,7 @@ public final class SalisContainerInputHandler implements IContainerInputHandler 
 
     public static final SalisContainerInputHandler INSTANCE = new SalisContainerInputHandler();
 
+    @Optional.Method(modid = "NotEnoughItems")
     public static void register() {
         GuiContainerManager.addInputHandler(SalisContainerInputHandler.INSTANCE);
     }

--- a/src/main/java/dev/rndmorris/salisarcana/client/handlers/SalisContainerInputHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/handlers/SalisContainerInputHandler.java
@@ -1,0 +1,64 @@
+package dev.rndmorris.salisarcana.client.handlers;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+
+import codechicken.nei.guihook.GuiContainerManager;
+import codechicken.nei.guihook.IContainerInputHandler;
+import cpw.mods.fml.common.Optional;
+import dev.rndmorris.salisarcana.client.QuickStashFocus;
+import dev.rndmorris.salisarcana.config.SalisConfig;
+import dev.rndmorris.salisarcana.mixins.early.accessor.AccessorGuiContainer;
+
+@Optional.Interface(iface = "codechicken.nei.guihook.IContainerInputHandler", modid = "NotEnoughItems")
+public final class SalisContainerInputHandler implements IContainerInputHandler {
+
+    public static final SalisContainerInputHandler INSTANCE = new SalisContainerInputHandler();
+
+    public static void register() {
+        GuiContainerManager.addInputHandler(SalisContainerInputHandler.INSTANCE);
+    }
+
+    private SalisContainerInputHandler() {}
+
+    @Override
+    public boolean keyTyped(GuiContainer gui, char keyChar, int keyCode) {
+        return false;
+    }
+
+    @Override
+    public void onKeyTyped(GuiContainer gui, char keyChar, int keyID) {}
+
+    @Override
+    public boolean lastKeyTyped(GuiContainer gui, char keyChar, int keyID) {
+        if (SalisConfig.features.quickStashFocus.isEnabled()) {
+            if (keyID == QuickStashFocus.KEYBIND.getKeyCode()) {
+                QuickStashFocus.tryStashSlot(((AccessorGuiContainer) gui).getHoveredSlot(), gui.inventorySlots);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean mouseClicked(GuiContainer gui, int mousex, int mousey, int button) {
+        return false;
+    }
+
+    @Override
+    public void onMouseClicked(GuiContainer gui, int mousex, int mousey, int button) {}
+
+    @Override
+    public void onMouseUp(GuiContainer gui, int mousex, int mousey, int button) {}
+
+    @Override
+    public boolean mouseScrolled(GuiContainer gui, int mousex, int mousey, int scrolled) {
+        return false;
+    }
+
+    @Override
+    public void onMouseScrolled(GuiContainer gui, int mousex, int mousey, int scrolled) {}
+
+    @Override
+    public void onMouseDragged(GuiContainer gui, int mousex, int mousey, int button, long heldTime) {}
+}

--- a/src/main/java/dev/rndmorris/salisarcana/common/compat/MixinModCompat.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/compat/MixinModCompat.java
@@ -2,10 +2,13 @@ package dev.rndmorris.salisarcana.common.compat;
 
 import static dev.rndmorris.salisarcana.SalisArcana.LOG;
 
+import com.mitchej123.hodgepodge.config.FixesConfig;
 import com.mitchej123.hodgepodge.config.TweaksConfig;
 
 import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.versioning.DefaultArtifactVersion;
 import dev.rndmorris.salisarcana.config.SalisConfig;
+import dev.rndmorris.salisarcana.mixins.TargetedMod;
 import jss.bugtorch.config.BugTorchConfig;
 
 public class MixinModCompat {
@@ -18,7 +21,7 @@ public class MixinModCompat {
         // we get here.
 
         // For other mods, we may have to fetch config values manually.
-        if (Loader.isModLoaded("hodgepodge")) {
+        if (TargetedMod.HODGEPODGE.isLoaded()) {
             // Hodgepodge's cv support is buggy and won't charge amulets, so we force-disable it if either
             // is enabled, and we enable ours instead.
             if (TweaksConfig.addCVSupportToWandPedestal || SalisConfig.features.wandPedestalUseCV.isEnabled()) {
@@ -32,5 +35,21 @@ public class MixinModCompat {
                 LOG.info("Salis Arcana: Disabling Thaumcraft candle color array out of bounds fix -- BugTorch Enabled");
             }
         }
+    }
+
+    public static boolean multiKeyBindsPermitted() {
+        return (TargetedMod.HODGEPODGE.isLoaded() && FixesConfig.triggerAllConflictingKeybindings)
+            || (TargetedMod.NOT_ENOUGH_ITEMS.isLoaded() && doesNEIHaveKeyBindPatch())
+            || TargetedMod.CONTROLLING.isLoaded()
+            || TargetedMod.MODERN_KEYBINDING.isLoaded();
+    }
+
+    private static boolean doesNEIHaveKeyBindPatch() {
+        final var minVersion = new DefaultArtifactVersion("2.8.113-GTNH");
+        return Loader.instance()
+            .getIndexedModList()
+            .get("NotEnoughItems")
+            .getProcessedVersion()
+            .compareTo(minVersion) >= 0;
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigFeatures.java
@@ -486,6 +486,11 @@ public class ConfigFeatures extends ConfigGroup {
         "fakePlayersDropLootbags",
         "Allows kills from fake players to drop loot bags from champion mobs.").setEnabled(true);
 
+    public final ToggleSetting quickStashFocus = new ToggleSetting(
+        this,
+        "quickStashFocus",
+        "Add a keybind to move a Wand Focus from your hand (while in-game) or a hovered-over accessible slot (while in a GUI) into the player's Focus Pouch(es).");
+
     public boolean singleWandReplacementEnabled() {
         return (this.replaceWandCapsSettings.isEnabled() || this.replaceWandCoreSettings.isEnabled())
             && SalisConfig.bugfixes.arcaneWorkbenchGhostItemFix.isEnabled()

--- a/src/main/java/dev/rndmorris/salisarcana/lib/WandFocusHelper.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/WandFocusHelper.java
@@ -4,13 +4,21 @@ import static dev.rndmorris.salisarcana.lib.ArrayHelper.tryGet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.inventory.Slot;
 import net.minecraft.item.ItemStack;
 
+import baubles.api.BaublesApi;
+import dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.container.AccessorContainerFocusPouch;
 import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.api.wands.ItemFocusBasic;
+import thaumcraft.common.items.wands.ItemFocusPouch;
 
 public class WandFocusHelper {
 
@@ -36,4 +44,83 @@ public class WandFocusHelper {
         return null;
     }
 
+    /**
+     * Try to extract a focus from a slot and store it in the player's inventory, prioritizing Baubles over the
+     * inventory.
+     *
+     * @param container The container from where the focus is being extracted.
+     * @param slot      The slot of the container from where the focus is being extracted.
+     * @param player    The player who is interacting with the container.
+     * @return Whether a focus was successfully moved from that slot to a Focus Pouch on the player.
+     */
+    public static boolean storeFocusFromSlot(Container container, Slot slot, EntityPlayer player) {
+        if (slot == null || !slot.canTakeStack(player)) return false;
+
+        final ItemStack focusStack = slot.getStack();
+        if (focusStack == null || !(focusStack.getItem() instanceof ItemFocusBasic)) return false;
+
+        // Try to guard against any potential bad IInventory implementations
+        final Supplier<ItemStack> extractor = () -> {
+            final ItemStack takenStack = slot.decrStackSize(1);
+            if (takenStack == null || !(takenStack.getItem() instanceof ItemFocusBasic)) return null;
+
+            slot.onPickupFromSlot(player, takenStack);
+            return takenStack;
+        };
+
+        // Don't try to store foci into a currently open Focus Pouch
+        int skipIdx = -1;
+        if (container instanceof AccessorContainerFocusPouch pouchContainer) {
+            int blockedSlot = pouchContainer.salisarcana$getBlockSlot();
+            skipIdx = container.getSlot(blockedSlot)
+                .getSlotIndex();
+        }
+
+        // Try to store the focus, prioritizing the focus pouches in the Bauble slots first.
+        if (storeFocusInInventory(BaublesApi.getBaubles(player), extractor, -1)
+            || storeFocusInInventory(player.inventory, extractor, skipIdx)) {
+            container.detectAndSendChanges();
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Place a focus into the first non-full Focus Pouch within this inventory.
+     *
+     * @param inventory The inventory to scan for Focus Pouches
+     * @param focus     A function that extracts the Wand Focus that needs to be stored. Returning null will cancel the
+     *                  operation.
+     * @param skipIdx   An index of the inventory to skip. Use -1 if no indices should be skipped.
+     * @return Whether the focus was successfully added to a Focus Pouch.
+     */
+    private static boolean storeFocusInInventory(IInventory inventory, Supplier<ItemStack> focus, int skipIdx) {
+        for (int i = 0; i < inventory.getSizeInventory(); i++) {
+            if (i == skipIdx) continue;
+
+            final var stack = inventory.getStackInSlot(i);
+            if (stack == null || !(stack.getItem() instanceof ItemFocusPouch pouch)) continue;
+
+            final ItemStack[] pouchSlots = pouch.getInventory(stack);
+            for (int j = 0; j < pouchSlots.length; j++) {
+                if (pouchSlots[j] == null) {
+                    // Take the focus from out of the slot
+                    final ItemStack focusStack = focus.get();
+                    if (focusStack == null) return false;
+
+                    // Put the focus in the pouch
+                    pouchSlots[j] = focusStack;
+                    pouch.setInventory(stack, pouchSlots);
+
+                    // Update the inventory to inform it that the slot's NBT has changed
+                    inventory.setInventorySlotContents(i, stack);
+
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -15,7 +15,7 @@ public enum Mixins implements IMixins {
     // spotless:off
     // Early Mixins
     ACCESSORS(new SalisBuilder(Phase.EARLY)
-        .addClientMixins("accessor.AccessorGuiContainer", "accessor.AccessorMinecraft")),
+        .addClientMixins("accessor.AccessorGuiContainer", "accessor.AccessorMinecraft", "accessor.AccessorCreativeSlot")),
     VANILLA_GUI_KEY_TYPED(new SalisBuilder(Phase.EARLY)
         .addClientMixins("gui.MixinGuiContainer_HandleKeyTyped")
         .addExcludedMod(TargetedMod.NOT_ENOUGH_ITEMS)),

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -15,8 +15,15 @@ public enum Mixins implements IMixins {
     // spotless:off
     // Early Mixins
     ACCESSORS(new SalisBuilder(Phase.EARLY)
-        .addCommonMixins("accessor.AccessorGuiContainer")
-        .addClientMixins("accessor.AccessorMinecraft")),
+        .addClientMixins("accessor.AccessorGuiContainer", "accessor.AccessorMinecraft")),
+    VANILLA_GUI_KEY_TYPED(new SalisBuilder(Phase.EARLY)
+        .addClientMixins("gui.MixinGuiContainer_HandleKeyTyped")
+        .addExcludedMod(TargetedMod.NOT_ENOUGH_ITEMS)),
+
+    // Late Accessors
+    THAUM_ACCESSORS(new SalisBuilder()
+        .addCommonMixins("thaumcraft.common.container.AccessorContainerFocusPouch")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Bugfixes
     ADVANCED_ARCANE_FURNACE_SAVE_NBT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -21,6 +21,9 @@ public enum Mixins implements IMixins {
         .addExcludedMod(TargetedMod.NOT_ENOUGH_ITEMS)),
 
     // Late Accessors
+    // These mixins do not cause any visible changes to the execution of Thaumcraft code, meaning that conflicts are
+    // highly unlikely. Furthermore, these mixins being always applied allows for focus quick-stashing to be dynamically
+    // enabled & disabled in the future.
     THAUM_ACCESSORS(new SalisBuilder()
         .addCommonMixins("thaumcraft.common.container.AccessorContainerFocusPouch")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -24,6 +24,10 @@ public enum Mixins implements IMixins {
     THAUM_ACCESSORS(new SalisBuilder()
         .addCommonMixins("thaumcraft.common.container.AccessorContainerFocusPouch")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    CAPTURE_FOCUS_KEYBIND(new SalisBuilder()
+        .addClientMixins("thaumcraft.common.lib.events.MixinKeyHandler_CaptureFocusKeybind")
+        .setApplyIf(() -> !MixinModCompat.multiKeyBindsPermitted())
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Bugfixes
     ADVANCED_ARCANE_FURNACE_SAVE_NBT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
@@ -17,6 +17,9 @@ public enum TargetedMod implements ITargetMod {
     BAUBLES_EXPANDED("Baubles|Expanded"),
     UNDERGROUND_BIOMES("UndergroundBiomes"),
     NOT_ENOUGH_ITEMS("NotEnoughItems", "codechicken.nei.asm.NEICorePlugin"),
+    HODGEPODGE("hodgepodge"),
+    CONTROLLING("controlling"),
+    MODERN_KEYBINDING("mkb"),
     ANGELICA("angelica"),
     ASPECT_RECIPE_INDEX("aspectrecipeindex");
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/TargetedMod.java
@@ -16,6 +16,7 @@ public enum TargetedMod implements ITargetMod {
     TC4_TWEAKS("tc4tweak"),
     BAUBLES_EXPANDED("Baubles|Expanded"),
     UNDERGROUND_BIOMES("UndergroundBiomes"),
+    NOT_ENOUGH_ITEMS("NotEnoughItems", "codechicken.nei.asm.NEICorePlugin"),
     ANGELICA("angelica"),
     ASPECT_RECIPE_INDEX("aspectrecipeindex");
 
@@ -26,6 +27,11 @@ public enum TargetedMod implements ITargetMod {
     TargetedMod(String modId) {
         this.modId = modId;
         this.builder = new TargetModBuilder().setModId(modId);
+    }
+
+    TargetedMod(String modId, String coreModClass) {
+        this(modId);
+        this.builder.setCoreModClass(coreModClass);
     }
 
     public boolean isLoaded() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/early/accessor/AccessorCreativeSlot.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/early/accessor/AccessorCreativeSlot.java
@@ -1,0 +1,13 @@
+package dev.rndmorris.salisarcana.mixins.early.accessor;
+
+import net.minecraft.inventory.Slot;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(targets = "net.minecraft.client.gui.inventory.GuiContainerCreative$CreativeSlot")
+public interface AccessorCreativeSlot {
+
+    @Accessor("field_148332_b")
+    Slot salisarcana$getBaseSlot();
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/early/gui/MixinGuiContainer_HandleKeyTyped.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/early/gui/MixinGuiContainer_HandleKeyTyped.java
@@ -1,0 +1,20 @@
+package dev.rndmorris.salisarcana.mixins.early.gui;
+
+import net.minecraft.client.gui.inventory.GuiContainer;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dev.rndmorris.salisarcana.client.handlers.SalisContainerInputHandler;
+import dev.rndmorris.salisarcana.mixins.early.accessor.AccessorGuiContainer;
+
+@Mixin(GuiContainer.class)
+abstract class MixinGuiContainer_HandleKeyTyped implements AccessorGuiContainer {
+
+    @Inject(method = "keyTyped", at = @At("TAIL"))
+    private void handleKeyTyped(char typedChar, int keyCode, CallbackInfo ci) {
+        SalisContainerInputHandler.INSTANCE.lastKeyTyped((GuiContainer) (Object) this, typedChar, keyCode);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/AccessorContainerFocusPouch.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/container/AccessorContainerFocusPouch.java
@@ -1,0 +1,13 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.container;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import thaumcraft.common.container.ContainerFocusPouch;
+
+@Mixin(value = ContainerFocusPouch.class, remap = false)
+public interface AccessorContainerFocusPouch {
+
+    @Accessor("blockSlot")
+    int salisarcana$getBlockSlot();
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinKeyHandler_CaptureFocusKeybind.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinKeyHandler_CaptureFocusKeybind.java
@@ -1,0 +1,26 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.lib.events;
+
+import net.minecraft.client.settings.KeyBinding;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import dev.rndmorris.salisarcana.client.QuickStashFocus;
+import thaumcraft.common.lib.events.KeyHandler;
+
+@Mixin(KeyHandler.class)
+abstract class MixinKeyHandler_CaptureFocusKeybind {
+
+    @Shadow
+    public KeyBinding keyF;
+
+    @Inject(method = "<init>", at = @At("TAIL"))
+    private void captureKeys(CallbackInfo ci) {
+        if (QuickStashFocus.KEYBIND == null) {
+            QuickStashFocus.KEYBIND = this.keyF;
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinKeyHandler_CaptureFocusKeybind.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/events/MixinKeyHandler_CaptureFocusKeybind.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import dev.rndmorris.salisarcana.client.QuickStashFocus;
 import thaumcraft.common.lib.events.KeyHandler;
 
-@Mixin(KeyHandler.class)
+@Mixin(value = KeyHandler.class, remap = false)
 abstract class MixinKeyHandler_CaptureFocusKeybind {
 
     @Shadow

--- a/src/main/java/dev/rndmorris/salisarcana/network/MessageQuickStashFocus.java
+++ b/src/main/java/dev/rndmorris/salisarcana/network/MessageQuickStashFocus.java
@@ -1,0 +1,57 @@
+package dev.rndmorris.salisarcana.network;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.inventory.Slot;
+
+import cpw.mods.fml.common.network.simpleimpl.IMessage;
+import cpw.mods.fml.common.network.simpleimpl.IMessageHandler;
+import cpw.mods.fml.common.network.simpleimpl.MessageContext;
+import dev.rndmorris.salisarcana.config.SalisConfig;
+import dev.rndmorris.salisarcana.lib.WandFocusHelper;
+import io.netty.buffer.ByteBuf;
+
+public class MessageQuickStashFocus implements IMessage, IMessageHandler<MessageQuickStashFocus, IMessage> {
+
+    private int windowId;
+    private int slot;
+
+    public MessageQuickStashFocus() {}
+
+    public MessageQuickStashFocus(int slot, int windowId) {
+        this.slot = slot;
+        this.windowId = windowId;
+    }
+
+    @Override
+    public void fromBytes(ByteBuf buf) {
+        this.windowId = buf.readInt();
+        this.slot = buf.readInt();
+    }
+
+    @Override
+    public void toBytes(ByteBuf buf) {
+        buf.writeInt(this.windowId);
+        buf.writeInt(this.slot);
+    }
+
+    @Override
+    public IMessage onMessage(MessageQuickStashFocus message, MessageContext ctx) {
+        if (!SalisConfig.features.quickStashFocus.isEnabled()) return null;
+
+        final EntityPlayer player = ctx.getServerHandler().playerEntity;
+        final Container container = player.openContainer;
+
+        if (container.windowId != message.windowId) return null;
+        if (message.slot < 0 || message.slot >= container.inventorySlots.size()) return null;
+
+        final Slot slot = container.getSlot(message.slot);
+
+        if (WandFocusHelper.storeFocusFromSlot(container, slot, player)) {
+            player.worldObj.playSoundAtEntity(player, "thaumcraft:cameraticks", 0.3F, 1.0F);
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/network/NetworkHandler.java
+++ b/src/main/java/dev/rndmorris/salisarcana/network/NetworkHandler.java
@@ -19,6 +19,7 @@ public class NetworkHandler {
         instance.registerMessage(MessageForgetScannedObjects.class, MessageForgetScannedObjects.class, 6, Side.CLIENT);
         instance.registerMessage(MessageForgetScannedCategory.class, MessageForgetScannedCategory.class, 7, Side.CLIENT);
         instance.registerMessage(MessageExtendedEnchantItem.class, MessageExtendedEnchantItem.class, 8, Side.SERVER);
+        instance.registerMessage(MessageQuickStashFocus.class, MessageQuickStashFocus.class, 9, Side.SERVER);
         // spotless:on
     }
 }

--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -174,6 +174,9 @@ salisarcana:duplicate_research.text=Duplicate "%s"
 salisarcana:duplicate_research.prompt=Shift-click to purchase a duplicate of this research
 salisarcana:duplicate_research.success=Duplicated research paper added to inventory
 
+salisarcana:keybind_category=Salis Arcana
+salisarcana:keybind.quick_stash_focus=Quick-Stash Focus
+
 tile.blockPortalNothing.name=Portal to Nothing
 
 slot.focus_pouch=§aFocus Pouch§7


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature - adds a new keybind to stash a Wand Focus out of an open inventory or your hand into your Focus Pouch(es).

### What is the current behavior? (You can also link to an open issue here)
Such a keybind does not exist. Closes #465.

### What is the new behavior?
Pressing "F" (configurable like any other hotkey) will take a focus out of any slot, if that slot is accessible to the player, and store it in their equipped Focus Pouches, using the same order as vanilla Thaumcraft.

When pressed in-game, instead stores the wand focus held in the player's hand.

### Does this PR introduce a breaking change?
No. However, GTNH likes making it so all modded keybinds are unset by default (ex. [MixinKeyHandlerThaumcraft](https://github.com/GTNewHorizons/Hodgepodge/blob/master/src/main/java/com/mitchej123/hodgepodge/mixins/late/thaumcraft/MixinKeyHandlerThaumcraft.java)), so we may need to introduce a config setting to make the keybind default to unset.

### Other information
- All inventory changes run on the client before being sent to the server. This means that stashing foci is always instant, no matter how much ping you have to the server.
- Unfortunately, implementing a GUI key handler requires a mixin in vanilla Minecraft. `MixinGuiContainer_HandleKeyTyped` does the job when NEI is not installed, and we use `IContainerInputHandler` when NEI is installed.
- The TODO in `QuickStashFocus` was left there intentionally. If you believe it to be an important feature, I can implement it relatively simply.
- I intentionally did not gate the entries in `Mixins.java` on the config, since we probably want to eventually allow the player (and any servers they join) to turn this feature on & off without restarting the game.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [ ] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [ ] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
