### PR TITLE
Remove `@Optional` from `NEIConfig`

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/common/compat/NEIConfig.java
+++ b/src/main/java/dev/rndmorris/salisarcana/common/compat/NEIConfig.java
@@ -8,7 +8,6 @@ import com.gtnewhorizons.aspectrecipeindex.nei.arcaneworkbench.ArcaneSlotPositio
 
 import codechicken.nei.api.API;
 import codechicken.nei.api.IConfigureNEI;
-import cpw.mods.fml.common.Optional;
 import dev.rndmorris.salisarcana.SalisArcana;
 import dev.rndmorris.salisarcana.Tags;
 import dev.rndmorris.salisarcana.common.compat.nei.WandCapSubstitutionHandler;
@@ -17,11 +16,9 @@ import dev.rndmorris.salisarcana.common.item.PlaceholderItem;
 import dev.rndmorris.salisarcana.config.SalisConfig;
 import thaumcraft.client.gui.GuiArcaneWorkbench;
 
-@Optional.Interface(iface = "codechicken.nei.api.API", modid = "NotEnoughItems")
 public class NEIConfig implements IConfigureNEI {
 
     @Override
-    @Optional.Method(modid = "NotEnoughItems")
     public void loadConfig() {
         hidePlaceholder(PlaceholderItem.capPlaceholder);
         hidePlaceholder(PlaceholderItem.rodPlaceholder);
@@ -31,7 +28,6 @@ public class NEIConfig implements IConfigureNEI {
         }
     }
 
-    @Optional.Method(modid = "NotEnoughItems")
     private void hidePlaceholder(PlaceholderItem placeholder) {
         if (placeholder != null) {
             API.hideItem(new ItemStack(placeholder, 0, OreDictionary.WILDCARD_VALUE));
@@ -39,13 +35,11 @@ public class NEIConfig implements IConfigureNEI {
     }
 
     @Override
-    @Optional.Method(modid = "NotEnoughItems")
     public String getName() {
         return SalisArcana.MODID;
     }
 
     @Override
-    @Optional.Method(modid = "NotEnoughItems")
     public String getVersion() {
         return Tags.VERSION;
     }


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix / cleanup

### What is the current behavior? (You can also link to an open issue here)
The `NEIConfig` class misuses `@Optional`.

Firstly, it is not necessary to apply `@Optional.Method` to a method unless its signature refers to a class that won't be present. All of these methods refer only to Java classes, so that is not important. (There does exist *one* JVM curiosity which could also require `@Optional.Method` to fix, but it is not present in this code.)

Secondly, the `@Optional.Interface` wasn't even referring to the right class, so it never did anything.

Finally, this class is never referred to anywhere in our code. The only way it would get loaded is through NEI's mechanism with searches and automatically loads all classes that implement `IConfigureNEI`. When NEI isn't present, this class doesn't get loaded, which means that its contents are irrelevant.

### What is the new behavior?
Removed all `@Optional` annotations, removing the erroneous annotation (and theoretically speeding up the code by skipping FML's class transformer) without any consequence to our program.

### Does this PR introduce a breaking change?
No

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
