### PR TITLE
Preserve tile entity data during Thaumcraft harvesting

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -141,6 +141,12 @@ When performing a mundane crafting recipe in an Arcane Workbench, it will preten
 
 Use Forge's fishing lists to determine what fish, junk, and treasure a fishing golem catches.
 
+## Preserve Tile Entity Data During Thaumcraft Harvesting
+
+**Config option:** `preserveTileEntityDrops`
+
+Preserves tile entity data while Thaumcraft harvests blocks, preventing the Primal Crusher from creating incorrect drops.
+
 ## Rotated Silverwood Logs Display Correct Name in WAILA
 
 **Config option:** `silverwoodLogCorrectName`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -130,6 +130,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "equalTradeBreaksBlocks",
         "Fixes a bug where you couldn't break blocks if you were holding the equal trade focus item.");
 
+    public final ToggleSetting preserveTileEntityDrops = new ToggleSetting(
+        this,
+        "preserveTileEntityDrops",
+        "Preserves tile entity data while Thaumcraft harvests blocks, preventing the Primal Crusher from creating incorrect drops.");
+
     public final ToggleSetting nodesRechargeInGameTime = new ToggleSetting(
         this,
         "nodesRechargeInGameTime",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -117,6 +117,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.equalTradeBreaksBlocks)
         .addCommonMixins("thaumcraft.common.items.wands.foci.MixinItemFocusTrade_BreakBlocks")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    PRESERVE_TILE_ENTITY_DROPS(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.preserveTileEntityDrops)
+        .addCommonMixins("thaumcraft.common.lib.utils.MixinBlockUtils_PreserveTileEntityDrops")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     NODE_RECHARGE_TIME(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.nodesRechargeInGameTime)
         .addCommonMixins("thaumcraft.common.tiles.MixinTileNode_RechargeTime")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinBlockUtils_PreserveTileEntityDrops.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinBlockUtils_PreserveTileEntityDrops.java
@@ -1,0 +1,41 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.lib.utils;
+
+import net.minecraft.block.Block;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.common.lib.utils.BlockUtils;
+
+@Mixin(value = BlockUtils.class, remap = false)
+abstract class MixinBlockUtils_PreserveTileEntityDrops {
+
+    @WrapOperation(
+        method = "harvestBlock(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;IIIZI)Z",
+        at = @At(
+            value = "INVOKE",
+            target = "Lthaumcraft/common/lib/utils/BlockUtils;removeBlock(Lnet/minecraft/world/World;IIILnet/minecraft/entity/player/EntityPlayer;)Z",
+            ordinal = 1,
+            remap = false),
+        remap = false)
+    private static boolean preserveTileEntityUntilHarvest(World world, int x, int y, int z, EntityPlayer player,
+        Operation<Boolean> original, @Local(name = "flag1") boolean canHarvest) {
+        if (!canHarvest) return original.call(world, x, y, z, player);
+
+        Block block = world.getBlock(x, y, z);
+        int metadata = world.getBlockMetadata(x, y, z);
+        block.onBlockHarvested(world, x, y, z, metadata, player);
+
+        boolean removed = block.removedByPlayer(world, player, x, y, z, true);
+        if (removed) {
+            block.onBlockDestroyedByPlayer(world, x, y, z, metadata);
+        }
+        return removed;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinBlockUtils_PreserveTileEntityDrops.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/utils/MixinBlockUtils_PreserveTileEntityDrops.java
@@ -28,6 +28,9 @@ abstract class MixinBlockUtils_PreserveTileEntityDrops {
         Operation<Boolean> original, @Local(name = "flag1") boolean canHarvest) {
         if (!canHarvest) return original.call(world, x, y, z, player);
 
+        // Mirrors Thaumcraft's removeBlock, except willHarvest is true so tile entity data remains
+        // available until BlockUtils calls harvestBlock. The block variable cannot be null here because
+        // canHarvest is only true when Thaumcraft found a valid block.
         Block block = world.getBlock(x, y, z);
         int metadata = world.getBlockMetadata(x, y, z);
         block.onBlockHarvested(world, x, y, z, metadata, player);


### PR DESCRIPTION
Thaumcraft removes blocks before calling their harvest logic. Blocks whose drops depend on a tile entity can therefore lose their metadata and NBT. For example, mining a Vibrant Capacitor Bank with the Primal Crusher's area mining converted it into a Chaotic Capacitor Bank.