### PR TITLE
Create debug log to track changes in player warp

### DIFF
--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,0 +1,9 @@
+# Debug Tools
+
+Config file: `config/salisarcana/debug.cfg`
+
+## Log Stack Trace When Warp Changes
+
+**Config option:** `logWarpSources`
+
+Print out the thread info, stack trace, player name, warp type, and quantity of warp applied whenever a player's warp changes.

--- a/src/main/java/dev/rndmorris/salisarcana/config/SalisConfig.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/SalisConfig.java
@@ -11,6 +11,7 @@ import dev.rndmorris.salisarcana.SalisArcana;
 import dev.rndmorris.salisarcana.config.group.ConfigAddons;
 import dev.rndmorris.salisarcana.config.group.ConfigBugfixes;
 import dev.rndmorris.salisarcana.config.group.ConfigCommands;
+import dev.rndmorris.salisarcana.config.group.ConfigDebug;
 import dev.rndmorris.salisarcana.config.group.ConfigFeatures;
 import dev.rndmorris.salisarcana.config.group.ConfigModCompat;
 import dev.rndmorris.salisarcana.config.group.ConfigThaumcraft;
@@ -27,6 +28,7 @@ public class SalisConfig {
     public static final ConfigFeatures features = new ConfigFeatures();
     public static final ConfigModCompat modCompat = new ConfigModCompat();
     public static final ConfigThaumcraft thaum = new ConfigThaumcraft();
+    public static final ConfigDebug debug = new ConfigDebug();
 
     public static boolean enableVersionChecking;
 

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigDebug.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigDebug.java
@@ -1,0 +1,25 @@
+package dev.rndmorris.salisarcana.config.group;
+
+import org.jetbrains.annotations.NotNull;
+
+import dev.rndmorris.salisarcana.config.ConfigGroup;
+import dev.rndmorris.salisarcana.config.settings.ToggleSetting;
+
+public class ConfigDebug extends ConfigGroup {
+
+    public final ToggleSetting logWarpSources = new ToggleSetting(
+        this,
+        "logWarpSources",
+        "Print out the thread info, stack trace, player name, warp type, and quantity of warp applied whenever a player's warp changes.")
+            .setEnabled(false);
+
+    @Override
+    public @NotNull String getGroupName() {
+        return "debug";
+    }
+
+    @Override
+    public @NotNull String getGroupComment() {
+        return "Options for debugging Thaumcraft & its add-ons. All features in this group are disabled by default.";
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -649,6 +649,13 @@ public enum Mixins implements IMixins {
         .addCommonMixins("thaumcraft.common.tiles.MixinTileCrucible_ScalingAspectDecay")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
+    // Debug
+
+    DEBUG_LOG_WARP_STACK_TRACE(new SalisBuilder()
+        .applyIf(SalisConfig.debug.logWarpSources)
+        .addCommonMixins("thaumcraft.common.lib.research.MixinPlayerKnowledge_DebugLogWarp")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
+
     // Required
     ADD_VISCONTAINER_INTERFACE(new SalisBuilder()
         .setRequired()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinPlayerKnowledge_DebugLogWarp.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/lib/research/MixinPlayerKnowledge_DebugLogWarp.java
@@ -1,0 +1,99 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.lib.research;
+
+import java.util.Map;
+import java.util.StringJoiner;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.relauncher.Side;
+import thaumcraft.common.lib.research.PlayerKnowledge;
+
+@Mixin(value = PlayerKnowledge.class, remap = false)
+abstract class MixinPlayerKnowledge_DebugLogWarp {
+
+    @Unique
+    private static final Logger salisArcana$warpLogger = LogManager.getLogger("Thaumcraft Warp Debug");
+
+    @Shadow
+    public Map<String, Integer> warp;
+
+    @Shadow
+    public Map<String, Integer> warpSticky;
+
+    @Shadow
+    public Map<String, Integer> warpTemp;
+
+    @Inject(method = "addWarpPerm", at = @At("TAIL"))
+    private void logAddPerm(String player, int amount, CallbackInfo ci) {
+        salisArcana$logWarp(player, "Add " + amount + " PERM");
+    }
+
+    @Inject(method = "addWarpSticky", at = @At("TAIL"))
+    private void logAddSticky(String player, int amount, CallbackInfo ci) {
+        salisArcana$logWarp(player, "Add " + amount + " STICKY");
+    }
+
+    @Inject(method = "addWarpTemp", at = @At("TAIL"))
+    private void logAddTemp(String player, int amount, CallbackInfo ci) {
+        salisArcana$logWarp(player, "Add " + amount + " TEMP");
+    }
+
+    @Inject(method = "setWarpPerm", at = @At("TAIL"))
+    private void logSetPerm(String player, int amount, CallbackInfo ci) {
+        salisArcana$logWarp(player, "Set " + amount + " PERM");
+    }
+
+    @Inject(method = "setWarpSticky", at = @At("TAIL"))
+    private void logSetSticky(String player, int amount, CallbackInfo ci) {
+        salisArcana$logWarp(player, "Set " + amount + " STICKY");
+    }
+
+    @Inject(method = "setWarpTemp", at = @At("TAIL"))
+    private void logSetTemp(String player, int amount, CallbackInfo ci) {
+        salisArcana$logWarp(player, "Set " + amount + " TEMP");
+    }
+
+    @Unique
+    private void salisArcana$logWarp(String player, String message) {
+        final Side side = FMLCommonHandler.instance()
+            .getEffectiveSide();
+        final StackTraceElement[] stackTrace = Thread.currentThread()
+            .getStackTrace();
+        final StringJoiner stackLog = new StringJoiner("\n\t");
+
+        // Skip the first 3 elements of the stack trace
+        for (int i = 3; i < stackTrace.length; i++) {
+            if (side == Side.CLIENT
+                && "thaumcraft.common.lib.network.playerdata.PacketSyncWarp".equals(stackTrace[i].getClassName())
+                && "onMessage".equals(stackTrace[i].getMethodName())) {
+
+                // This was a sync packet, most likely. No need to log the rest of the stack trace.
+                // It *is* still a good idea to log other client-side warp effects, since those are usually a bug.
+                stackLog.add("Caused by synchronization via PacketSyncWarp");
+                break;
+            }
+
+            stackLog.add(stackTrace[i].toString());
+        }
+
+        // Use only one logging call, so the message doesn't get interleaved with logs from other threads.
+        salisArcana$warpLogger.info(
+            "Thread: \"{}\" | Player: {} | {} | Is Now: {} PERM {} STICKY {} TEMP | Stack Trace:\n\t{}",
+            Thread.currentThread()
+                .getName(),
+            player,
+            message,
+            this.warp.getOrDefault(player, 0),
+            this.warpSticky.getOrDefault(player, 0),
+            this.warpTemp.getOrDefault(player, 0),
+            stackLog.toString());
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Feature for debugging

### What is the current behavior? (You can also link to an open issue here)
Closes #510

### What is the new behavior?
A config setting in a new category (`debug`), off by default, that will log basically all useful information about every event when warp gets applied to a player.

### Does this PR introduce a breaking change?
No

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
