### PR TITLE
Force reservoirs to use the correct face when checking their essentia type

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -382,3 +382,9 @@ Lowers the frequency of Thaumcraft's Arcane Bore calls to drain vis for speedup,
 **Config option:** `allowDropsFromLiveLeaves`
 
 Allow saplings to be dropped from magical leaves which are still connected to a log (those that cannot decay over time).
+
+## Reservoirs Correctly Return Essentia Type
+
+**Config option:** `reservoirsUseArgInGetEssentiaType`
+
+Force reservoirs to use the correct face when checking their essentia type. Allows downwards-facing reservoirs to be emptied by unlabeled jars placed directly below them.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -350,6 +350,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "allowDropsFromLiveLeaves",
         "Allow saplings to be dropped from magical leaves which are still connected to a log.");
 
+    public final ToggleSetting reservoirsUseArgInGetEssentiaType = new ToggleSetting(
+        this,
+        "reservoirsUseArgInGetEssentiaType",
+        "Force reservoirs to use the correct face when checking their essentia type. Allows downwards-facing reservoirs to be emptied by unlabeled jars placed directly below them.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -325,8 +325,7 @@ public enum Mixins implements IMixins {
     RESERVOIR_GETESSENTIATYPE_USES_ARG(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.reservoirsUseArgInGetEssentiaType)
         .addCommonMixins("thaumcraft.common.tiles.MixinTileEssentiaReservoir_UseArgInGetEssentiaType")
-        .addRequiredMod(TargetedMod.THAUMCRAFT)
-    ),
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -315,6 +315,11 @@ public enum Mixins implements IMixins {
         .addCommonMixins("thaumcraft.common.blocks.MixinBlockMagicalLeaves_AllowConnectedLeafDrops")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
+    RESERVOIR_GETESSENTIATYPE_USES_ARG(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.reservoirsUseArgInGetEssentiaType)
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileEssentiaReservoir_UseArgInGetEssentiaType")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)
+    ),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEssentiaReservoir_UseArgInGetEssentiaType.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEssentiaReservoir_UseArgInGetEssentiaType.java
@@ -1,0 +1,25 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
+
+import net.minecraftforge.common.util.ForgeDirection;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.common.tiles.TileEssentiaReservoir;
+
+@Mixin(value = TileEssentiaReservoir.class, remap = false)
+abstract class MixinTileEssentiaReservoir_UseArgInGetEssentiaType {
+
+    @ModifyExpressionValue(
+        method = "getEssentiaType",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraftforge/common/util/ForgeDirection;UNKNOWN:Lnet/minecraftforge/common/util/ForgeDirection;"))
+    private ForgeDirection useFaceInstead(ForgeDirection original, @Local(argsOnly = true) ForgeDirection loc) {
+        return loc;
+    }
+
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEssentiaReservoir_UseArgInGetEssentiaType.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileEssentiaReservoir_UseArgInGetEssentiaType.java
@@ -2,11 +2,11 @@ package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
 
 import net.minecraftforge.common.util.ForgeDirection;
 
+import org.spongepowered.asm.lib.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
-import com.llamalad7.mixinextras.sugar.Local;
 
 import thaumcraft.common.tiles.TileEssentiaReservoir;
 
@@ -17,8 +17,9 @@ abstract class MixinTileEssentiaReservoir_UseArgInGetEssentiaType {
         method = "getEssentiaType",
         at = @At(
             value = "FIELD",
-            target = "Lnet/minecraftforge/common/util/ForgeDirection;UNKNOWN:Lnet/minecraftforge/common/util/ForgeDirection;"))
-    private ForgeDirection useFaceInstead(ForgeDirection original, @Local(argsOnly = true) ForgeDirection loc) {
+            target = "Lnet/minecraftforge/common/util/ForgeDirection;UNKNOWN:Lnet/minecraftforge/common/util/ForgeDirection;",
+            opcode = Opcodes.GETSTATIC))
+    private ForgeDirection useFaceInstead(ForgeDirection original, ForgeDirection loc) {
         return loc;
     }
 


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bugfix

### What is the current behavior? (You can also link to an open issue here)
Closes #516 

### What is the new behavior?
Reservoirs will check the input direction instead of `UNKNOWN`.

### Does this PR introduce a breaking change?
No

### Other information
"Run Obfuscated Client" loads no mods, not even Salis Arcana, on my machine.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [ ] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
