### PR TITLE
Fix avg vis cost averaging and rounding

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -388,3 +388,9 @@ Allow saplings to be dropped from magical leaves which are still connected to a 
 **Config option:** `portableHoleClientSync`
 
 Properly synchronizes the holes creates with the Portable Hole focus to the client. This prevents ghost blocks when the player moves the camera while using the focus. Also makes other clients in multiplayer display the portable hole visual effect.
+
+## Fix Wand Average Cost Tooltips
+
+**Config option:** `fixWandAverageCostTooltip`
+
+Tweak how a wand's average vis cost is calculated to display a more accurate number. Example: Thaumium+Silverwood scepters (20% discount) should now show 80% instead of 79%.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -355,6 +355,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "allowDropsFromLiveLeaves",
         "Allow saplings to be dropped from magical leaves which are still connected to a log.");
 
+    public final ToggleSetting fixWandAverageCostTooltip = new ToggleSetting(
+        this,
+        "fixWandAverageCostTooltip",
+        "Tweak how a wand's average vis cost is calculated to display a more accurate number. Example: Thaumium+Silverwood scepters (20% discount) should now show 80% instead of 79%.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -359,13 +359,11 @@ public class ConfigBugfixes extends ConfigGroup {
         this,
         "reservoirsUseArgInGetEssentiaType",
         "Force reservoirs to use the correct face when checking their essentia type. Allows downwards-facing reservoirs to be emptied by unlabeled jars placed directly below them.");
-    
+
     public final ToggleSetting fixWandAverageCostTooltip = new ToggleSetting(
         this,
         "fixWandAverageCostTooltip",
         "Tweak how a wand's average vis cost is calculated to display a more accurate number. Example: Thaumium+Silverwood scepters (20% discount) should now show 80% instead of 79%.");
-                                                                  
-    
 
     @Nonnull
     @Override

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -322,6 +322,10 @@ public enum Mixins implements IMixins {
         .addCommonMixins("thaumcraft.common.blocks.MixinBlockMagicalLeaves_AllowConnectedLeafDrops")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
+    SHOW_TOT_AND_NUM(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.fixWandAverageCostTooltip)
+        .addCommonMixins("thaumcraft.common.items.wands.MixinItemWandCasting_UseRoundedAverageCost")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_UseRoundedAverageCost.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_UseRoundedAverageCost.java
@@ -15,6 +15,11 @@ import thaumcraft.common.items.wands.ItemWandCasting;
 @Mixin(ItemWandCasting.class)
 abstract class MixinItemWandCasting_UseRoundedAverageCost {
 
+    /**
+     * The original implementation calculates the new total as a {@code float} then truncates to an {@code int}
+     * for every aspect is touches. To avoid truncating I instead keep the new running total as a {@code float}.
+     * I skipped multiplying by {@code 100.0F} here because that can be factored out to the very end.
+     */
     @Definition(id = "tot", local = @Local(name = "tot", type = int.class))
     @Definition(id = "mod", local = @Local(name = "mod", type = float.class))
     @Expression("(float)tot + mod * 100.0")
@@ -24,6 +29,10 @@ abstract class MixinItemWandCasting_UseRoundedAverageCost {
         return original;
     }
 
+    /**
+     * Round our average to the nearest whole number for display purposes. This lets thaumium+silverwood
+     * scepters (actual value 79.something) be rounded up to 80.
+     */
     @Definition(id = "tot", local = @Local(name = "tot", type = int.class))
     @Definition(id = "num", local = @Local(name = "num", type = int.class))
     @Expression("tot / num")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_UseRoundedAverageCost.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/MixinItemWandCasting_UseRoundedAverageCost.java
@@ -1,0 +1,34 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.items.wands;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.sugar.Local;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalFloatRef;
+
+import thaumcraft.common.items.wands.ItemWandCasting;
+
+@Mixin(ItemWandCasting.class)
+abstract class MixinItemWandCasting_UseRoundedAverageCost {
+
+    @Definition(id = "tot", local = @Local(name = "tot", type = int.class))
+    @Definition(id = "mod", local = @Local(name = "mod", type = float.class))
+    @Expression("(float)tot + mod * 100.0")
+    @ModifyExpressionValue(method = "addInformation", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private float trackTotAsFloat(float original, @Local(name = "mod") float mod, @Share("totF") LocalFloatRef totF) {
+        totF.set(totF.get() + mod);
+        return original;
+    }
+
+    @Definition(id = "tot", local = @Local(name = "tot", type = int.class))
+    @Definition(id = "num", local = @Local(name = "num", type = int.class))
+    @Expression("tot / num")
+    @ModifyExpressionValue(method = "addInformation", at = @At("MIXINEXTRAS:EXPRESSION"))
+    private int useRoundedAverage(int original, @Share("totF") LocalFloatRef totF, @Local(name = "num") int num) {
+        return Math.round(totF.get() / num * 100);
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bugfix

### What is the current behavior? (You can also link to an open issue here)
Average vis cost calculation is bad. Closes #457 

### What is the new behavior?
Average vis cost calculation is slightly less bad, and now shows the average rounded to the nearest whole number.

<img width="939" height="237" alt="image" src="https://github.com/user-attachments/assets/1663b08e-e6e2-43d0-bcf8-e3f22700bc9f" />


### Does this PR introduce a breaking change?
No

### Other information
"Run Obfuscated Client" loads no mods, not even Salis Arcana, on my machine.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [ ] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
