### PR TITLE
Speed up potion aspect registration by only computing the effect lists once

### DIFF
--- a/docs/thaumcraft_configuration.md
+++ b/docs/thaumcraft_configuration.md
@@ -130,3 +130,6 @@ Improves the performance of the aspect tooltips by rewriting its logic.
 
 ### Config Option: `betterParticleEngine`
 Improves the particle engine of Thaumcraft by removing unnecessary GL operations.
+
+### Config Option: `speedupPotionAspectRegistration`
+Caches equivalent potion effects during Thaumcraft aspect registration.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigThaumcraft.java
@@ -175,6 +175,11 @@ public class ConfigThaumcraft extends ConfigGroup {
         "Improves the particle engine of Thaumcraft by removing unnecessary GL operations.")
             .setCategory(tc4PerformanceCategory);
 
+    public final ToggleSetting speedupPotionAspectRegistration = new ToggleSetting(
+        this,
+        "speedupPotionAspectRegistration",
+        "Cache equivalent potion effects during Thaumcraft aspect registration.").setCategory(tc4PerformanceCategory);
+
     public final ToggleSetting crucibleScalingAspectDecay = new ToggleSetting(
         this,
         "crucibleScalingAspectDecay",

--- a/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
@@ -6,7 +6,7 @@ import java.util.function.IntFunction;
 
 public final class PotionMetadataCache<T> {
 
-    public static final int ALL_METADATA_BITS = 0x7FFF;
+    public static final int ALL_METADATA_BITS = 32767; // 2^15-1
     private static final int SPLASH_BIT = 1 << 14;
 
     private final int metadataMask;
@@ -17,6 +17,7 @@ public final class PotionMetadataCache<T> {
     }
 
     public T get(int metadata, IntFunction<T> loader) {
+        // Metadata values that differ only in irrelevant bits produce identical effects.
         int key = metadata & metadataMask;
         if (!values.containsKey(key)) {
             values.put(key, loader.apply(metadata));
@@ -25,38 +26,63 @@ public final class PotionMetadataCache<T> {
     }
 
     public static int findRelevantBits(Iterable<?> requirements, Iterable<?> amplifiers) {
-        int result = addExpressionBits(SPLASH_BIT, requirements);
-        return result == ALL_METADATA_BITS ? result : addExpressionBits(result, amplifiers);
+        // getPotionEffects reads the 15th metadata bit to handle splash effects.
+        int relevantBits = addExpressionBits(SPLASH_BIT, requirements);
+
+        if (relevantBits == ALL_METADATA_BITS) return relevantBits;
+
+        return addExpressionBits(relevantBits, amplifiers);
     }
 
-    private static int addExpressionBits(int bits, Iterable<?> expressions) {
+    private static int addExpressionBits(int relevantBits, Iterable<?> expressions) {
         for (Object value : expressions) {
             if (!(value instanceof String expression)) return ALL_METADATA_BITS;
 
-            for (int i = 0; i < expression.length(); i++) {
-                char current = expression.charAt(i);
-                if (current == '=' || current == '<' || current == '>') return ALL_METADATA_BITS;
-                if (isAsciiDigit(current)) {
-                    int numberStart = i;
-                    int number = 0;
-                    do {
-                        number = number * 10 + expression.charAt(i) - '0';
-                        i++;
-                    } while (i < expression.length() && isAsciiDigit(expression.charAt(i)));
-                    i--;
+            int index = 0;
+            while (index < expression.length()) {
+                char token = expression.charAt(index);
 
-                    int previous = numberStart - 1;
-                    while (previous >= 0 && Character.isWhitespace(expression.charAt(previous))) previous--;
-                    if (previous < 0 || expression.charAt(previous) != '*') {
-                        int shiftedBit = number & 31;
-                        if (shiftedBit < 15) bits |= 1 << shiftedBit;
+                // comparisons inspect the total number of set bits, making every bit relevant.
+                if (token == '=' || token == '<' || token == '>') return ALL_METADATA_BITS;
+
+                if (isAsciiDigit(token)) {
+                    int numberStart = index;
+                    int tokenValue = 0;
+                    // Vanilla uses only 0-6 here, but mods may reference metadata bits 10-14.
+                    while (index < expression.length() && isAsciiDigit(expression.charAt(index))) {
+                        tokenValue = tokenValue * 10 + (expression.charAt(index) - '0');
+                        index++;
                     }
-                } else if (!Character.isWhitespace(current) && "|&!*-+".indexOf(current) < 0) {
+
+                    // A number preceded by '*' is a factor, not a bit index: (index*factor)
+                    // Vanilla does not use it but its expression parser supports so do we
+                    if (isMultiplicationFactor(expression, numberStart)) continue;
+
+                    int bitIndex = tokenValue;
+                    // Match PotionHelper's shift, discarding bits outside potion metadata.
+                    relevantBits |= (1 << bitIndex) & ALL_METADATA_BITS;
+                    continue;
+                }
+
+                if (!Character.isWhitespace(token) && !isExpressionOperator(token)) {
+                    // Unknown syntax cannot be reduced safely, so disable the optimization.
                     return ALL_METADATA_BITS;
                 }
+                index++;
             }
         }
-        return bits;
+        return relevantBits;
+    }
+
+    private static boolean isMultiplicationFactor(String expression, int numberStart) {
+        // The factor follows '*', so look backward past optional whitespace to classify this number.
+        int previous = numberStart - 1;
+        while (previous >= 0 && Character.isWhitespace(expression.charAt(previous))) previous--;
+        return previous >= 0 && expression.charAt(previous) == '*';
+    }
+
+    private static boolean isExpressionOperator(char token) {
+        return "|&!*-+".indexOf(token) >= 0;
     }
 
     private static boolean isAsciiDigit(char character) {

--- a/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
@@ -20,7 +20,7 @@ public final class PotionMetadataCache<T> {
         // Metadata values that differ only in irrelevant bits produce identical effects.
         int key = metadata & metadataMask;
         if (!values.containsKey(key)) {
-            values.put(key, loader.apply(metadata));
+            values.put(key, loader.apply(key));
         }
         return values.get(key);
     }

--- a/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
@@ -25,7 +25,7 @@ public final class PotionMetadataCache<T> {
         return values.get(key);
     }
 
-    public static int findRelevantBits(Iterable<?> requirements, Iterable<?> amplifiers) {
+    public static int findRelevantBits(Iterable<String> requirements, Iterable<String> amplifiers) {
         // getPotionEffects reads the 15th metadata bit to handle splash effects.
         int relevantBits = addExpressionBits(SPLASH_BIT, requirements);
 
@@ -34,10 +34,8 @@ public final class PotionMetadataCache<T> {
         return addExpressionBits(relevantBits, amplifiers);
     }
 
-    private static int addExpressionBits(int relevantBits, Iterable<?> expressions) {
-        for (Object value : expressions) {
-            if (!(value instanceof String expression)) return ALL_METADATA_BITS;
-
+    private static int addExpressionBits(int relevantBits, Iterable<String> expressions) {
+        for (String expression : expressions) {
             int index = 0;
             while (index < expression.length()) {
                 char token = expression.charAt(index);

--- a/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/lib/PotionMetadataCache.java
@@ -1,0 +1,65 @@
+package dev.rndmorris.salisarcana.lib;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.IntFunction;
+
+public final class PotionMetadataCache<T> {
+
+    public static final int ALL_METADATA_BITS = 0x7FFF;
+    private static final int SPLASH_BIT = 1 << 14;
+
+    private final int metadataMask;
+    private final Map<Integer, T> values = new HashMap<>();
+
+    public PotionMetadataCache(int metadataMask) {
+        this.metadataMask = metadataMask;
+    }
+
+    public T get(int metadata, IntFunction<T> loader) {
+        int key = metadata & metadataMask;
+        if (!values.containsKey(key)) {
+            values.put(key, loader.apply(metadata));
+        }
+        return values.get(key);
+    }
+
+    public static int findRelevantBits(Iterable<?> requirements, Iterable<?> amplifiers) {
+        int result = addExpressionBits(SPLASH_BIT, requirements);
+        return result == ALL_METADATA_BITS ? result : addExpressionBits(result, amplifiers);
+    }
+
+    private static int addExpressionBits(int bits, Iterable<?> expressions) {
+        for (Object value : expressions) {
+            if (!(value instanceof String expression)) return ALL_METADATA_BITS;
+
+            for (int i = 0; i < expression.length(); i++) {
+                char current = expression.charAt(i);
+                if (current == '=' || current == '<' || current == '>') return ALL_METADATA_BITS;
+                if (isAsciiDigit(current)) {
+                    int numberStart = i;
+                    int number = 0;
+                    do {
+                        number = number * 10 + expression.charAt(i) - '0';
+                        i++;
+                    } while (i < expression.length() && isAsciiDigit(expression.charAt(i)));
+                    i--;
+
+                    int previous = numberStart - 1;
+                    while (previous >= 0 && Character.isWhitespace(expression.charAt(previous))) previous--;
+                    if (previous < 0 || expression.charAt(previous) != '*') {
+                        int shiftedBit = number & 31;
+                        if (shiftedBit < 15) bits |= 1 << shiftedBit;
+                    }
+                } else if (!Character.isWhitespace(current) && "|&!*-+".indexOf(current) < 0) {
+                    return ALL_METADATA_BITS;
+                }
+            }
+        }
+        return bits;
+    }
+
+    private static boolean isAsciiDigit(char character) {
+        return character >= '0' && character <= '9';
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -290,6 +290,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.thaum.betterParticleEngine)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_SkipRendering")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    SPEEDUP_POTION_ASPECT_REGISTRATION(new SalisBuilder()
+        .applyIf(SalisConfig.thaum.speedupPotionAspectRegistration)
+        .addCommonMixins("thaumcraft.common.config.MixinConfigAspects_SpeedupPotionAspects")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     FIX_PARTICLE_ENGINE_LEAK(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.fixParticleEngineLeak)
         .addClientMixins("thaumcraft.client.fx.MixinParticleEngine_FixLeak")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigAspects_SpeedupPotionAspects.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigAspects_SpeedupPotionAspects.java
@@ -1,0 +1,52 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.config;
+
+import java.util.List;
+
+import net.minecraft.potion.PotionEffect;
+import net.minecraft.potion.PotionHelper;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+
+import dev.rndmorris.salisarcana.lib.PotionMetadataCache;
+import thaumcraft.common.config.ConfigAspects;
+
+@Mixin(value = ConfigAspects.class, remap = false)
+abstract class MixinConfigAspects_SpeedupPotionAspects {
+
+    @Unique
+    private static PotionMetadataCache<List<PotionEffect>> salisarcana$potionEffectCache;
+
+    @Inject(method = "registerItemAspects", at = @At("HEAD"), require = 1)
+    private static void salisarcana$createPotionEffectCache(CallbackInfo ci) {
+        int metadataMask = PotionMetadataCache
+            .findRelevantBits(PotionHelper.potionRequirements.values(), PotionHelper.potionAmplifiers.values());
+
+        salisarcana$potionEffectCache = metadataMask == PotionMetadataCache.ALL_METADATA_BITS ? null
+            : new PotionMetadataCache<>(metadataMask);
+    }
+
+    @WrapOperation(
+        method = "registerItemAspects",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/potion/PotionHelper;getPotionEffects(IZ)Ljava/util/List;",
+            remap = true),
+        require = 1)
+    private static List<PotionEffect> salisarcana$cachePotionEffects(int metadata, boolean includeUsable,
+        Operation<List<PotionEffect>> original) {
+        if (salisarcana$potionEffectCache == null) return original.call(metadata, includeUsable);
+        return salisarcana$potionEffectCache.get(metadata, value -> original.call(value, includeUsable));
+    }
+
+    @Inject(method = "registerItemAspects", at = @At("RETURN"), require = 1)
+    private static void salisarcana$clearPotionEffectCache(CallbackInfo ci) {
+        salisarcana$potionEffectCache = null;
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigAspects_SpeedupPotionAspects.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigAspects_SpeedupPotionAspects.java
@@ -18,6 +18,7 @@ import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 import dev.rndmorris.salisarcana.lib.PotionMetadataCache;
 import thaumcraft.common.config.ConfigAspects;
 
+@SuppressWarnings("unchecked")
 @Mixin(value = ConfigAspects.class, remap = false)
 abstract class MixinConfigAspects_SpeedupPotionAspects {
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigAspects_SpeedupPotionAspects.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/config/MixinConfigAspects_SpeedupPotionAspects.java
@@ -6,13 +6,14 @@ import net.minecraft.potion.PotionEffect;
 import net.minecraft.potion.PotionHelper;
 
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.sugar.Share;
+import com.llamalad7.mixinextras.sugar.ref.LocalRef;
 
 import dev.rndmorris.salisarcana.lib.PotionMetadataCache;
 import thaumcraft.common.config.ConfigAspects;
@@ -20,16 +21,14 @@ import thaumcraft.common.config.ConfigAspects;
 @Mixin(value = ConfigAspects.class, remap = false)
 abstract class MixinConfigAspects_SpeedupPotionAspects {
 
-    @Unique
-    private static PotionMetadataCache<List<PotionEffect>> salisarcana$potionEffectCache;
-
     @Inject(method = "registerItemAspects", at = @At("HEAD"), require = 1)
-    private static void salisarcana$createPotionEffectCache(CallbackInfo ci) {
+    private static void salisarcana$createPotionEffectCache(CallbackInfo ci,
+        @Share("potionEffectCache") LocalRef<PotionMetadataCache<List<PotionEffect>>> potionEffectCacheRef) {
         int metadataMask = PotionMetadataCache
             .findRelevantBits(PotionHelper.potionRequirements.values(), PotionHelper.potionAmplifiers.values());
 
-        salisarcana$potionEffectCache = metadataMask == PotionMetadataCache.ALL_METADATA_BITS ? null
-            : new PotionMetadataCache<>(metadataMask);
+        potionEffectCacheRef.set(
+            metadataMask == PotionMetadataCache.ALL_METADATA_BITS ? null : new PotionMetadataCache<>(metadataMask));
     }
 
     @WrapOperation(
@@ -40,13 +39,10 @@ abstract class MixinConfigAspects_SpeedupPotionAspects {
             remap = true),
         require = 1)
     private static List<PotionEffect> salisarcana$cachePotionEffects(int metadata, boolean includeUsable,
-        Operation<List<PotionEffect>> original) {
-        if (salisarcana$potionEffectCache == null) return original.call(metadata, includeUsable);
-        return salisarcana$potionEffectCache.get(metadata, value -> original.call(value, includeUsable));
-    }
-
-    @Inject(method = "registerItemAspects", at = @At("RETURN"), require = 1)
-    private static void salisarcana$clearPotionEffectCache(CallbackInfo ci) {
-        salisarcana$potionEffectCache = null;
+        Operation<List<PotionEffect>> original,
+        @Share("potionEffectCache") LocalRef<PotionMetadataCache<List<PotionEffect>>> potionEffectCacheRef) {
+        PotionMetadataCache<List<PotionEffect>> potionEffectCache = potionEffectCacheRef.get();
+        if (potionEffectCache == null) return original.call(metadata, includeUsable);
+        return potionEffectCache.get(metadata, value -> original.call(value, includeUsable));
     }
 }

--- a/src/main/resources/META-INF/salisarcana_at.cfg
+++ b/src/main/resources/META-INF/salisarcana_at.cfg
@@ -8,3 +8,5 @@ public net.minecraft.client.renderer.ItemRenderer field_78454_c # equippedProgre
 public net.minecraft.client.renderer.ItemRenderer field_78451_d # prevEquippedProgress
 
 public net.minecraft.item.Item func_77621_a(Lnet/minecraft/world/World;Lnet/minecraft/entity/player/EntityPlayer;Z)Lnet/minecraft/util/MovingObjectPosition; # getMovingObjectPositionFromPlayer
+public net.minecraft.potion.PotionHelper field_77927_l # potionRequirements
+public net.minecraft.potion.PotionHelper field_77928_m # potionAmplifiers


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
This PR fixes a performance issue during boot.

### What is the current behavior? (You can also link to an open issue here)
Thaumcraft computes the effect list of each potion, computing the effect list for 32767 potions

### What is the new behavior?
Potions have bit formulas, and it is possible to compute a mask to discard all the bits that are not considered for any potion.
From there, we can compute potion effect lists once then cache them.

This is what this PR does. It also compute the bitmask dynamically in case some mod changes the potion effect list or something, and fallback to original behavior if no meaningful bitmask can be computed.

In comparison, in latest dev builds of NH, Thaumcraft postinit goes down from 1.1s to only 0.3s with this change.

### Does this PR introduce a breaking change?
No

### Other information

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
