### PR TITLE
block the circular calls to avoid deadlock caused SOF for energizing bee empowered nodes

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -406,3 +406,9 @@ Force reservoirs to use the correct face when checking their essentia type. Allo
 **Config option:** `fixWandAverageCostTooltip`
 
 Tweak how a wand's average vis cost is calculated to display a more accurate number. Example: Thaumium+Silverwood scepters (20% discount) should now show 80% instead of 79%.
+
+## Fix Energizing Bee Empowered Nodes Caused Crash
+
+**Config option:** `fixNodeRemovingCircularCall`
+
+Fix SOF from energizing bee empowered node caused deadlock.

--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -411,4 +411,4 @@ Tweak how a wand's average vis cost is calculated to display a more accurate num
 
 **Config option:** `fixNodeRemovingCircularCall`
 
-Fix SOF from energizing bee empowered node caused deadlock.
+Prevent vis networks from sending block updates if the entity was invalidated, which will prevent an infinite recursion caused crash while energizing a node being empowered by the bees with Logistic Pipes installed.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -373,7 +373,7 @@ public class ConfigBugfixes extends ConfigGroup {
     public final ToggleSetting fixNodeRemovingCircularCall = new ToggleSetting(
         this,
         "fixNodeRemovingCircularCall",
-        "Fix SOF from removing node TE caused circular calling.");
+        "Fix SOF from energizing bee empowered node caused deadlock.");
 
     @Nonnull
     @Override

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -370,6 +370,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "fixWandAverageCostTooltip",
         "Tweak how a wand's average vis cost is calculated to display a more accurate number. Example: Thaumium+Silverwood scepters (20% discount) should now show 80% instead of 79%.");
 
+    public final ToggleSetting fixNodeRemovingCircularCall = new ToggleSetting(
+        this,
+        "fixNodeRemovingCircularCall",
+        "Fix SOF from removing node TE caused circular calling.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -373,7 +373,7 @@ public class ConfigBugfixes extends ConfigGroup {
     public final ToggleSetting fixNodeRemovingCircularCall = new ToggleSetting(
         this,
         "fixNodeRemovingCircularCall",
-        "Fix SOF from energizing bee empowered node caused deadlock.");
+        "Prevent vis networks from sending block updates if the tile entity was invalidated, preventing an infinite recursion crash when empowering a node with Logistics Pipes installed.");
 
     @Nonnull
     @Override

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -165,6 +165,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.upgradedFocusVisCost)
         .addCommonMixins("thaumcraft.api.wands.MixinItemFocusBasic_WandUpgradeLevel")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    NODE_REMOVE_CIRCULAR_CALL_PATCH(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.fixNodeRemovingCircularCall)
+        .addCommonMixins("thaumcraft.api.visnet.MixinTileVisNode_onRemoveThisNode")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     JAR_NO_CREATIVE_DROPS(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.jarNoCreativeDrops)
         .addCommonMixins("thaumcraft.common.blocks.MixinBlockJar_NoCreativeDrops")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -167,7 +167,7 @@ public enum Mixins implements IMixins {
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     NODE_REMOVE_CIRCULAR_CALL_PATCH(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.fixNodeRemovingCircularCall)
-        .addCommonMixins("thaumcraft.api.visnet.MixinTileVisNode_onRemoveThisNode")
+        .addCommonMixins("thaumcraft.api.visnet.MixinTileVisNode_OnRemoveThisNode")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
     JAR_NO_CREATIVE_DROPS(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.jarNoCreativeDrops)

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_OnRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_OnRemoveThisNode.java
@@ -13,7 +13,7 @@ import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 import thaumcraft.api.visnet.TileVisNode;
 
 @Mixin(value = TileVisNode.class, remap = false)
-abstract class MixinTileVisNode_onRemoveThisNode extends TileEntity {
+abstract class MixinTileVisNode_OnRemoveThisNode extends TileEntity {
 
     @Inject(method = "invalidate", at = @At("HEAD"), remap = true)
     private void onInvalidate(CallbackInfo ci) {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
@@ -14,8 +14,8 @@ import thaumcraft.api.visnet.TileVisNode;
 @Mixin(value = TileVisNode.class, remap = false)
 abstract class MixinTileVisNode_onRemoveThisNode extends TileEntity {
 
-    @Inject(method = "invalidate", at = @At("HEAD"), remap = false)
-    private void onInvalidate() {
+    @Inject(method = "invalidate", at = @At("HEAD"), remap = true)
+    private void onInvalidate(CallbackInfo ci) {
         super.invalidate();
     }
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
@@ -8,20 +8,20 @@ import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import thaumcraft.api.visnet.TileVisNode;
 
 @Mixin(TileVisNode.class)
-public class MixinTileVisNode_onRemoveThisNode {
+abstract class MixinTileVisNode_onRemoveThisNode {
 
-    private static final ThreadLocal<Boolean> isRemoving = ThreadLocal.withInitial(() -> false);
+    private static final ThreadLocal<Boolean> salisarcana$isRemoving = ThreadLocal.withInitial(() -> false);
 
     @WrapMethod(method = "removeThisNode", remap = false)
     private void guardCircularCall(Operation<Void> original) {
-        if (isRemoving.get()) {
+        if (salisarcana$isRemoving.get()) {
             return;
         }
-        isRemoving.set(true);
+        salisarcana$isRemoving.set(true);
         try {
             original.call();
         } finally {
-            isRemoving.remove();
+            salisarcana$isRemoving.remove();
         }
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
@@ -6,6 +6,7 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
@@ -21,7 +21,7 @@ abstract class MixinTileVisNode_onRemoveThisNode extends TileEntity {
 
     @WrapWithCondition(
         method = "removeThisNode",
-        at = @At(value = "INVOKE", target = "Lthaumcraft/api/visnet/TileVisNode;parentChanged()V", remap = false))
+        at = @At(value = "INVOKE", target = "Lthaumcraft/api/visnet/TileVisNode;parentChanged()V"))
     private boolean shouldDoParentChanged(TileVisNode instance) {
         return !this.isInvalid();
     }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
@@ -1,0 +1,27 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.api.visnet;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+
+import thaumcraft.api.visnet.TileVisNode;
+
+@Mixin(TileVisNode.class)
+public class MixinTileVisNode_onRemoveThisNode {
+
+    private static final ThreadLocal<Boolean> isRemoving = ThreadLocal.withInitial(() -> false);
+
+    @WrapMethod(method = "removeThisNode", remap = false)
+    private void guardCircularCall(Operation<Void> original) {
+        if (isRemoving.get()) {
+            return;
+        }
+        isRemoving.set(true);
+        try {
+            original.call();
+        } finally {
+            isRemoving.remove();
+        }
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
@@ -1,27 +1,40 @@
 package dev.rndmorris.salisarcana.mixins.late.thaumcraft.api.visnet;
 
-import org.spongepowered.asm.mixin.Mixin;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
 
-import com.llamalad7.mixinextras.injector.wrapmethod.WrapMethod;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
 
 import thaumcraft.api.visnet.TileVisNode;
 
-@Mixin(TileVisNode.class)
-abstract class MixinTileVisNode_onRemoveThisNode {
+@Mixin(value = TileVisNode.class, remap = false)
+abstract class MixinTileVisNode_onRemoveThisNode extends TileEntity {
 
-    private static final ThreadLocal<Boolean> salisarcana$isRemoving = ThreadLocal.withInitial(() -> false);
+    @Inject(method = "invalidate", at = @At("HEAD"), remap = false)
+    private void onInvalidate() {
+        super.invalidate();
+    }
 
-    @WrapMethod(method = "removeThisNode", remap = false)
-    private void guardCircularCall(Operation<Void> original) {
-        if (salisarcana$isRemoving.get()) {
-            return;
+    @WrapOperation(
+        method = "removeThisNode",
+        at = @At(value = "INVOKE", target = "Lthaumcraft/api/visnet/TileVisNode;parentChanged()V", remap = false))
+    private void wrapParentChanged(TileVisNode instance, Operation<Void> original) {
+        if (!this.isInvalid()) {
+            original.call(instance);
         }
-        salisarcana$isRemoving.set(true);
-        try {
-            original.call();
-        } finally {
-            salisarcana$isRemoving.remove();
+    }
+
+    @WrapOperation(
+        method = "removeThisNode",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;markBlockForUpdate(III)V", remap = true))
+    private void wrapMarkForUpdate(World w, int x, int y, int z, Operation<Void> original) {
+        if (!this.isInvalid()) {
+            original.call(w, x, y, z);
         }
     }
 }

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/api/visnet/MixinTileVisNode_onRemoveThisNode.java
@@ -7,8 +7,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 
-import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
-import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import com.llamalad7.mixinextras.injector.v2.WrapWithCondition;
 
 import thaumcraft.api.visnet.TileVisNode;
 
@@ -20,21 +19,17 @@ abstract class MixinTileVisNode_onRemoveThisNode extends TileEntity {
         super.invalidate();
     }
 
-    @WrapOperation(
+    @WrapWithCondition(
         method = "removeThisNode",
         at = @At(value = "INVOKE", target = "Lthaumcraft/api/visnet/TileVisNode;parentChanged()V", remap = false))
-    private void wrapParentChanged(TileVisNode instance, Operation<Void> original) {
-        if (!this.isInvalid()) {
-            original.call(instance);
-        }
+    private boolean shouldDoParentChanged(TileVisNode instance) {
+        return !this.isInvalid();
     }
 
-    @WrapOperation(
+    @WrapWithCondition(
         method = "removeThisNode",
         at = @At(value = "INVOKE", target = "Lnet/minecraft/world/World;markBlockForUpdate(III)V", remap = true))
-    private void wrapMarkForUpdate(World w, int x, int y, int z, Operation<Void> original) {
-        if (!this.isInvalid()) {
-            original.call(w, x, y, z);
-        }
+    private boolean shouldDoMarkForUpdate(World w, int x, int y, int z) {
+        return !this.isInvalid();
     }
 }


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
bug fix
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16065
Closes: https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/25576

### What is the current behavior? (You can also link to an open issue here)
this issue seems to be [first reported](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/16065) when it was 2.5.1, later it got another report when it was 2.7.0.

now it got another 2.8.4 ver report
https://pastebin.com/UKkzmUeC
It is reported that when energizing the node empowered by the bee, would cause this SOF issue
Energise -> setTileEntity() -> invalidate() -> removeThisNode() -> markBlockForUpdate() =>
listened by LP =>> getTileEntity() -> func_150806_e(), te==null -> setTileEntity()

the way to reproduce this issue is to Energize a node which is empowered by the bee, and there is smth consuming the cvis besides. the energize process is, put down a node stabilizer, then wand rclick on the jar to release the node, then attach the transducer on it, then energize, will crash atp it converts to an energized node.

### What is the new behavior?
~~it is too hard to reproduce for me, idk if it is fixed for now lol, but SOF should be fixed, and I will test it hard~~
~~issue reproduced in 2.9.0 daily 690, still testing~~
it won't sof any more
pre energize:
<img width="1552" height="902" alt="Screenshot 2026-08-23 at 11 18 30" src="https://github.com/user-attachments/assets/284052e6-0b14-4da6-9150-334a7217a3f7" />
post energize:
<img width="1552" height="902" alt="Screenshot 2026-08-23 at 11 19 26" src="https://github.com/user-attachments/assets/c795f444-7016-46b6-beca-60850a4088b4" />
no issue occurred

### Does this PR introduce a breaking change?
it is not intended to 

### Other information
~~anyways, the code of LP was not changed, the calling chain is also ARR and only could be patched with mixin and I don't think there is a typical fix for this issue.~~

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
