### PR TITLE
Make Wand Focus: Warding treat the world metadata as authoritative

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -412,3 +412,15 @@ Tweak how a wand's average vis cost is calculated to display a more accurate num
 **Config option:** `fixNodeRemovingCircularCall`
 
 Prevent vis networks from sending block updates if the entity was invalidated, which will prevent an infinite recursion caused crash while energizing a node being empowered by the bees with Logistic Pipes installed.
+
+## Warded Block Uses World Metadata
+
+**Config option:** `wardingUseWorldMetadata`
+
+Have Warded Blocks treat the world metadata as authoritative rather than the metadata stored in the NBT. Fixes metadata truncation with mods like NEID and EndlessIDs.
+
+**Config option:** `wardingDontStoreNBTMeta`
+
+Stop Warded Blocks from storing their metadata in the NBT, reducing network traffic & save-file size. Requires `wardingUseWorldMetadata`, disabled by default.
+
+**Warning:** Any Warded Blocks loaded when this setting is enabled will become invalid if you uninstall Salis Arcana or disable `wardingUseWorldMetadata`.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -375,6 +375,19 @@ public class ConfigBugfixes extends ConfigGroup {
         "fixNodeRemovingCircularCall",
         "Prevent vis networks from sending block updates if the tile entity was invalidated, preventing an infinite recursion crash when empowering a node with Logistics Pipes installed.");
 
+    public final ToggleSetting wardingUseWorldMetadata = new ToggleSetting(
+        this,
+        "wardingUseWorldMetadata",
+        "Have Warded Blocks treat the world metadata as authoritative rather than the metadata stored in the NBT. Fixes metadata truncation with mods like NEID and EndlessIDs.");
+
+    public final ToggleSetting wardingDontStoreNBTMeta = new ToggleSetting(
+        wardingUseWorldMetadata,
+        "wardingDontStoreNBTMeta",
+        """
+            Stop Warded Blocks from storing their metadata in the NBT, reducing network traffic & save-file size. Requires `wardingUseWorldMetadata`.
+            WARNING: Any Warded Blocks loaded when this setting is enabled will become invalid if you uninstall Salis Arcana or disable `wardingUseWorldMetadata`.""")
+            .setEnabled(false);
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -306,6 +306,14 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.stableRunicMatrixAnimation)
         .addClientMixins("thaumcraft.client.renderers.tile.MixinTileRunicMatrixRenderer_StableAltar")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    WARDING_USE_WORLD_METADATA(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.wardingUseWorldMetadata)
+        .addCommonMixins("thaumcraft.common.items.wands.foci.MixinItemFocusWarding_UseWorldMetadata")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    WARDING_DONT_SAVE_NBT_META(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.wardingDontStoreNBTMeta)
+        .addCommonMixins("thaumcraft.common.tiles.MixinTileWarded_DontStoreMetadata")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     FIX_INVENTORY_ASPECTS(new SalisBuilder()
         .setApplyIf(() -> SalisConfig.bugfixes.fixInventoryAspects.isEnabled()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusWarding_UseWorldMetadata.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/items/wands/foci/MixinItemFocusWarding_UseWorldMetadata.java
@@ -1,0 +1,29 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.items.wands.foci;
+
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+import com.llamalad7.mixinextras.sugar.Local;
+
+import thaumcraft.api.BlockCoordinates;
+import thaumcraft.common.items.wands.foci.ItemFocusWarding;
+
+@Mixin(ItemFocusWarding.class)
+abstract class MixinItemFocusWarding_UseWorldMetadata {
+
+    @ModifyArg(
+        method = "onFocusRightClick",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/World;setBlock(IIILnet/minecraft/block/Block;II)Z",
+            ordinal = 1,
+            remap = true),
+        index = 4,
+        remap = false)
+    private int getMetadataFromWorld(int metadata, @Local(argsOnly = true) World world, @Local BlockCoordinates c) {
+        return world.getBlockMetadata(c.x, c.y, c.z);
+    }
+}

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileWarded_DontStoreMetadata.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/tiles/MixinTileWarded_DontStoreMetadata.java
@@ -1,0 +1,34 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.tiles;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import com.llamalad7.mixinextras.expression.Definition;
+import com.llamalad7.mixinextras.expression.Expression;
+
+import thaumcraft.api.TileThaumcraft;
+import thaumcraft.common.tiles.TileWarded;
+
+@Mixin(TileWarded.class)
+abstract class MixinTileWarded_DontStoreMetadata extends TileThaumcraft {
+
+    @Definition(id = "getByte", method = "Lnet/minecraft/nbt/NBTTagCompound;getByte(Ljava/lang/String;)B", remap = true)
+    @Expression("?.getByte('md')")
+    @Redirect(method = "readCustomNBT", at = @At("MIXINEXTRAS:EXPRESSION"), remap = false)
+    private byte getMetadataFromWorld(NBTTagCompound instance, String s) {
+        return (byte) this.worldObj.getBlockMetadata(this.xCoord, this.yCoord, this.zCoord);
+    }
+
+    @Definition(
+        id = "setByte",
+        method = "Lnet/minecraft/nbt/NBTTagCompound;setByte(Ljava/lang/String;B)V",
+        remap = true)
+    @Expression("?.setByte('md', ?)")
+    @Redirect(method = "writeCustomNBT", at = @At("MIXINEXTRAS:EXPRESSION"), remap = false)
+    private void dontStoreMetadata(NBTTagCompound instance, String key, byte value) {
+        // This method intentionally left blank.
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

### What is the current behavior? (You can also link to an open issue here)
Closes GTNewHorizons/Dupes-Exploits-GTNH#348

Using Wand Focus: Warding on a block with a metadata value > 127 would cause the metadata to get truncated to a byte when the block was un-warded, allowing for blocks to be transmuted between metadata.

### What is the new behavior?
Wand Focus: Warding already sets the metadata of the Warded Block to the un-truncated metadata of the original block in order for the block renderer to work, so this PR changes the un-warding part of Wand Focus: Warding to read the metadata of the world rather than the one in the NBT.

Since this also means that the metadata in the NBT is now useless, introduces a second option to entirely remove that metadata (at the cost of making those save files *require* the first mixin to be enabled.)

### Does this PR introduce a breaking change?
No, unless you enable that second mixin.

### Other information
There seems to be an unrelated bug with EndlessIDs that causes Warded Blocks to render as transparent when you first ward a block (and render normally after you trigger the chunk to re-render a second time), unrelated to these mixins.

There also seems to be yet another unrelated bug in that GT5U ores don't actually render the "ore" part of their textures when warded, but that also seems to be unrelated to these mixins.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask) - I chose to put both settings in the same group, even though the second setting is more of an optimization, so they'd be located next to each other in the config file.
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [ ] Changes have been tested using an obfuscated client connected to an obfuscated standalone server - not on an obfuscated client, but with GT5U
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
