### PR TITLE
Make Golem Fetters check for redstone power when they're placed

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -407,6 +407,12 @@ Properly synchronizes the holes creates with the Portable Hole focus to the clie
 
 Force reservoirs to use the correct face when checking their essentia type. Allows downwards-facing reservoirs to be emptied by unlabeled jars placed directly below them.
 
+## Activate Golem Fetters When Placed
+
+**Config option:** `activateGolemFetterOnPlace`
+
+Make Golem Fetters activate instantly if they're placed into a location that is already receiving redstone power.
+
 ## Fix Wand Average Cost Tooltips
 
 **Config option:** `fixWandAverageCostTooltip`

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -375,6 +375,11 @@ public class ConfigBugfixes extends ConfigGroup {
         "fixWandAverageCostTooltip",
         "Tweak how a wand's average vis cost is calculated to display a more accurate number. Example: Thaumium+Silverwood scepters (20% discount) should now show 80% instead of 79%.");
 
+    public final ToggleSetting activateGolemFetterOnPlace = new ToggleSetting(
+        this,
+        "activateGolemFetterOnPlace",
+        "Make Golem Fetters activate instantly if they're placed into a location that is already receiving redstone power.");
+
     public final ToggleSetting fixNodeRemovingCircularCall = new ToggleSetting(
         this,
         "fixNodeRemovingCircularCall",

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -355,6 +355,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.reservoirsUseArgInGetEssentiaType)
         .addCommonMixins("thaumcraft.common.tiles.MixinTileEssentiaReservoir_UseArgInGetEssentiaType")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    GOLEM_FETTER_ACTIVATE_ON_PLACE(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.activateGolemFetterOnPlace)
+        .addCommonMixins("thaumcraft.common.blocks.MixinBlockCosmeticSolid_ActivateFetterOnPlace")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
     FIX_AVG_VIS_COST_CALCULATION(new SalisBuilder()
         .applyIf(SalisConfig.bugfixes.fixWandAverageCostTooltip)
         .addCommonMixins("thaumcraft.common.items.wands.MixinItemWandCasting_UseRoundedAverageCost")

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCosmeticSolid_ActivateFetterOnPlace.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/blocks/MixinBlockCosmeticSolid_ActivateFetterOnPlace.java
@@ -1,0 +1,27 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.blocks;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.material.Material;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+
+import thaumcraft.common.blocks.BlockCosmeticSolid;
+
+@Mixin(BlockCosmeticSolid.class)
+abstract class MixinBlockCosmeticSolid_ActivateFetterOnPlace extends Block {
+
+    protected MixinBlockCosmeticSolid_ActivateFetterOnPlace(Material materialIn) {
+        super(materialIn);
+    }
+
+    @Override
+    public int onBlockPlaced(World worldIn, int x, int y, int z, int side, float subX, float subY, float subZ,
+        int meta) {
+        if (meta == 9 && worldIn.isBlockIndirectlyGettingPowered(x, y, z)) {
+            return 10;
+        } else {
+            return super.onBlockPlaced(worldIn, x, y, z, side, subX, subY, subZ, meta);
+        }
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

### What is the current behavior? (You can also link to an open issue here)
Closes #439

### What is the new behavior?
Golem Fetters instantly activate when placed next to redstone power

### Does this PR introduce a breaking change?
No

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
