### PR TITLE
Simplify texture cache mixin

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_BindTextureCache.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/client/lib/MixinUtilsFX_BindTextureCache.java
@@ -7,8 +7,8 @@ import net.minecraft.util.ResourceLocation;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 
 import thaumcraft.client.lib.UtilsFX;
 
@@ -16,19 +16,22 @@ import thaumcraft.client.lib.UtilsFX;
 abstract class MixinUtilsFX_BindTextureCache {
 
     @Shadow(remap = false)
-    private static Map<String, ResourceLocation> boundTextures;
+    static Map<String, ResourceLocation> boundTextures;
 
-    @Inject(method = "bindTexture(Ljava/lang/String;)V", at = @At("HEAD"))
-    private static void salisarcana$cacheTexture(String texture, CallbackInfo ci) {
-        boundTextures.computeIfAbsent(texture, key -> new ResourceLocation("thaumcraft", key));
+    @ModifyExpressionValue(
+        method = "bindTexture(Ljava/lang/String;)V",
+        at = @At(value = "NEW", target = "net/minecraft/util/ResourceLocation", remap = true))
+    private static ResourceLocation salisarcana$cacheTexture(ResourceLocation original, String texture) {
+        boundTextures.put(texture, original);
+        return original;
     }
 
-    @Inject(method = "bindTexture(Ljava/lang/String;Ljava/lang/String;)V", at = @At("HEAD"))
-    private static void salisarcana$cacheTexture(String mod, String texture, CallbackInfo ci) {
-        final var key = mod + ":" + texture;
-        if (!boundTextures.containsKey(key)) {
-            boundTextures.put(key, new ResourceLocation(mod, texture));
-        }
+    @ModifyExpressionValue(
+        method = "bindTexture(Ljava/lang/String;Ljava/lang/String;)V",
+        at = @At(value = "NEW", target = "net/minecraft/util/ResourceLocation", remap = true))
+    private static ResourceLocation salisarcana$cacheTexture(ResourceLocation original, String mod, String texture) {
+        boundTextures.put(mod + ":" + texture, original);
+        return original;
     }
 
 }


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Simplification for mixin

### What is the current behavior? (You can also link to an open issue here)
The mixin for caching the UtilsFX `bindTexture` calls uses more operations than necessary, while also duplicating the initialization code.

### What is the new behavior?
The mixin is now simpler & probably slightly more efficient.

### Does this PR introduce a breaking change?
No

### Other information
This would be even better with an `@Overwrite` to make the code take advantage of `computeIfAbsent`, but that might be overkill.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
