### PR TITLE
Prevent entropy-upgraded Traveling Trunks from collecting dead items

### DIFF
--- a/docs/bugfixes.md
+++ b/docs/bugfixes.md
@@ -436,3 +436,9 @@ Have Warded Blocks treat the world metadata as authoritative rather than the met
 Stop Warded Blocks from storing their metadata in the NBT, reducing network traffic & save-file size. Requires `wardingUseWorldMetadata`, disabled by default.
 
 **Warning:** Any Warded Blocks loaded when this setting is enabled will become invalid if you uninstall Salis Arcana or disable `wardingUseWorldMetadata`.
+
+## Prevent Traveling Trunk Item Duplication
+
+**Config option:** `preventTravelingTrunkDupe`
+
+Prevent entropy-upgraded Traveling Trunks from absorbing dead items which may have been already collected by something else.

--- a/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
+++ b/src/main/java/dev/rndmorris/salisarcana/config/group/ConfigBugfixes.java
@@ -398,6 +398,11 @@ public class ConfigBugfixes extends ConfigGroup {
             WARNING: Any Warded Blocks loaded when this setting is enabled will become invalid if you uninstall Salis Arcana or disable `wardingUseWorldMetadata`.""")
             .setEnabled(false);
 
+    public final ToggleSetting preventTravelingTrunkDupe = new ToggleSetting(
+        this,
+        "preventTravelingTrunkDupe",
+        "Prevent entropy-upgraded Traveling Trunks from absorbing dead items which may have been already collected by something else.");
+
     @Nonnull
     @Override
     public String getGroupName() {

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/Mixins.java
@@ -371,6 +371,10 @@ public enum Mixins implements IMixins {
         .applyIf(SalisConfig.bugfixes.fixWandAverageCostTooltip)
         .addCommonMixins("thaumcraft.common.items.wands.MixinItemWandCasting_UseRoundedAverageCost")
         .addRequiredMod(TargetedMod.THAUMCRAFT)),
+    TRAVELING_TRUNK_DONT_CONSUME_DEAD_ITEMS(new SalisBuilder()
+        .applyIf(SalisConfig.bugfixes.preventTravelingTrunkDupe)
+        .addCommonMixins("thaumcraft.common.entities.golems.MixinEntityTravelingTrunk_SkipDeadItems")
+        .addRequiredMod(TargetedMod.THAUMCRAFT)),
 
     // Features
     EXTENDED_BAUBLES_SUPPORT(new SalisBuilder()

--- a/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/golems/MixinEntityTravelingTrunk_SkipDeadItems.java
+++ b/src/main/java/dev/rndmorris/salisarcana/mixins/late/thaumcraft/common/entities/golems/MixinEntityTravelingTrunk_SkipDeadItems.java
@@ -1,0 +1,27 @@
+package dev.rndmorris.salisarcana.mixins.late.thaumcraft.common.entities.golems;
+
+import java.util.List;
+
+import net.minecraft.command.IEntitySelector;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import thaumcraft.common.entities.golems.EntityTravelingTrunk;
+
+@Mixin(EntityTravelingTrunk.class)
+abstract class MixinEntityTravelingTrunk_SkipDeadItems {
+
+    @Redirect(
+        method = "pullItems",
+        at = @At(
+            value = "INVOKE",
+            target = "Lnet/minecraft/world/World;getEntitiesWithinAABB(Ljava/lang/Class;Lnet/minecraft/util/AxisAlignedBB;)Ljava/util/List;"))
+    private <T> List<T> skipDeadItems(World instance, Class<T> entityClass, AxisAlignedBB axisAlignedBB) {
+        // `IEntitySelector.selectAnything` skips all dead entities.
+        return instance.selectEntitiesWithinAABB(entityClass, axisAlignedBB, IEntitySelector.selectAnything);
+    }
+}


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

### What is the current behavior? (You can also link to an open issue here)
- Place a Traveling Trunk on top of a Hopper
- Upgrade the Traveling Trunk with a Golem Upgrade: Entropy
- Drop items so they touch the Hopper and the Traveling Trunk at the same time
- See that the dropped stack gets stored in both the Hopper & the Trunk, duplicating the items.

Closes GTNewHorizons/Dupes-Exploits-GTNH#282

### What is the new behavior?
Traveling Trunks filter item entities by checking if they're dead first, causing the items to only get collected by only one of the Hopper & the Trunk.

### Does this PR introduce a breaking change?
No

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
