### PR TITLE
Fix quick-stash keybind resetting on every load

### DIFF
--- a/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
+++ b/src/main/java/dev/rndmorris/salisarcana/client/QuickStashFocus.java
@@ -27,9 +27,9 @@ public final class QuickStashFocus {
         // If none of these mods are present, use the Thaumcraft keybind instead.
         if (MixinModCompat.multiKeyBindsPermitted()) {
             KEYBIND = new KeyBinding(
-                "salisarcana:keybind.quick_stash_focus",
+                "salisarcana.keybind.quick_stash_focus",
                 Keyboard.KEY_F,
-                "salisarcana:keybind_category");
+                "salisarcana.keybind_category");
             ClientRegistry.registerKeyBinding(KEYBIND);
         }
 

--- a/src/main/resources/assets/salisarcana/lang/en_US.lang
+++ b/src/main/resources/assets/salisarcana/lang/en_US.lang
@@ -174,8 +174,9 @@ salisarcana:duplicate_research.text=Duplicate "%s"
 salisarcana:duplicate_research.prompt=Shift-click to purchase a duplicate of this research
 salisarcana:duplicate_research.success=Duplicated research paper added to inventory
 
-salisarcana:keybind_category=Salis Arcana
-salisarcana:keybind.quick_stash_focus=Quick-Stash Focus
+# Keybinds - these lang keys cannot contain colons, or Minecraft won't parse them correctly when loading.
+salisarcana.keybind_category=Salis Arcana
+salisarcana.keybind.quick_stash_focus=Quick-Stash Focus
 
 tile.blockPortalNothing.name=Portal to Nothing
 


### PR DESCRIPTION
### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
Bug fix

### What is the current behavior? (You can also link to an open issue here)
Closes #527

### What is the new behavior?
Removed colons from the lang keys for the keybinds, so Minecraft parses them correctly.

### Does this PR introduce a breaking change?
No. It would have reset everyone's keybinds for quick-stashing foci, but that keybind already resets itself on every load.

### Checklist
- [x] All mixins are registered in `Mixins.java`
- [x] New entries in `Mixins.java` are linked to a config entry so they can be enabled/disabled
- [x] Config entries are in the appropriate group (if unclear where something belongs, ask)
- [x] Config entries are documented in their corresponding `.md` file in `/docs`
- [x] Changes have been tested using an obfuscated client connected to an obfuscated standalone server
- [x] *Standards and Best Practices* as detailed in [CONTRIBUTING](https://github.com/rndmorris/Salis-Arcana/blob/main/CONTRIBUTING.md) have been followed.
